### PR TITLE
Cobertura de teste na classe SecurityToggleState

### DIFF
--- a/lib/app/core/states/security_toggle_state.dart
+++ b/lib/app/core/states/security_toggle_state.dart
@@ -1,12 +1,13 @@
-  /// Creates a new instance of [SecurityToggleState] with a title, current enabled state and a callback function.
-  /// 
+class SecurityToggleState {
+  /// Creates a new instance of [SecurityToggleState] with a title, current state and a callback function.
+  ///
   /// [title] is the title of the toggle.
   /// [isEnabled] is the current state of the toggle.
   /// [onChanged] is the callback function that is called when the toggle state changes.
   SecurityToggleState({
     required this.title,
     required this.isEnabled,
-    required this.onChanged,
+    this.onChanged,
   });
 
   /// Creates an empty instance of [SecurityToggleState].
@@ -15,7 +16,6 @@
   factory SecurityToggleState.empty() => SecurityToggleState(
         title: '',
         isEnabled: false,
-        onChanged: (_) {},
       );
 
   /// The title of the toggle.
@@ -25,5 +25,5 @@
   final bool? isEnabled;
 
   /// The callback function that is called when the toggle state changes.
-  final void Function(bool value) onChanged;
+  final void Function(bool value)? onChanged;
 }

--- a/lib/app/core/states/security_toggle_state.dart
+++ b/lib/app/core/states/security_toggle_state.dart
@@ -1,17 +1,29 @@
-class SecurityToggleState {
+  /// Creates a new instance of [SecurityToggleState] with a title, current enabled state and a callback function.
+  /// 
+  /// [title] is the title of the toggle.
+  /// [isEnabled] is the current state of the toggle.
+  /// [onChanged] is the callback function that is called when the toggle state changes.
   SecurityToggleState({
     required this.title,
     required this.isEnabled,
     required this.onChanged,
   });
 
+  /// Creates an empty instance of [SecurityToggleState].
+  ///
+  /// The created instance has an empty title, is in the disabled state and has an empty callback function.
   factory SecurityToggleState.empty() => SecurityToggleState(
         title: '',
         isEnabled: false,
         onChanged: (_) {},
       );
 
+  /// The title of the toggle.
   final String title;
+
+  /// The current state of the toggle.
   final bool? isEnabled;
+
+  /// The callback function that is called when the toggle state changes.
   final void Function(bool value) onChanged;
 }

--- a/test/app/core/states/security_toggle_state_test.dart
+++ b/test/app/core/states/security_toggle_state_test.dart
@@ -1,0 +1,37 @@
+// ignore_for_file: avoid_print, prefer_function_declarations_over_variables
+import 'package:flutter_test/flutter_test.dart';
+import 'package:penhas/app/core/states/security_toggle_state.dart';
+
+void main() {
+  group(SecurityToggleState, () {
+    test('create an instance with a title, enabled state and callback', () {
+      // arrange
+      const title = 'Toggle Title';
+      final callback = (value) {
+        print(value);
+      };
+      // act
+      final toggle = SecurityToggleState(
+        title: title,
+        isEnabled: true,
+        onChanged: callback,
+      );
+      // assert
+      print(toggle.onChanged);
+      expect(toggle.title, title);
+      expect(toggle.isEnabled, true);
+      expect(toggle.onChanged, callback);
+    });
+
+    test(
+        'create an empty instance with a title, disabled state and empty callback',
+        () {
+      // final callback = void (bool value) {};
+      final toggle = SecurityToggleState.empty();
+
+      expect(toggle.title, '');
+      expect(toggle.isEnabled, false);
+      expect(toggle.onChanged, isNull);
+    });
+  });
+}

--- a/test/app/core/states/security_toggle_state_test.dart
+++ b/test/app/core/states/security_toggle_state_test.dart
@@ -17,16 +17,15 @@ void main() {
         onChanged: callback,
       );
       // assert
-      print(toggle.onChanged);
       expect(toggle.title, title);
       expect(toggle.isEnabled, true);
+      expect(toggle.onChanged, isNotNull);
       expect(toggle.onChanged, callback);
     });
 
     test(
         'create an empty instance with a title, disabled state and empty callback',
         () {
-      // final callback = void (bool value) {};
       final toggle = SecurityToggleState.empty();
 
       expect(toggle.title, '');


### PR DESCRIPTION
## Objetivo

Criar os testes para a classe SecurityToggleState

## Execução 

1. Documentação da classe utilizando o dart documentation;
2. Ajustado a propriedade 'onChange' para nullable sem prejuízo para o projeto, pois quem consume esta propriedade também espera um nullable; 
3. Criado os testes para a classe