### PR TITLE
Remover código "toString()" utilizado apenas para debug

### DIFF
--- a/lib/app/core/entities/user_location.dart
+++ b/lib/app/core/entities/user_location.dart
@@ -13,9 +13,4 @@ class UserLocationEntity extends Equatable {
 
   @override
   List<Object?> get props => [latitude, longitude, accuracy];
-
-  @override
-  String toString() {
-    return 'UserLocation(latitude: ${latitude.toString()}, longitude: ${longitude.toString()}, accuracy: ${accuracy.toString()})';
-  }
 }

--- a/lib/app/features/appstate/domain/entities/app_state_entity.dart
+++ b/lib/app/features/appstate/domain/entities/app_state_entity.dart
@@ -84,11 +84,6 @@ class QuizSessionEntity extends Equatable {
 
   @override
   List<Object?> get props => [currentMessage, sessionId, isFinished, endScreen];
-
-  @override
-  String toString() {
-    return 'QuizSessionEntity{currentMessage: ${currentMessage.toString()}, sessionId: $sessionId, endScreen: ${endScreen.toString()}, isFinished: ${isFinished.toString()} }';
-  }
 }
 
 @immutable
@@ -114,11 +109,6 @@ class QuizMessageEntity extends Equatable {
   @override
   List<dynamic> get props =>
       [content, style, action, type, ref, options, buttonLabel];
-
-  @override
-  String toString() {
-    return 'QuizMessageEntity{content: ${content.toString()}, type: ${type.toString()}, style: ${style.toString()}, action: ${action.toString()}, ref: $ref}, buttonLabel: ${buttonLabel.toString()}, options: ${options.toString()}';
-  }
 }
 
 class QuizMessageMultiplechoicesOptions extends Equatable {
@@ -132,11 +122,6 @@ class QuizMessageMultiplechoicesOptions extends Equatable {
 
   @override
   List<Object?> get props => [display, index!];
-
-  @override
-  String toString() {
-    return 'QuizMessageMultiplechoicesOptions{index: ${index.toString()}, display: ${display.toString()}}';
-  }
 }
 
 @immutable

--- a/lib/app/features/feed/domain/entities/tweet_entity.dart
+++ b/lib/app/features/feed/domain/entities/tweet_entity.dart
@@ -47,11 +47,6 @@ class TweetEntity extends TweetTiles {
         lastReply,
       ];
 
-  @override
-  String toString() {
-    return 'TweetEntity{id: ${id.toString()}, parentId: $parentId, name: ${userName.toString()}, clientId: ${clientId.toString()}, createdAt: ${createdAt.toString()}, totalReply: ${totalReply.toString()}, totalLikes: ${totalLikes.toString()}, anonymous: ${anonymous.toString()}, content: ${content.toString()}, avatar: ${avatar.toString()}, meta: ${meta.toString()}, lastReplay: ${lastReply.toString()}}';
-  }
-
   TweetEntity copyWith({
     String? id,
     String? userName,
@@ -96,11 +91,6 @@ class TweetMeta extends Equatable {
 
   @override
   List<Object?> get props => [liked, owner, canReply];
-
-  @override
-  String toString() {
-    return 'TweetMeta {liked: ${liked.toString()}, owner: ${owner.toString()}, canReply: $canReply';
-  }
 }
 
 class TweetNewsGroupEntity extends TweetTiles {

--- a/lib/app/features/feed/domain/entities/tweet_session_entity.dart
+++ b/lib/app/features/feed/domain/entities/tweet_session_entity.dart
@@ -20,9 +20,4 @@ class TweetSessionEntity extends Equatable {
 
   @override
   List<Object?> get props => [hasMore, orderBy, parent, tweets, nextPage];
-
-  @override
-  String toString() {
-    return 'TweetSessionEntity{hasMore: ${hasMore.toString()}, orderBy: ${orderBy.toString()}, nextPage: ${nextPage.toString()}, tweets: ${tweets.toString()}}';
-  }
 }


### PR DESCRIPTION
## Objetivo

Remover o `toString()` utilizado apenas para debug.

## Execução

Removido os código de `toString()`  nas classes que não tem utilidade no código de produção, este código aumenta a necessidade de cobertura de teste sem necessidade. 
