### PR TITLE
Correção de typo do SafelyParser

### DIFF
--- a/lib/app/core/extension/safely_parser.dart
+++ b/lib/app/core/extension/safely_parser.dart
@@ -1,6 +1,6 @@
 import 'package:penhas/app/shared/logger/log.dart';
 
-extension SafetlyParser on Object? {
+extension SafelyParser on Object? {
   double? safeParseDouble() {
     final value = this;
 

--- a/lib/app/core/extension/safely_parser.dart
+++ b/lib/app/core/extension/safely_parser.dart
@@ -1,4 +1,4 @@
-import 'package:penhas/app/shared/logger/log.dart';
+import '../../shared/logger/log.dart';
 
 extension SafelyParser on Object? {
   double? safeParseDouble() {

--- a/lib/app/features/notification/data/repositories/notification_repository.dart
+++ b/lib/app/features/notification/data/repositories/notification_repository.dart
@@ -1,14 +1,15 @@
 import 'dart:convert';
 
 import 'package:dartz/dartz.dart';
-import 'package:penhas/app/core/entities/valid_fiel.dart';
-import 'package:penhas/app/core/error/failures.dart';
-import 'package:penhas/app/core/extension/safely_parser.dart';
-import 'package:penhas/app/core/network/api_client.dart';
-import 'package:penhas/app/features/authentication/presentation/shared/map_exception_to_failure.dart';
-import 'package:penhas/app/features/notification/data/models/notification_session_model.dart';
-import 'package:penhas/app/features/notification/domain/entities/notification_session_entity.dart';
-import 'package:penhas/app/shared/logger/log.dart';
+
+import '../../../../core/entities/valid_fiel.dart';
+import '../../../../core/error/failures.dart';
+import '../../../../core/extension/safely_parser.dart';
+import '../../../../core/network/api_client.dart';
+import '../../../../shared/logger/log.dart';
+import '../../../authentication/presentation/shared/map_exception_to_failure.dart';
+import '../../domain/entities/notification_session_entity.dart';
+import '../models/notification_session_model.dart';
 
 abstract class INotificationRepository {
   Future<Either<Failure, ValidField>> unread();

--- a/lib/app/features/notification/data/repositories/notification_repository.dart
+++ b/lib/app/features/notification/data/repositories/notification_repository.dart
@@ -3,7 +3,7 @@ import 'dart:convert';
 import 'package:dartz/dartz.dart';
 import 'package:penhas/app/core/entities/valid_fiel.dart';
 import 'package:penhas/app/core/error/failures.dart';
-import 'package:penhas/app/core/extension/safetly_parser.dart';
+import 'package:penhas/app/core/extension/safely_parser.dart';
 import 'package:penhas/app/core/network/api_client.dart';
 import 'package:penhas/app/features/authentication/presentation/shared/map_exception_to_failure.dart';
 import 'package:penhas/app/features/notification/data/models/notification_session_model.dart';

--- a/lib/app/features/support_center/data/models/support_center_place_detail_model.dart
+++ b/lib/app/features/support_center/data/models/support_center_place_detail_model.dart
@@ -1,4 +1,4 @@
-import 'package:penhas/app/core/extension/safetly_parser.dart';
+import 'package:penhas/app/core/extension/safely_parser.dart';
 import 'package:penhas/app/features/support_center/domain/entities/support_center_place_detail_entity.dart';
 import 'package:penhas/app/features/support_center/domain/entities/support_center_place_entity.dart';
 

--- a/lib/app/features/support_center/data/models/support_center_place_detail_model.dart
+++ b/lib/app/features/support_center/data/models/support_center_place_detail_model.dart
@@ -1,6 +1,6 @@
-import 'package:penhas/app/core/extension/safely_parser.dart';
-import 'package:penhas/app/features/support_center/domain/entities/support_center_place_detail_entity.dart';
-import 'package:penhas/app/features/support_center/domain/entities/support_center_place_entity.dart';
+import '../../../../core/extension/safely_parser.dart';
+import '../../domain/entities/support_center_place_detail_entity.dart';
+import '../../domain/entities/support_center_place_entity.dart';
 
 class SupportCenterPlaceDetailModel extends SupportCenterPlaceDetailEntity {
   const SupportCenterPlaceDetailModel({

--- a/lib/app/features/support_center/data/models/support_center_place_session_model.dart
+++ b/lib/app/features/support_center/data/models/support_center_place_session_model.dart
@@ -1,4 +1,4 @@
-import 'package:penhas/app/core/extension/safetly_parser.dart';
+import 'package:penhas/app/core/extension/safely_parser.dart';
 import 'package:penhas/app/features/support_center/domain/entities/support_center_place_entity.dart';
 import 'package:penhas/app/features/support_center/domain/entities/support_center_place_session_entity.dart';
 

--- a/lib/app/features/support_center/data/models/support_center_place_session_model.dart
+++ b/lib/app/features/support_center/data/models/support_center_place_session_model.dart
@@ -1,6 +1,6 @@
-import 'package:penhas/app/core/extension/safely_parser.dart';
-import 'package:penhas/app/features/support_center/domain/entities/support_center_place_entity.dart';
-import 'package:penhas/app/features/support_center/domain/entities/support_center_place_session_entity.dart';
+import '../../../../core/extension/safely_parser.dart';
+import '../../domain/entities/support_center_place_entity.dart';
+import '../../domain/entities/support_center_place_session_entity.dart';
 
 class SupportCenterPlaceSessionModel extends SupportCenterPlaceSessionEntity {
   const SupportCenterPlaceSessionModel({

--- a/lib/app/features/support_center/domain/entities/support_center_place_entity.dart
+++ b/lib/app/features/support_center/domain/entities/support_center_place_entity.dart
@@ -1,5 +1,5 @@
 import 'package:equatable/equatable.dart';
-import 'package:penhas/app/core/extension/safetly_parser.dart';
+import 'package:penhas/app/core/extension/safely_parser.dart';
 
 class SupportCenterPlaceEntity extends Equatable {
   const SupportCenterPlaceEntity({

--- a/lib/app/features/support_center/domain/entities/support_center_place_entity.dart
+++ b/lib/app/features/support_center/domain/entities/support_center_place_entity.dart
@@ -1,5 +1,6 @@
 import 'package:equatable/equatable.dart';
-import 'package:penhas/app/core/extension/safely_parser.dart';
+
+import '../../../../core/extension/safely_parser.dart';
 
 class SupportCenterPlaceEntity extends Equatable {
   const SupportCenterPlaceEntity({

--- a/test/app/core/extension/safely_parser_test.dart
+++ b/test/app/core/extension/safely_parser_test.dart
@@ -3,21 +3,22 @@ import 'package:penhas/app/core/extension/safely_parser.dart';
 
 void main() {
   group('SafelyParser extension', () {
-    test('safeParseDouble should parse double from string or number', () {
+    test('safeParseDouble parse double from string or number', () {
       expect((1.0).safeParseDouble(), 1.0);
       expect(('1.0').safeParseDouble(), 1.0);
       expect(('not a number').safeParseDouble(), isNull);
       expect((null).safeParseDouble(), isNull);
     });
 
-    test('safeParseInt should parse int from string or number', () {
+    test('safeParseInt parse int from string or number', () {
       expect((1).safeParseInt(), 1);
       expect(('1').safeParseInt(), 1);
+      expect(('default value').safeParseInt(def: 42), 42);
       expect(('not an int').safeParseInt(), 0);
       expect((null).safeParseInt(), 0);
     });
 
-    test('safeParseBool should return true for 1, false for anything else', () {
+    test('safeParseBool return true for 1, false for anything else', () {
       expect((1).safeParseBool(), isTrue);
       expect((0).safeParseBool(), isFalse);
       expect(('1').safeParseBool(), isFalse);

--- a/test/app/core/extension/safely_parser_test.dart
+++ b/test/app/core/extension/safely_parser_test.dart
@@ -7,21 +7,21 @@ void main() {
       expect((1.0).safeParseDouble(), 1.0);
       expect(('1.0').safeParseDouble(), 1.0);
       expect(('not a number').safeParseDouble(), isNull);
-      expect((null as Object?).safeParseDouble(), isNull);
+      expect((null).safeParseDouble(), isNull);
     });
 
     test('safeParseInt should parse int from string or number', () {
       expect((1).safeParseInt(), 1);
       expect(('1').safeParseInt(), 1);
       expect(('not an int').safeParseInt(), 0);
-      expect((null as Object?).safeParseInt(), 0);
+      expect((null).safeParseInt(), 0);
     });
 
     test('safeParseBool should return true for 1, false for anything else', () {
       expect((1).safeParseBool(), isTrue);
       expect((0).safeParseBool(), isFalse);
       expect(('1').safeParseBool(), isFalse);
-      expect((null as Object?).safeParseBool(), isFalse);
+      expect((null).safeParseBool(), isFalse);
     });
   });
 }

--- a/test/app/core/extension/safely_parser_test.dart
+++ b/test/app/core/extension/safely_parser_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:penhas/app/core/extension/safely_parser.dart';
+
+void main() {
+  group('SafelyParser extension', () {
+    test('safeParseDouble should parse double from string or number', () {
+      expect((1.0).safeParseDouble(), 1.0);
+      expect(('1.0').safeParseDouble(), 1.0);
+      expect(('not a number').safeParseDouble(), isNull);
+      expect((null as Object?).safeParseDouble(), isNull);
+    });
+
+    test('safeParseInt should parse int from string or number', () {
+      expect((1).safeParseInt(), 1);
+      expect(('1').safeParseInt(), 1);
+      expect(('not an int').safeParseInt(), 0);
+      expect((null as Object?).safeParseInt(), 0);
+    });
+
+    test('safeParseBool should return true for 1, false for anything else', () {
+      expect((1).safeParseBool(), isTrue);
+      expect((0).safeParseBool(), isFalse);
+      expect(('1').safeParseBool(), isFalse);
+      expect((null as Object?).safeParseBool(), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Objetivo

1. Corrigir typo do SafelyParser
2. Cobertura de teste do SafelyParser

## Execução

1. Corrigido o typo e ajustado nos código que o utilizam
2. Criado teste unitário

