### PR TITLE
Lint para `test`

### DIFF
--- a/test/analysis_options.yaml
+++ b/test/analysis_options.yaml
@@ -1,0 +1,19 @@
+analyzer:
+  exclude:
+    - '**.freezed.dart'
+    - '**.g.dart'
+    - '**.mocks.dart'
+
+  errors:
+    invalid_null_aware_operator: ignore
+
+linter:
+  rules:
+    - avoid_print
+    - avoid_unnecessary_containers
+    - avoid_web_libraries_in_flutter
+    - no_logic_in_create_state
+    - sort_child_properties_last
+    - use_build_context_synchronously
+    - use_full_hex_values_for_flutter_colors
+    - use_key_in_widget_constructors


### PR DESCRIPTION
## Objetivo

O **lint** do ambiente de produção normalmente entra em conflito com a demanda do ambiente de teste. 

## Execução

Criar um **lint** na raíz do diretório `/test`, que sobrescreve o **lint** do diretório root do projeto. Desta maneira é possível ter regras de lint adequada ao ambiente de teste.