### PR TITLE
Cobertura de teste do ChangePasswordDataSource

### DIFF
--- a/penhas.code-workspace
+++ b/penhas.code-workspace
@@ -17,8 +17,10 @@
 			"editor.inlayHints.enabled": "offUnlessPressed",
 		},
 		"cSpell.words": [
+			"datasources",
+			"mocktail",
 			"penhas",
-			"mocktail"
+			"usecases"
 		]
 	}
 }


### PR DESCRIPTION
## Objetivo

1. Cobertura de teste do ChangePasswordDataSource

## Execução

1. Migrado do `Mockito` para o `Mocktail`
2. Criado teste para o `validToken()`
