### PR TITLE
Desativar "info" como fatal error no code quality workflow

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Analyze code
         if: ${{ needs.check-changes.outputs.changed_files }}
         run: |
-          dart analyze --fatal-infos --fatal-warnings \
+          dart analyze --fatal-warnings \
             ${{ needs.check-changes.outputs.changed_files }}
 
       - name: Check code formatting


### PR DESCRIPTION
## Objetivo

A ativação do **lint** está gerando 1.851 issues no projeto. Boa parte destes issues é "style" e outra é sobre API depreciada. O ideal é realizar um plano de solução destas issues de lint antes de travar por definitivo no CI.

## Execução

Removido a opção  `--fatal-infos` deixando as issues de info como não falta até que tenhamos corrigidos os 1.851 issues do projeto.

Quando estas issues estiver solucionadas, aí estas opção é reativada