### PR TITLE
AuthenticationWithEmailAndPassword migrado para mocktail

### DIFF
--- a/test/app/features/authentication/domain/usecases/authentication_test.dart
+++ b/test/app/features/authentication/domain/usecases/authentication_test.dart
@@ -1,65 +1,94 @@
 import 'package:dartz/dartz.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mockito/mockito.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:penhas/app/core/error/failures.dart';
+import 'package:penhas/app/core/managers/app_configuration.dart';
 import 'package:penhas/app/features/authentication/domain/entities/session_entity.dart';
+import 'package:penhas/app/features/authentication/domain/repositories/i_authentication_repository.dart';
 import 'package:penhas/app/features/authentication/domain/usecases/authentication_with_email_password.dart';
 import 'package:penhas/app/features/authentication/domain/usecases/email_address.dart';
 import 'package:penhas/app/features/authentication/domain/usecases/password_validator.dart';
 import 'package:penhas/app/features/authentication/domain/usecases/sign_in_password.dart';
 
-import '../../../../../utils/helper.mocks.dart';
+class MockAppConfiguration extends Mock implements IAppConfiguration {}
+
+class MockAuthenticationRepository extends Mock
+    implements IAuthenticationRepository {}
 
 void main() {
-  late final MockIAppConfiguration mockAppConfiguration = MockIAppConfiguration();
-  late final MockIAuthenticationRepository mockAuthenticatonRepository =
-      MockIAuthenticationRepository();
+  late MockAppConfiguration mockAppConfiguration;
+  late MockAuthenticationRepository mockAuthenticationRepository;
+  late AuthenticationWithEmailAndPassword useCase;
+  late SessionEntity successSession;
+  late EmailAddress emailAddress;
+  late SignInPassword password;
 
-  late final AuthenticationWithEmailAndPassword useCase =
-      AuthenticationWithEmailAndPassword(
-    authenticationRepository: mockAuthenticatonRepository,
-    appConfiguration: mockAppConfiguration,
-  );
+  setUp(() {
+    mockAppConfiguration = MockAppConfiguration();
+    mockAuthenticationRepository = MockAuthenticationRepository();
+    useCase = AuthenticationWithEmailAndPassword(
+      authenticationRepository: mockAuthenticationRepository,
+      appConfiguration: mockAppConfiguration,
+    );
 
-  group('authentication with email and password', () {
-    const successSession = SessionEntity(
-        sessionToken: 'my_strong_session_token',);
-    final emailAddress = EmailAddress('valid@email.com');
-    final password = SignInPassword('_myStr0ngP@ssw0rd', PasswordValidator());
+    emailAddress = EmailAddress('valid@email.com');
+    password = SignInPassword('_myStr0ngP@ssw0rd', PasswordValidator());
+    successSession = SessionEntity(sessionToken: 'my_strong_session_token');
+  });
 
-    test('should get success response', () async {
-      // arrange
-      when(mockAuthenticatonRepository.signInWithEmailAndPassword(
-        emailAddress: anyNamed('emailAddress'),
-        password: anyNamed('password'),
-      ),).thenAnswer((_) async => right(successSession));
-      when(mockAppConfiguration.saveApiToken(token: anyNamed('token')))
-          .thenAnswer((_) async => Future.value());
-      // act
-      final Either<Failure, SessionEntity> result =
-          await useCase(email: emailAddress, password: password);
-      // assert
-      expect(result, right(successSession));
-      verify(mockAuthenticatonRepository.signInWithEmailAndPassword(
-          emailAddress: emailAddress, password: password,),);
-      verifyNoMoreInteractions(mockAuthenticatonRepository);
-    });
+  group(AuthenticationWithEmailAndPassword, () {
+    group('authentication with email and password', () {
+      test('should get success response', () async {
+        // arrange
+        when(
+          () => mockAuthenticationRepository.signInWithEmailAndPassword(
+            emailAddress: emailAddress,
+            password: password,
+          ),
+        ).thenAnswer((_) async => right(successSession));
 
-    test(
-        'should get UserAndPasswordInvalidFailure response for invalid user or password',
-        () async {
-      when(mockAuthenticatonRepository.signInWithEmailAndPassword(
-              emailAddress: anyNamed('emailAddress'),
-              password: anyNamed('password'),),)
-          .thenAnswer((_) async => left(UserAndPasswordInvalidFailure()));
+        when(
+          () => mockAppConfiguration.saveApiToken(
+            token: successSession.sessionToken,
+          ),
+        ).thenAnswer((_) async => Future.value());
+        // act
+        final Either<Failure, SessionEntity> result =
+            await useCase(email: emailAddress, password: password);
+        // assert
+        expect(result, right(successSession));
+        verify(
+          () => mockAuthenticationRepository.signInWithEmailAndPassword(
+            emailAddress: emailAddress,
+            password: password,
+          ),
+        ).called(1);
 
-      final Either<Failure, SessionEntity> result =
-          await useCase(email: emailAddress, password: password);
+        verifyNoMoreInteractions(mockAuthenticationRepository);
+      });
 
-      expect(result, left(UserAndPasswordInvalidFailure()));
-      verify(mockAuthenticatonRepository.signInWithEmailAndPassword(
-          emailAddress: emailAddress, password: password,),);
-      verifyNoMoreInteractions(mockAuthenticatonRepository);
+      test(
+          'should get UserAndPasswordInvalidFailure response for invalid user or password',
+          () async {
+        when(
+          () => mockAuthenticationRepository.signInWithEmailAndPassword(
+            emailAddress: emailAddress,
+            password: password,
+          ),
+        ).thenAnswer((_) async => left(UserAndPasswordInvalidFailure()));
+
+        final Either<Failure, SessionEntity> result =
+            await useCase(email: emailAddress, password: password);
+
+        expect(result, left(UserAndPasswordInvalidFailure()));
+        verify(
+          () => mockAuthenticationRepository.signInWithEmailAndPassword(
+            emailAddress: emailAddress,
+            password: password,
+          ),
+        ).called(1);
+        verifyNoMoreInteractions(mockAuthenticationRepository);
+      });
     });
   });
 }


### PR DESCRIPTION
## Objetivo

Migrar os testes do AuthenticationWithEmailAndPassword que estão utilizando o mockito. O mockito está sendo removido como dependência do projeto.

## Execução

Ajustado os teste para utilizar o mocktail.