### PR TITLE
FilterSkillRepository migrado para mocktail

### DIFF
--- a/test/app/features/filter/data/repositories/filter_skill_repository_test.dart
+++ b/test/app/features/filter/data/repositories/filter_skill_repository_test.dart
@@ -1,39 +1,42 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mockito/mockito.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:penhas/app/core/network/api_client.dart';
 import 'package:penhas/app/features/filters/data/models/filter_skills_model.dart';
 import 'package:penhas/app/features/filters/domain/repositories/filter_skill_repository.dart';
 
-import '../../../../../utils/helper.mocks.dart';
 import '../../../../../utils/json_util.dart';
 
+class MockApiProvider extends Mock implements IApiProvider {}
+
 void main() {
-  const String jsonFile = 'filters/filter_skills.json';
-  late final MockIApiProvider apiProvider = MockIApiProvider();
+  late MockApiProvider apiProvider;
   late IFilterSkillRepository sut;
+  const jsonFile = 'filters/filter_skills.json';
 
   setUp(() {
+    apiProvider = MockApiProvider();
     sut = FilterSkillRepository(apiProvider: apiProvider);
   });
 
-  group('FilterUseCase', () {
-    test('should retrieve skills from server', () async {
+  group(FilterSkillRepository, () {
+    test('retrieve skills from server', () async {
       // arrange
       final jsonData = await JsonUtil.getJson(from: jsonFile);
       final actual = FilterSkillsModel.fromJson(jsonData).skills;
       when(
-        apiProvider.get(
-          path: anyNamed('path'),
-          headers: anyNamed('headers'),
-          parameters: anyNamed('parameters'),
+        () => apiProvider.get(
+          path: any(named: 'path'),
+          headers: any(named: 'headers'),
+          parameters: any(named: 'parameters'),
         ),
       ).thenAnswer((_) => JsonUtil.getString(from: jsonFile));
       // act
-      // unwrap do Either pq ele não se dá bem com o Collection nativo,
-      // eu teria que alterar para um List dele, mas me recurso a fazer isto
-      // só para o teste, já que na códgio terá outras implicações.
-      final matcher = await sut.skills().then((v) => v.getOrElse(() => null)!);
+      final result = await sut.skills();
       // assert
-      expect(actual, matcher);
+      expect(
+        actual,
+        result.fold((l) => l, (r) => r),
+      );
     });
   });
 }


### PR DESCRIPTION
## Objetivo

Migrar os testes do FilterSkillRepository que estão utilizando o mockito. O mockito está sendo removido como dependência do projeto.

## Execução

Ajustado os teste para utilizar o mocktail.