### PR TITLE
GuardianDataSource migrado para o mocktail

### DIFF
--- a/test/app/features/help_center/data/datasources/guardian_datasources_alert_test.dart
+++ b/test/app/features/help_center/data/datasources/guardian_datasources_alert_test.dart
@@ -1,34 +1,43 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
-import 'package:mockito/mockito.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:penhas/app/core/entities/user_location.dart';
 import 'package:penhas/app/core/error/failures.dart';
+import 'package:penhas/app/core/network/api_server_configure.dart';
 import 'package:penhas/app/features/help_center/data/datasources/guardian_data_source.dart';
 import 'package:penhas/app/features/help_center/data/models/alert_model.dart';
 
-import '../../../../../utils/helper.mocks.dart';
 import '../../../../../utils/json_util.dart';
 
+class MockHttpClient extends Mock implements http.Client {}
+
+class MockApiServerConfigure extends Mock implements IApiServerConfigure {}
+
 void main() {
-  late final MockHttpClient apiClient = MockHttpClient();
-  late final MockIApiServerConfigure serverConfigure =
-      MockIApiServerConfigure();
+  late Uri serverEndpoint;
+  late http.Client apiClient;
+  late IApiServerConfigure serverConfigure;
   late IGuardianDataSource dataSource;
-  final Uri serverEndpoint = Uri.https('api.anyserver.io', '/');
-  const String sessionToken = 'my_really.long.JWT';
+  const sessionToken = 'my_really.long.JWT';
 
   setUp(() {
+    apiClient = MockHttpClient();
+    serverConfigure = MockApiServerConfigure();
+    serverEndpoint = Uri.https('api.anyserver.io', '/');
     dataSource = GuardianDataSource(
       apiClient: apiClient,
       serverConfiguration: serverConfigure,
     );
 
     // MockApiServerConfigure configuration
-    when(serverConfigure.baseUri).thenAnswer((_) => serverEndpoint);
-    when(serverConfigure.apiToken)
-        .thenAnswer((_) => Future.value(sessionToken));
-    when(serverConfigure.userAgent)
-        .thenAnswer((_) => Future.value('iOS 11.4/Simulator/1.0.0'));
+    when(() => serverConfigure.baseUri).thenAnswer((_) => serverEndpoint);
+    when(() => serverConfigure.apiToken).thenAnswer((_) async => sessionToken);
+    when(() => serverConfigure.userAgent)
+        .thenAnswer((_) async => 'iOS 11.4/Simulator/1.0.0');
+  });
+
+  setUpAll(() {
+    registerFallbackValue(Uri());
   });
 
   Future<Map<String, String>> _setUpHttpHeader() async {
@@ -40,7 +49,7 @@ void main() {
     };
   }
 
-  Uri _setuHttpRequest(String path, Map<String, String> queryParameters) {
+  Uri _setUpHttpRequest(String path, Map<String, String> queryParameters) {
     return Uri(
       scheme: serverEndpoint.scheme,
       host: serverEndpoint.host,
@@ -49,18 +58,14 @@ void main() {
     );
   }
 
-  PostExpectation<Future<http.Response>> _mockPostRequest() {
-    return when(
-      apiClient.post(
-        any,
-        headers: anyNamed('headers'),
-        body: anyNamed('body'),
-      ),
-    );
-  }
-
   void _setUpMockPostHttpClientSuccess200(String? bodyContent) {
-    _mockPostRequest().thenAnswer(
+    when(
+      () => apiClient.post(
+        any(),
+        headers: any(named: 'headers'),
+        body: any(named: 'body'),
+      ),
+    ).thenAnswer(
       (_) async => http.Response(
         bodyContent!,
         200,
@@ -72,7 +77,13 @@ void main() {
   }
 
   void _setUpMockPostHttpClientSuccess400(String bodyContent) {
-    _mockPostRequest().thenAnswer(
+    when(
+      () => apiClient.post(
+        any(),
+        headers: any(named: 'headers'),
+        body: any(named: 'body'),
+      ),
+    ).thenAnswer(
       (_) async => http.Response(
         bodyContent,
         400,
@@ -84,13 +95,13 @@ void main() {
   }
 
   group(
-    'GuardianDataSource',
+    GuardianDataSource,
     () {
-      String? bodyContent;
-      UserLocationEntity? userLocation;
+      late String bodyContent;
+      late UserLocationEntity userLocation;
 
       setUp(() {
-        userLocation = const UserLocationEntity(latitude: 1.0, longitude: -1.0);
+        userLocation = UserLocationEntity(latitude: 1.0, longitude: -1.0);
         bodyContent = JsonUtil.getStringSync(
           from: 'help_center/guardian_alert_warning.json',
         );
@@ -98,24 +109,24 @@ void main() {
 
       group('alert()', () {
         test(
-          'should perform a POST with X-API-Key',
+          'perform a POST with X-API-Key',
           () async {
             // arrange
             const endPointPath = '/me/guardioes/alert';
             final headers = await _setUpHttpHeader();
-            final request = _setuHttpRequest(endPointPath, {
-              'gps_lat': '${userLocation!.latitude}',
-              'gps_long': '${userLocation!.longitude}'
+            final request = _setUpHttpRequest(endPointPath, {
+              'gps_lat': '${userLocation.latitude}',
+              'gps_long': '${userLocation.longitude}'
             });
             _setUpMockPostHttpClientSuccess200(bodyContent);
             // act
             await dataSource.alert(userLocation);
             // assert
-            verify(apiClient.post(request, headers: headers));
+            verify(() => apiClient.post(request, headers: headers)).called(1);
           },
         );
         test(
-          'should get a valid session for a successful request',
+          'get a valid session for a successful request',
           () async {
             // arrange
             _setUpMockPostHttpClientSuccess200(bodyContent);
@@ -127,12 +138,12 @@ void main() {
             // act
             final received = await dataSource.alert(userLocation);
             // assert
-            expect(received, expected);
+            expect(expected, received);
           },
         );
 
         test(
-          'should get a GuardianAlertGpsFailure for a invalid gps data on the request',
+          'get a GuardianAlertGpsFailure for a invalid gps data on the request',
           () async {
             // arrange
             final bodyWithError = JsonUtil.getStringSync(

--- a/test/app/features/help_center/data/datasources/guardian_datasources_alert_test.dart
+++ b/test/app/features/help_center/data/datasources/guardian_datasources_alert_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: prefer_const_constructors
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:mocktail/mocktail.dart';
@@ -136,9 +138,9 @@ void main() {
                   'Não há guardiões cadastrado! Nenhum alerta foi enviado.',
             );
             // act
-            final received = await dataSource.alert(userLocation);
+            final actual = await dataSource.alert(userLocation);
             // assert
-            expect(expected, received);
+            expect(actual, expected);
           },
         );
 

--- a/test/app/features/help_center/data/datasources/guardian_datasources_create_test.dart
+++ b/test/app/features/help_center/data/datasources/guardian_datasources_create_test.dart
@@ -1,33 +1,42 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
-import 'package:mockito/mockito.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:penhas/app/core/network/api_server_configure.dart';
 import 'package:penhas/app/features/help_center/data/datasources/guardian_data_source.dart';
 import 'package:penhas/app/features/help_center/data/models/alert_model.dart';
 import 'package:penhas/app/features/help_center/domain/entities/guardian_session_entity.dart';
 
-import '../../../../../utils/helper.mocks.dart';
 import '../../../../../utils/json_util.dart';
 
+class MockHttpClient extends Mock implements http.Client {}
+
+class MockApiServerConfigure extends Mock implements IApiServerConfigure {}
+
 void main() {
-  late final MockHttpClient apiClient = MockHttpClient();
-  late final MockIApiServerConfigure serverConfigure =
-      MockIApiServerConfigure();
+  late Uri serverEndpoint;
+  late http.Client apiClient;
+  late IApiServerConfigure serverConfigure;
   late IGuardianDataSource dataSource;
-  final Uri serverEndpoint = Uri.https('api.anyserver.io', '/');
-  const String sessionToken = 'my_really.long.JWT';
+  const sessionToken = 'my_really.long.JWT';
 
   setUp(() {
+    apiClient = MockHttpClient();
+    serverConfigure = MockApiServerConfigure();
+    serverEndpoint = Uri.https('api.anyserver.io', '/');
     dataSource = GuardianDataSource(
       apiClient: apiClient,
       serverConfiguration: serverConfigure,
     );
 
     // MockApiServerConfigure configuration
-    when(serverConfigure.baseUri).thenAnswer((_) => serverEndpoint);
-    when(serverConfigure.apiToken)
-        .thenAnswer((_) => Future.value(sessionToken));
-    when(serverConfigure.userAgent)
-        .thenAnswer((_) => Future.value('iOS 11.4/Simulator/1.0.0'));
+    when(() => serverConfigure.baseUri).thenAnswer((_) => serverEndpoint);
+    when(() => serverConfigure.apiToken).thenAnswer((_) async => sessionToken);
+    when(() => serverConfigure.userAgent)
+        .thenAnswer((_) async => 'iOS 11.4/Simulator/1.0.0');
+  });
+
+  setUpAll(() {
+    registerFallbackValue(Uri());
   });
 
   Future<Map<String, String>> _setUpHttpHeader() async {
@@ -39,7 +48,7 @@ void main() {
     };
   }
 
-  Uri _setuHttpRequest(String path, Map<String, String?> queryParameters) {
+  Uri _setUpHttpRequest(String path, Map<String, String?> queryParameters) {
     return Uri(
       scheme: serverEndpoint.scheme,
       host: serverEndpoint.host,
@@ -48,18 +57,14 @@ void main() {
     );
   }
 
-  PostExpectation<Future<http.Response>> _mockPostRequest() {
-    return when(
-      apiClient.post(
-        any,
-        headers: anyNamed('headers'),
-        body: anyNamed('body'),
-      ),
-    );
-  }
-
   void _setUpMockPostHttpClientSuccess200(String? bodyContent) {
-    _mockPostRequest().thenAnswer(
+    when(
+      () => apiClient.post(
+        any(),
+        headers: any(named: 'headers'),
+        body: any(named: 'body'),
+      ),
+    ).thenAnswer(
       (_) async => http.Response(
         bodyContent!,
         200,
@@ -71,10 +76,10 @@ void main() {
   }
 
   group(
-    'GuardianDataSource',
+    GuardianDataSource,
     () {
-      String? bodyContent;
-      GuardianContactEntity? guardian;
+      late String bodyContent;
+      late GuardianContactEntity guardian;
 
       setUp(() {
         bodyContent = JsonUtil.getStringSync(
@@ -88,24 +93,24 @@ void main() {
 
       group('create()', () {
         test(
-          'should perform a POST with X-API-Key',
+          'perform a POST with X-API-Key',
           () async {
             // arrange
             const endPointPath = '/me/guardioes';
             final headers = await _setUpHttpHeader();
-            final request = _setuHttpRequest(endPointPath, {
-              'nome': guardian!.name,
-              'celular': guardian!.mobile,
+            final request = _setUpHttpRequest(endPointPath, {
+              'nome': guardian.name,
+              'celular': guardian.mobile,
             });
             _setUpMockPostHttpClientSuccess200(bodyContent);
             // act
             await dataSource.create(guardian);
             // assert
-            verify(apiClient.post(request, headers: headers));
+            verify(() => apiClient.post(request, headers: headers)).called(1);
           },
         );
         test(
-          'should get a valid ValidField for a successful request',
+          'get a valid ValidField for a successful request',
           () async {
             // arrange
             _setUpMockPostHttpClientSuccess200(bodyContent);

--- a/test/app/features/help_center/data/datasources/guardian_datasources_create_test.dart
+++ b/test/app/features/help_center/data/datasources/guardian_datasources_create_test.dart
@@ -119,9 +119,9 @@ void main() {
             );
             final expected = AlertModel.fromJson(jsonData);
             // act
-            final received = await dataSource.create(guardian);
+            final actual = await dataSource.create(guardian);
             // assert
-            expect(received, expected);
+            expect(actual, expected);
           },
         );
       });

--- a/test/app/features/help_center/data/datasources/guardian_datasources_delete_test.dart
+++ b/test/app/features/help_center/data/datasources/guardian_datasources_delete_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: prefer_const_constructors
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:mocktail/mocktail.dart';
@@ -107,11 +109,10 @@ void main() {
           () async {
             // arrange
             _setUpMockPostHttpClientSuccess204();
-            const actual = ValidField();
             // act
-            final received = await dataSource.delete(guardian);
+            final actual = await dataSource.delete(guardian);
             // assert
-            expect(actual, received);
+            expect(actual, ValidField());
           },
         );
       });

--- a/test/app/features/help_center/data/datasources/guardian_datasources_delete_test.dart
+++ b/test/app/features/help_center/data/datasources/guardian_datasources_delete_test.dart
@@ -1,32 +1,41 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
-import 'package:mockito/mockito.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:penhas/app/core/entities/valid_fiel.dart';
+import 'package:penhas/app/core/network/api_server_configure.dart';
 import 'package:penhas/app/features/help_center/data/datasources/guardian_data_source.dart';
 import 'package:penhas/app/features/help_center/domain/entities/guardian_session_entity.dart';
 
-import '../../../../../utils/helper.mocks.dart';
+class MockHttpClient extends Mock implements http.Client {}
+
+class MockApiServerConfigure extends Mock implements IApiServerConfigure {}
 
 void main() {
-  late final MockHttpClient apiClient = MockHttpClient();
+  late Uri serverEndpoint;
+  late http.Client apiClient;
+  late IApiServerConfigure serverConfigure;
   late IGuardianDataSource dataSource;
-  late final MockIApiServerConfigure serverConfigure =
-      MockIApiServerConfigure();
-  final Uri serverEndpoint = Uri.https('api.anyserver.io', '/');
-  const String sessionToken = 'my_really.long.JWT';
+  const sessionToken = 'my_really.long.JWT';
 
   setUp(() {
+    apiClient = MockHttpClient();
+    serverConfigure = MockApiServerConfigure();
+    serverEndpoint = Uri.https('api.anyserver.io', '/');
     dataSource = GuardianDataSource(
       apiClient: apiClient,
       serverConfiguration: serverConfigure,
     );
 
     // MockApiServerConfigure configuration
-    when(serverConfigure.baseUri).thenAnswer((_) => serverEndpoint);
-    when(serverConfigure.apiToken)
+    when(() => serverConfigure.baseUri).thenAnswer((_) => serverEndpoint);
+    when(() => serverConfigure.apiToken)
         .thenAnswer((_) => Future.value(sessionToken));
-    when(serverConfigure.userAgent)
+    when(() => serverConfigure.userAgent)
         .thenAnswer((_) => Future.value('iOS 11.4/Simulator/1.0.0'));
+  });
+
+  setUpAll(() {
+    registerFallbackValue(Uri());
   });
 
   Future<Map<String, String>> _setUpHttpHeader() async {
@@ -38,7 +47,7 @@ void main() {
     };
   }
 
-  Uri _setuHttpRequest(String path, Map<String, String> queryParameters) {
+  Uri _setUpHttpRequest(String path, Map<String, String> queryParameters) {
     return Uri(
       scheme: serverEndpoint.scheme,
       host: serverEndpoint.host,
@@ -49,9 +58,9 @@ void main() {
 
   void _setUpMockPostHttpClientSuccess204() {
     when(
-      apiClient.delete(
-        any,
-        headers: anyNamed('headers'),
+      () => apiClient.delete(
+        any(),
+        headers: any(named: 'headers'),
       ),
     ).thenAnswer(
       (_) async => http.Response(
@@ -65,9 +74,9 @@ void main() {
   }
 
   group(
-    'GuardianDataSource',
+    GuardianDataSource,
     () {
-      GuardianContactEntity? guardian;
+      late GuardianContactEntity guardian;
 
       setUp(() {
         guardian = const GuardianContactEntity(
@@ -80,29 +89,29 @@ void main() {
 
       group('delete()', () {
         test(
-          'should perform a DELETE with X-API-Key',
+          'perform a DELETE with X-API-Key',
           () async {
             // arrange
-            final endPointPath = '/me/guardioes/${guardian!.id}';
+            final endPointPath = '/me/guardioes/${guardian.id}';
             final headers = await _setUpHttpHeader();
-            final request = _setuHttpRequest(endPointPath, {});
+            final request = _setUpHttpRequest(endPointPath, {});
             _setUpMockPostHttpClientSuccess204();
             // act
             await dataSource.delete(guardian);
             // assert
-            verify(apiClient.delete(request, headers: headers));
+            verify(() => apiClient.delete(request, headers: headers)).called(1);
           },
         );
         test(
-          'should get a valid ValidField for a successful delete',
+          'get a valid ValidField for a successful delete',
           () async {
             // arrange
             _setUpMockPostHttpClientSuccess204();
-            const expected = ValidField();
+            const actual = ValidField();
             // act
             final received = await dataSource.delete(guardian);
             // assert
-            expect(expected, received);
+            expect(actual, received);
           },
         );
       });

--- a/test/app/features/help_center/data/datasources/guardian_datasources_fetch_test.dart
+++ b/test/app/features/help_center/data/datasources/guardian_datasources_fetch_test.dart
@@ -101,11 +101,11 @@ void main() {
             _setUpMockGetHttpClientSuccess200(bodyContent);
             final jsonData =
                 await JsonUtil.getJson(from: 'help_center/guardian_list.json');
-            final actual = GuardianSessionModel.fromJson(jsonData);
+            final expected = GuardianSessionModel.fromJson(jsonData);
             // act
-            final received = await dataSource.fetch();
+            final actual = await dataSource.fetch();
             // assert
-            expect(actual, received);
+            expect(actual, expected);
           },
         );
       });

--- a/test/app/features/help_center/data/datasources/guardian_datasources_fetch_test.dart
+++ b/test/app/features/help_center/data/datasources/guardian_datasources_fetch_test.dart
@@ -1,30 +1,41 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
-import 'package:mockito/mockito.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:penhas/app/core/network/api_server_configure.dart';
 import 'package:penhas/app/features/help_center/data/datasources/guardian_data_source.dart';
 import 'package:penhas/app/features/help_center/data/models/guardian_session_model.dart';
 
-import '../../../../../utils/helper.mocks.dart';
 import '../../../../../utils/json_util.dart';
 
+class MockHttpClient extends Mock implements http.Client {}
+
+class MockApiServerConfigure extends Mock implements IApiServerConfigure {}
+
 void main() {
-  late final MockHttpClient apiClient = MockHttpClient();
-  late final MockIApiServerConfigure serverConfigure =
-      MockIApiServerConfigure();
-  final Uri serverEndpoint = Uri.https('api.anyserver.io', '/');
-  late final IGuardianDataSource dataSource = GuardianDataSource(
-    apiClient: apiClient,
-    serverConfiguration: serverConfigure,
-  );
-  const String sessionToken = 'my_really.long.JWT';
+  late Uri serverEndpoint;
+  late http.Client apiClient;
+  late IApiServerConfigure serverConfigure;
+  late IGuardianDataSource dataSource;
+  const sessionToken = 'my_really.long.JWT';
 
   setUp(() {
+    apiClient = MockHttpClient();
+    serverConfigure = MockApiServerConfigure();
+    serverEndpoint = Uri.https('api.anyserver.io', '/');
+    dataSource = GuardianDataSource(
+      apiClient: apiClient,
+      serverConfiguration: serverConfigure,
+    );
+
     // MockApiServerConfigure configuration
-    when(serverConfigure.baseUri).thenAnswer((_) => serverEndpoint);
-    when(serverConfigure.apiToken)
-        .thenAnswer((_) => Future.value(sessionToken));
-    when(serverConfigure.userAgent)
-        .thenAnswer((_) => Future.value('iOS 11.4/Simulator/1.0.0'));
+    when(() => serverConfigure.baseUri).thenAnswer((_) => serverEndpoint);
+    when(() => serverConfigure.apiToken).thenAnswer((_) async => sessionToken);
+    when(() => serverConfigure.userAgent)
+        .thenAnswer((_) async => 'iOS 11.4/Simulator/1.0.0');
+  });
+
+  setUpAll(() {
+    registerFallbackValue(Uri());
   });
 
   Future<Map<String, String>> _setUpHttpHeader() async {
@@ -36,7 +47,7 @@ void main() {
     };
   }
 
-  Uri _setuHttpRequest(String path, Map<String, String> queryParameters) {
+  Uri _setUpHttpRequest(String path, Map<String, String> queryParameters) {
     return Uri(
       scheme: serverEndpoint.scheme,
       host: serverEndpoint.host,
@@ -45,31 +56,23 @@ void main() {
     );
   }
 
-  PostExpectation<Future<http.Response>> _mockGetRequest() {
-    return when(
-      apiClient.get(
-        any,
-        headers: anyNamed('headers'),
-      ),
-    );
-  }
-
   void _setUpMockGetHttpClientSuccess200(String? bodyContent) {
-    _mockGetRequest().thenAnswer(
-      (_) async => http.Response(
-        bodyContent!,
-        200,
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8'
-        },
-      ),
-    );
+    when(() => apiClient.get(
+          any(),
+          headers: any(named: 'headers'),
+        )).thenAnswer((_) async => http.Response(
+          bodyContent!,
+          200,
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8'
+          },
+        ));
   }
 
   group(
-    'GuardianDataSource',
+    GuardianDataSource,
     () {
-      String? bodyContent;
+      late String bodyContent;
 
       setUp(() {
         bodyContent =
@@ -78,31 +81,31 @@ void main() {
 
       group('fetch()', () {
         test(
-          'should perform a GET with X-API-Key',
+          'perform a GET with X-API-Key',
           () async {
             // arrange
             const endPointPath = '/me/guardioes';
             final headers = await _setUpHttpHeader();
-            final request = _setuHttpRequest(endPointPath, {});
+            final request = _setUpHttpRequest(endPointPath, {});
             _setUpMockGetHttpClientSuccess200(bodyContent);
             // act
             await dataSource.fetch();
             // assert
-            verify(apiClient.get(request, headers: headers));
+            verify(() => apiClient.get(request, headers: headers)).called(1);
           },
         );
         test(
-          'should get a valid GuardianSession for a successful request',
+          'get a valid GuardianSession for a successful request',
           () async {
             // arrange
             _setUpMockGetHttpClientSuccess200(bodyContent);
             final jsonData =
                 await JsonUtil.getJson(from: 'help_center/guardian_list.json');
-            final expected = GuardianSessionModel.fromJson(jsonData);
+            final actual = GuardianSessionModel.fromJson(jsonData);
             // act
             final received = await dataSource.fetch();
             // assert
-            expect(expected, received);
+            expect(actual, received);
           },
         );
       });

--- a/test/app/features/help_center/data/datasources/guardian_datasources_update_test.dart
+++ b/test/app/features/help_center/data/datasources/guardian_datasources_update_test.dart
@@ -116,9 +116,9 @@ void main() {
             );
             final expected = ValidField.fromJson(jsonData);
             // act
-            final received = await dataSource.update(guardian);
+            final actual = await dataSource.update(guardian);
             // assert
-            expect(expected, received);
+            expect(actual, expected);
           },
         );
       });

--- a/test/app/features/help_center/data/datasources/guardian_datasources_update_test.dart
+++ b/test/app/features/help_center/data/datasources/guardian_datasources_update_test.dart
@@ -1,33 +1,42 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
-import 'package:mockito/mockito.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:penhas/app/core/entities/valid_fiel.dart';
+import 'package:penhas/app/core/network/api_server_configure.dart';
 import 'package:penhas/app/features/help_center/data/datasources/guardian_data_source.dart';
 import 'package:penhas/app/features/help_center/domain/entities/guardian_session_entity.dart';
 
-import '../../../../../utils/helper.mocks.dart';
 import '../../../../../utils/json_util.dart';
 
+class MockHttpClient extends Mock implements http.Client {}
+
+class MockApiServerConfigure extends Mock implements IApiServerConfigure {}
+
 void main() {
-  late final MockHttpClient apiClient = MockHttpClient();
-  late final MockIApiServerConfigure serverConfigure =
-      MockIApiServerConfigure();
+  late Uri serverEndpoint;
+  late http.Client apiClient;
+  late IApiServerConfigure serverConfigure;
   late IGuardianDataSource dataSource;
-  final Uri serverEndpoint = Uri.https('api.anyserver.io', '/');
-  const String sessionToken = 'my_really.long.JWT';
+  const sessionToken = 'my_really.long.JWT';
 
   setUp(() {
+    apiClient = MockHttpClient();
+    serverConfigure = MockApiServerConfigure();
+    serverEndpoint = Uri.https('api.anyserver.io', '/');
     dataSource = GuardianDataSource(
       apiClient: apiClient,
       serverConfiguration: serverConfigure,
     );
 
     // MockApiServerConfigure configuration
-    when(serverConfigure.baseUri).thenAnswer((_) => serverEndpoint);
-    when(serverConfigure.apiToken)
-        .thenAnswer((_) => Future.value(sessionToken));
-    when(serverConfigure.userAgent)
-        .thenAnswer((_) => Future.value('iOS 11.4/Simulator/1.0.0'));
+    when(() => serverConfigure.baseUri).thenAnswer((_) => serverEndpoint);
+    when(() => serverConfigure.apiToken).thenAnswer((_) async => sessionToken);
+    when(() => serverConfigure.userAgent)
+        .thenAnswer((_) async => 'iOS 11.4/Simulator/1.0.0');
+  });
+
+  setUpAll(() {
+    registerFallbackValue(Uri());
   });
 
   Future<Map<String, String>> _setUpHttpHeader() async {
@@ -39,7 +48,7 @@ void main() {
     };
   }
 
-  Uri _setuHttpRequest(String path, Map<String, String?> queryParameters) {
+  Uri _setUpHttpRequest(String path, Map<String, String?> queryParameters) {
     return Uri(
       scheme: serverEndpoint.scheme,
       host: serverEndpoint.host,
@@ -48,17 +57,11 @@ void main() {
     );
   }
 
-  PostExpectation<Future<http.Response>> _mockPutRequest() {
-    return when(
-      apiClient.put(
-        any,
-        headers: anyNamed('headers'),
-      ),
-    );
-  }
-
   void _setUpMockPutHttpClientSuccess200(String? bodyContent) {
-    _mockPutRequest().thenAnswer(
+    when(() => apiClient.put(
+          any(),
+          headers: any(named: 'headers'),
+        )).thenAnswer(
       (_) async => http.Response(
         bodyContent!,
         200,
@@ -70,10 +73,10 @@ void main() {
   }
 
   group(
-    'GuardianDataSource',
+    GuardianDataSource,
     () {
-      String? bodyContent;
-      GuardianContactEntity? guardian;
+      late String bodyContent;
+      late GuardianContactEntity guardian;
 
       setUp(() {
         bodyContent = JsonUtil.getStringSync(
@@ -88,23 +91,23 @@ void main() {
       });
       group('create()', () {
         test(
-          'should perform a PUT with X-API-Key',
+          'perform a PUT with X-API-Key',
           () async {
             // arrange
-            final endPointPath = '/me/guardioes/${guardian!.id}';
+            final endPointPath = '/me/guardioes/${guardian.id}';
             final headers = await _setUpHttpHeader();
-            final request = _setuHttpRequest(endPointPath, {
-              'nome': guardian!.name,
+            final request = _setUpHttpRequest(endPointPath, {
+              'nome': guardian.name,
             });
             _setUpMockPutHttpClientSuccess200(bodyContent);
             // act
             await dataSource.update(guardian);
             // assert
-            verify(apiClient.put(request, headers: headers));
+            verify(() => apiClient.put(request, headers: headers)).called(1);
           },
         );
         test(
-          'should get a valid ValidField for a successful request',
+          'get a valid ValidField for a successful request',
           () async {
             // arrange
             _setUpMockPutHttpClientSuccess200(bodyContent);


### PR DESCRIPTION
## Objetivo

Migrar os testes do GuardianDataSource que estão utilizando o mockito. O mockito está sendo removido como dependência do projeto.

## Execução

Ajustado os teste para utilizar o mocktail.