### PR TITLE
NotificationRepository migrado para mocktail

### DIFF
--- a/test/app/features/notification/domain/repositories/notification_repository_test.dart
+++ b/test/app/features/notification/domain/repositories/notification_repository_test.dart
@@ -1,36 +1,43 @@
 import 'package:dartz/dartz.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mockito/mockito.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:penhas/app/core/network/api_client.dart';
 import 'package:penhas/app/features/notification/data/models/notification_session_model.dart';
 import 'package:penhas/app/features/notification/data/repositories/notification_repository.dart';
 
-import '../../../../../utils/helper.mocks.dart';
 import '../../../../../utils/json_util.dart';
 
-void main() {
-  late final MockIApiProvider apiProvider = MockIApiProvider();
-  late final INotificationRepository sut =
-      NotificationRepository(apiProvider: apiProvider);
+class MockApiProvider extends Mock implements IApiProvider {}
 
-  group('NotificationRepository', () {
+void main() {
+  late IApiProvider apiProvider;
+  late INotificationRepository sut;
+
+  setUpAll(() {
+    apiProvider = MockApiProvider();
+    sut = NotificationRepository(apiProvider: apiProvider);
+  });
+
+  group(NotificationRepository, () {
     test(
-        'should get a NotificationSessionModel from a successful server response',
-        () async {
-      // arrange
-      const jsonFile = 'notification/notification_session.json';
-      final jsonData = await JsonUtil.getJson(from: jsonFile);
-      final actual = right(NotificationSessionModel.fromJson(jsonData));
-      when(
-        apiProvider.get(
-          path: anyNamed('path'),
-          headers: anyNamed('headers'),
-          parameters: anyNamed('parameters'),
-        ),
-      ).thenAnswer((_) => JsonUtil.getString(from: jsonFile));
-      // act
-      final matcher = await sut.notifications();
-      // assert
-      expect(actual, matcher);
-    });
+      'get a NotificationSessionModel from a successful server response',
+      () async {
+        // arrange
+        const jsonFile = 'notification/notification_session.json';
+        final jsonData = await JsonUtil.getJson(from: jsonFile);
+        final actual = right(NotificationSessionModel.fromJson(jsonData));
+        when(
+          () => apiProvider.get(
+            path: any(named: 'path'),
+            headers: any(named: 'headers'),
+            parameters: any(named: 'parameters'),
+          ),
+        ).thenAnswer((_) => JsonUtil.getString(from: jsonFile));
+        // act
+        final matcher = await sut.notifications();
+        // assert
+        expect(actual, matcher);
+      },
+    );
   });
 }


### PR DESCRIPTION
## Objetivo

Migrar os testes do NotificationRepository que estão utilizando o mockito. O mockito está sendo removido como dependência do projeto.

## Execução

Ajustado os teste para utilizar o mocktail.