### PR TITLE
SupportCenterUseCase migrado para mocktail

### DIFF
--- a/lib/app/features/support_center/domain/entities/support_center_fetch_request.dart
+++ b/lib/app/features/support_center/domain/entities/support_center_fetch_request.dart
@@ -22,8 +22,14 @@ class SupportCenterFetchRequest extends Equatable {
   bool get stringify => true;
 
   @override
-  List<Object?> get props =>
-      [userLocation!, locationToken!, categories!, keywords!, nextPage!, rows!];
+  List<Object?> get props => [
+        userLocation,
+        locationToken,
+        categories,
+        keywords,
+        nextPage,
+        rows,
+      ];
 
   SupportCenterFetchRequest copyWith({
     UserLocationEntity? userLocation,

--- a/test/app/features/support_center/domain/usecases/support_center_usecase_fetch_test.dart
+++ b/test/app/features/support_center/domain/usecases/support_center_usecase_fetch_test.dart
@@ -1,38 +1,49 @@
 import 'package:dartz/dartz.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mockito/mockito.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:penhas/app/core/entities/user_location.dart';
 import 'package:penhas/app/core/error/failures.dart';
+import 'package:penhas/app/core/managers/location_services.dart';
+import 'package:penhas/app/features/support_center/data/repositories/support_center_repository.dart';
 import 'package:penhas/app/features/support_center/domain/entities/support_center_fetch_request.dart';
 import 'package:penhas/app/features/support_center/domain/usecases/support_center_usecase.dart';
 
-import '../../../../../utils/helper.mocks.dart';
+class MockSupportCenterRepository extends Mock
+    implements ISupportCenterRepository {}
+
+class MockLocationServices extends Mock implements ILocationServices {}
 
 void main() {
-  late final MockISupportCenterRepository supportCenterRepository =
-      MockISupportCenterRepository();
-  late final MockILocationServices locationServices = MockILocationServices();
-  late final SupportCenterUseCase sut = SupportCenterUseCase(
-    locationService: locationServices,
-    supportCenterRepository: supportCenterRepository,
-  );
+  late SupportCenterUseCase sut;
+  late ISupportCenterRepository supportCenterRepository;
+  late ILocationServices locationServices;
 
-  group('SupportCenterUsecase', () {
+  setUp(() {
+    locationServices = MockLocationServices();
+    supportCenterRepository = MockSupportCenterRepository();
+    sut = SupportCenterUseCase(
+      locationService: locationServices,
+      supportCenterRepository: supportCenterRepository,
+    );
+  });
+
+  group(SupportCenterUseCase, () {
     group('fetch', () {
-      test('should get GPSFailure for invalid gps information', () async {
+      test('get GPSFailure for invalid gps information', () async {
         // arrange
-        const fetchRequest = SupportCenterFetchRequest();
-        const gpsFailure =
+        final fetchRequest = SupportCenterFetchRequest();
+        final gpsFailure =
             'Não foi possível encontrar sua localização através do CEP 01203-777, tente novamente mais tarde ou ative a localização';
         final actual = left(
           GpsFailure(gpsFailure),
         );
-        when(supportCenterRepository.fetch(any)).thenAnswer((_) async => left(
-              GpsFailure(gpsFailure),
-            ),);
-        when(locationServices.currentLocation()).thenAnswer((_) async => right(
-            const UserLocationEntity(),),);
-        when(locationServices.isPermissionGranted())
+        when(() => supportCenterRepository.fetch(any())).thenAnswer(
+          (_) async => left(GpsFailure(gpsFailure)),
+        );
+        when(() => locationServices.currentLocation()).thenAnswer(
+          (_) async => right(const UserLocationEntity()),
+        );
+        when(() => locationServices.isPermissionGranted())
             .thenAnswer((_) async => true);
         // act
         final matcher = await sut.fetch(fetchRequest);

--- a/test/app/features/support_center/domain/usecases/support_center_usecase_test.dart
+++ b/test/app/features/support_center/domain/usecases/support_center_usecase_test.dart
@@ -1,33 +1,41 @@
 import 'package:dartz/dartz.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mockito/mockito.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:penhas/app/core/managers/location_services.dart';
 import 'package:penhas/app/features/support_center/data/models/support_center_metadata_model.dart';
+import 'package:penhas/app/features/support_center/data/repositories/support_center_repository.dart';
 import 'package:penhas/app/features/support_center/domain/usecases/support_center_usecase.dart';
 
-import '../../../../../utils/helper.mocks.dart';
 import '../../../../../utils/json_util.dart';
 
+class MockSupportCenterRepository extends Mock
+    implements ISupportCenterRepository {}
+
+class MockLocationServices extends Mock implements ILocationServices {}
+
 void main() {
-  late final MockISupportCenterRepository supportCenterRepository =
-      MockISupportCenterRepository();
-  late final MockILocationServices locationServices = MockILocationServices();
   late SupportCenterUseCase sut;
+  late ILocationServices locationServices;
+  late ISupportCenterRepository supportCenterRepository;
 
   setUp(() {
+    locationServices = MockLocationServices();
+    supportCenterRepository = MockSupportCenterRepository();
+
     sut = SupportCenterUseCase(
       locationService: locationServices,
       supportCenterRepository: supportCenterRepository,
     );
   });
 
-  group('SupportCenterUsecase', () {
+  group(SupportCenterUseCase, () {
     group('metadata', () {
-      test('should hit repository for first access', () async {
+      test('hit repository for first access', () async {
         // arrange
         const jsonFile = 'support_center/support_center_meta_data.json';
         final jsonData = await JsonUtil.getJson(from: jsonFile);
 
-        when(supportCenterRepository.metadata()).thenAnswer(
+        when(() => supportCenterRepository.metadata()).thenAnswer(
           (_) async => right(
             SupportCenterMetadataModel.fromJson(jsonData),
           ),
@@ -35,23 +43,21 @@ void main() {
         // act
         await sut.metadata();
         // assert
-        verify(supportCenterRepository.metadata());
+        verify(() => supportCenterRepository.metadata()).called(1);
       });
 
-      test('should avoid hit repository twice', () async {
+      test('avoid hit repository twice', () async {
         const jsonFile = 'support_center/support_center_meta_data.json';
         final jsonData = await JsonUtil.getJson(from: jsonFile);
 
-        when(supportCenterRepository.metadata()).thenAnswer(
-          (_) => Future.value(
-            right(SupportCenterMetadataModel.fromJson(jsonData)),
-          ),
+        when(() => supportCenterRepository.metadata()).thenAnswer(
+          (_) async => right(SupportCenterMetadataModel.fromJson(jsonData)),
         );
         await sut.metadata();
         // act
         await sut.metadata();
         // assert
-        verify(supportCenterRepository.metadata()).called(1);
+        verify(() => supportCenterRepository.metadata()).called(1);
       });
     });
   });


### PR DESCRIPTION
## Objetivo

Migrar os testes do SupportCenterUseCase que estão utilizando o mockito. O mockito está sendo removido como dependência do projeto.

## Execução

Ajustado os teste para utilizar o mocktail.