### PR TITLE
TweetDataSource migrado para mocktail

### DIFF
--- a/test/app/features/feed/data/datasources/tweet_data_source_create_test.dart
+++ b/test/app/features/feed/data/datasources/tweet_data_source_create_test.dart
@@ -1,23 +1,28 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
-import 'package:mockito/mockito.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:penhas/app/core/network/api_server_configure.dart';
 import 'package:penhas/app/features/feed/data/datasources/tweet_data_source.dart';
 import 'package:penhas/app/features/feed/data/models/tweet_model.dart';
 import 'package:penhas/app/features/feed/domain/entities/tweet_engage_request_option.dart';
 import 'package:penhas/app/features/feed/domain/entities/tweet_entity.dart';
 
-import '../../../../../utils/helper.mocks.dart';
 import '../../../../../utils/json_util.dart';
 
+class MockHttpClient extends Mock implements http.Client {}
+
+class MockApiServerConfigure extends Mock implements IApiServerConfigure {}
+
 void main() {
-  late final MockHttpClient apiClient = MockHttpClient();
+  late Uri serverEndpoint;
+  late http.Client apiClient;
   late ITweetDataSource dataSource;
-  late final MockIApiServerConfigure serverConfigure =
-      MockIApiServerConfigure();
-  Uri? serverEndpoint;
+  late IApiServerConfigure serverConfigure;
   const String sessionToken = 'my_really.long.JWT';
 
   setUp(() {
+    apiClient = MockHttpClient();
+    serverConfigure = MockApiServerConfigure();
     serverEndpoint = Uri.https('api.anyserver.io', '/');
     dataSource = TweetDataSource(
       apiClient: apiClient,
@@ -25,11 +30,15 @@ void main() {
     );
 
     // MockApiServerConfigure configuration
-    when(serverConfigure.baseUri).thenAnswer((_) => serverEndpoint!);
-    when(serverConfigure.apiToken)
+    when(() => serverConfigure.baseUri).thenAnswer((_) => serverEndpoint);
+    when(() => serverConfigure.apiToken)
         .thenAnswer((_) => Future.value(sessionToken));
-    when(serverConfigure.userAgent)
+    when(() => serverConfigure.userAgent)
         .thenAnswer((_) => Future.value('iOS 11.4/Simulator/1.0.0'));
+  });
+
+  setUpAll(() {
+    registerFallbackValue(Uri());
   });
 
   Future<Map<String, String>> _setUpHttpHeader() async {
@@ -41,27 +50,23 @@ void main() {
     };
   }
 
-  Uri _setuHttpRequest(String path, Map<String, String> queryParameters) {
+  Uri _setupHttpRequest(String path, Map<String, String> queryParameters) {
     return Uri(
-      scheme: serverEndpoint!.scheme,
-      host: serverEndpoint!.host,
+      scheme: serverEndpoint.scheme,
+      host: serverEndpoint.host,
       path: path,
       queryParameters: queryParameters.isEmpty ? null : queryParameters,
     );
   }
 
-  PostExpectation<Future<http.Response>> _mockPostRequest() {
-    return when(
-      apiClient.post(
-        any,
-        headers: anyNamed('headers'),
-        body: anyNamed('body'),
-      ),
-    );
-  }
-
   void _setUpMockPostHttpClientSuccess200(String? bodyContent) {
-    _mockPostRequest().thenAnswer(
+    when(
+      () => apiClient.post(
+        any(),
+        headers: any(named: 'headers'),
+        body: any(named: 'body'),
+      ),
+    ).thenAnswer(
       (_) async => http.Response(
         bodyContent!,
         200,
@@ -72,7 +77,7 @@ void main() {
     );
   }
 
-  group('FeedDataSource', () {
+  group(TweetDataSource, () {
     group('create()', () {
       String? bodyContent;
       TweetCreateRequestOption? requestOption;
@@ -84,25 +89,25 @@ void main() {
           message: 'Mensagem 1',
         );
       });
-      test('should perform a POST with X-API-Key', () async {
+      test('perform a POST with X-API-Key', () async {
         // arrange
         const endPointPath = '/me/tweets';
         final bodyRequest = Uri.encodeComponent(requestOption!.message!);
         final headers = await _setUpHttpHeader();
-        final request = _setuHttpRequest(endPointPath, {});
+        final request = _setupHttpRequest(endPointPath, {});
         _setUpMockPostHttpClientSuccess200(bodyContent);
         // act
         await dataSource.create(option: requestOption);
         // assert
         verify(
-          apiClient.post(
+          () => apiClient.post(
             request,
             headers: headers,
             body: 'content=$bodyRequest',
           ),
-        );
+        ).called(1);
       });
-      test('should get a valid ValidField for a successful request', () async {
+      test('get a valid ValidField for a successful request', () async {
         // arrange
         _setUpMockPostHttpClientSuccess200(bodyContent);
         final expected = TweetModel(

--- a/test/app/features/feed/data/datasources/tweet_data_source_current_test.dart
+++ b/test/app/features/feed/data/datasources/tweet_data_source_current_test.dart
@@ -1,34 +1,44 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
-import 'package:mockito/mockito.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:penhas/app/core/network/api_server_configure.dart';
 import 'package:penhas/app/features/feed/data/datasources/tweet_data_source.dart';
 import 'package:penhas/app/features/feed/data/models/tweet_session_model.dart';
 import 'package:penhas/app/features/feed/domain/entities/tweet_engage_request_option.dart';
 
-import '../../../../../utils/helper.mocks.dart';
 import '../../../../../utils/json_util.dart';
 
+class MockHttpClient extends Mock implements http.Client {}
+
+class MockApiServerConfigure extends Mock implements IApiServerConfigure {}
+
 void main() {
-  late final MockHttpClient apiClient = MockHttpClient();
+  late Uri serverEndpoint;
+  late http.Client apiClient;
   late ITweetDataSource dataSource;
-  late final MockIApiServerConfigure serverConfigure =
-      MockIApiServerConfigure();
-  Uri? serverEndpoint;
+  late IApiServerConfigure serverConfigure;
   const String sessionToken = 'my_really.long.JWT';
 
   setUp(() {
+    apiClient = MockHttpClient();
+    serverConfigure = MockApiServerConfigure();
     serverEndpoint = Uri.https('api.anyserver.io', '/');
+
     dataSource = TweetDataSource(
       apiClient: apiClient,
       serverConfiguration: serverConfigure,
     );
 
     // MockApiServerConfigure configuration
-    when(serverConfigure.baseUri).thenAnswer((_) => serverEndpoint!);
-    when(serverConfigure.apiToken)
+    when(() => serverConfigure.baseUri).thenAnswer((_) => serverEndpoint);
+    when(() => serverConfigure.apiToken)
         .thenAnswer((_) => Future.value(sessionToken));
-    when(serverConfigure.userAgent)
+    when(() => serverConfigure.userAgent)
         .thenAnswer((_) => Future.value('iOS 11.4/Simulator/1.0.0'));
+  });
+
+  setUpAll(() {
+    registerFallbackValue(Uri());
   });
 
   Future<Map<String, String>> _setUpHttpHeader() async {
@@ -40,26 +50,22 @@ void main() {
     };
   }
 
-  Uri _setuHttpRequest(String path, Map<String, String> queryParameters) {
+  Uri _setUpHttpRequest(String path, Map<String, String> queryParameters) {
     return Uri(
-      scheme: serverEndpoint!.scheme,
-      host: serverEndpoint!.host,
+      scheme: serverEndpoint.scheme,
+      host: serverEndpoint.host,
       path: path,
       queryParameters: queryParameters.isEmpty ? null : queryParameters,
     );
   }
 
-  PostExpectation<Future<http.Response>> _mockGetRequest() {
-    return when(
-      apiClient.get(
-        any,
-        headers: anyNamed('headers'),
-      ),
-    );
-  }
-
   void _setUpMockGetHttpClientSuccess200(String? bodyContent) {
-    _mockGetRequest().thenAnswer(
+    when(
+      () => apiClient.get(
+        any(),
+        headers: any(named: 'headers'),
+      ),
+    ).thenAnswer(
       (_) async => http.Response(
         bodyContent!,
         200,
@@ -70,7 +76,7 @@ void main() {
     );
   }
 
-  group('FeedDataSource', () {
+  group(TweetDataSource, () {
     group('current()', () {
       String? bodyContent;
       TweetEngageRequestOption? requestOption;
@@ -81,32 +87,37 @@ void main() {
         requestOption = TweetEngageRequestOption(tweetId: '200608T1545460001');
       });
 
-      test('should perform a GET with X-API-Key', () async {
-        // arrange
-        const endPointPath = '/timeline';
-        final queryParameters = {
-          'id': '200608T1545460001',
-        };
-        final headers = await _setUpHttpHeader();
-        final request = _setuHttpRequest(endPointPath, queryParameters);
-        _setUpMockGetHttpClientSuccess200(bodyContent);
-        // act
-        await dataSource.current(option: requestOption);
-        // assert
-        verify(apiClient.get(request, headers: headers));
-      });
-      test('should get a valid TweetSession for a successful request',
-          () async {
-        // arrange
-        _setUpMockGetHttpClientSuccess200(bodyContent);
-        final jsonData =
-            await JsonUtil.getJson(from: 'feed/tweet_current_response.json');
-        final expected = TweetSessionModel.fromJson(jsonData);
-        // act
-        final received = await dataSource.current(option: requestOption);
-        // assert
-        expect(expected, received);
-      });
+      test(
+        'perform a GET with X-API-Key',
+        () async {
+          // arrange
+          const endPointPath = '/timeline';
+          final queryParameters = {
+            'id': '200608T1545460001',
+          };
+          final headers = await _setUpHttpHeader();
+          final request = _setUpHttpRequest(endPointPath, queryParameters);
+          _setUpMockGetHttpClientSuccess200(bodyContent);
+          // act
+          await dataSource.current(option: requestOption);
+          // assert
+          verify(() => apiClient.get(request, headers: headers)).called(1);
+        },
+      );
+      test(
+        'get a valid TweetSession for a successful request',
+        () async {
+          // arrange
+          _setUpMockGetHttpClientSuccess200(bodyContent);
+          final jsonData =
+              await JsonUtil.getJson(from: 'feed/tweet_current_response.json');
+          final expected = TweetSessionModel.fromJson(jsonData);
+          // act
+          final received = await dataSource.current(option: requestOption);
+          // assert
+          expect(expected, received);
+        },
+      );
     });
   });
 }

--- a/test/app/features/feed/data/datasources/tweet_data_source_dislike_test.dart
+++ b/test/app/features/feed/data/datasources/tweet_data_source_dislike_test.dart
@@ -1,33 +1,44 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
-import 'package:mockito/mockito.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:penhas/app/core/network/api_server_configure.dart';
 import 'package:penhas/app/features/feed/data/datasources/tweet_data_source.dart';
 import 'package:penhas/app/features/feed/data/models/tweet_model.dart';
 import 'package:penhas/app/features/feed/domain/entities/tweet_engage_request_option.dart';
 
-import '../../../../../utils/helper.mocks.dart';
 import '../../../../../utils/json_util.dart';
 
+class MockHttpClient extends Mock implements http.Client {}
+
+class MockApiServerConfigure extends Mock implements IApiServerConfigure {}
+
 void main() {
-  late final MockHttpClient apiClient = MockHttpClient();
-  late final MockIApiServerConfigure serverConfigure =
-      MockIApiServerConfigure();
+  late Uri serverEndpoint;
+  late http.Client apiClient;
   late ITweetDataSource dataSource;
-  final Uri serverEndpoint = Uri.https('api.anyserver.io', '/');
+  late IApiServerConfigure serverConfigure;
   const String sessionToken = 'my_really.long.JWT';
 
   setUp(() {
+    apiClient = MockHttpClient();
+    serverConfigure = MockApiServerConfigure();
+    serverEndpoint = Uri.https('api.anyserver.io', '/');
+
     dataSource = TweetDataSource(
       apiClient: apiClient,
       serverConfiguration: serverConfigure,
     );
 
     // MockApiServerConfigure configuration
-    when(serverConfigure.baseUri).thenAnswer((_) => serverEndpoint);
-    when(serverConfigure.apiToken)
+    when(() => serverConfigure.baseUri).thenAnswer((_) => serverEndpoint);
+    when(() => serverConfigure.apiToken)
         .thenAnswer((_) => Future.value(sessionToken));
-    when(serverConfigure.userAgent)
+    when(() => serverConfigure.userAgent)
         .thenAnswer((_) => Future.value('iOS 11.4/Simulator/1.0.0'));
+  });
+
+  setUpAll(() {
+    registerFallbackValue(Uri());
   });
 
   Future<Map<String, String>> _setUpHttpHeader() async {
@@ -39,7 +50,7 @@ void main() {
     };
   }
 
-  Uri _setuHttpRequest(String path, Map<String, String> queryParameters) {
+  Uri _setUpHttpRequest(String path, Map<String, String> queryParameters) {
     return Uri(
       scheme: serverEndpoint.scheme,
       host: serverEndpoint.host,
@@ -48,18 +59,14 @@ void main() {
     );
   }
 
-  PostExpectation<Future<http.Response>> _mockPostRequest() {
-    return when(
-      apiClient.post(
-        any,
-        headers: anyNamed('headers'),
-        body: anyNamed('body'),
-      ),
-    );
-  }
-
   void _setUpMockPostHttpClientSuccess200(String? bodyContent) {
-    _mockPostRequest().thenAnswer(
+    when(
+      () => apiClient.post(
+        any(),
+        headers: any(named: 'headers'),
+        body: any(named: 'body'),
+      ),
+    ).thenAnswer(
       (_) async => http.Response(
         bodyContent!,
         200,
@@ -70,44 +77,50 @@ void main() {
     );
   }
 
-  group('FeedDataSource', () {
-    group('dislike()', () {
-      String? bodyContent;
-      TweetEngageRequestOption? requestOption;
+  group(TweetDataSource, () {
+    group(
+      'dislike()',
+      () {
+        String? bodyContent;
+        TweetEngageRequestOption? requestOption;
 
-      setUp(() {
-        bodyContent =
-            JsonUtil.getStringSync(from: 'feed/tweet_like_response.json');
-        requestOption = TweetEngageRequestOption(
-          tweetId: '200520T0032210001',
-          dislike: true,
+        setUp(() {
+          bodyContent =
+              JsonUtil.getStringSync(from: 'feed/tweet_like_response.json');
+          requestOption = TweetEngageRequestOption(
+            tweetId: '200520T0032210001',
+            dislike: true,
+          );
+        });
+        test(
+          'perform a POST with X-API-Key',
+          () async {
+            // arrange
+            final endPointPath = '/timeline/${requestOption!.tweetId}/like';
+            final queryParameters = {'remove': '1'};
+
+            final headers = await _setUpHttpHeader();
+            final request = _setUpHttpRequest(endPointPath, queryParameters);
+            _setUpMockPostHttpClientSuccess200(bodyContent);
+            // act
+            await dataSource.like(option: requestOption);
+            // assert
+            verify(() => apiClient.post(request, headers: headers)).called(1);
+          },
         );
-      });
-      test('should perform a POST with X-API-Key', () async {
-        // arrange
-        final endPointPath = '/timeline/${requestOption!.tweetId}/like';
-        final queryParameters = {'remove': '1'};
-
-        final headers = await _setUpHttpHeader();
-        final request = _setuHttpRequest(endPointPath, queryParameters);
-        _setUpMockPostHttpClientSuccess200(bodyContent);
-        // act
-        await dataSource.like(option: requestOption);
-        // assert
-        verify(apiClient.post(request, headers: headers));
-      });
-      test('should get a valid ValidField for a successful request', () async {
-        // arrange
-        _setUpMockPostHttpClientSuccess200(bodyContent);
-        final jsonData =
-            await JsonUtil.getJson(from: 'feed/tweet_like_response.json');
-        final expected =
-            TweetModel.fromJson(jsonData['tweet'] as Map<String, dynamic>);
-        // act
-        final received = await dataSource.like(option: requestOption);
-        // assert
-        expect(expected, received);
-      });
-    });
+        test('get a valid ValidField for a successful request', () async {
+          // arrange
+          _setUpMockPostHttpClientSuccess200(bodyContent);
+          final jsonData =
+              await JsonUtil.getJson(from: 'feed/tweet_like_response.json');
+          final expected =
+              TweetModel.fromJson(jsonData['tweet'] as Map<String, dynamic>);
+          // act
+          final received = await dataSource.like(option: requestOption);
+          // assert
+          expect(expected, received);
+        });
+      },
+    );
   });
 }

--- a/test/app/features/feed/data/datasources/tweet_data_source_fetch_test.dart
+++ b/test/app/features/feed/data/datasources/tweet_data_source_fetch_test.dart
@@ -1,33 +1,48 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
-import 'package:mockito/mockito.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:penhas/app/core/network/api_server_configure.dart';
 import 'package:penhas/app/features/feed/data/datasources/tweet_data_source.dart';
 import 'package:penhas/app/features/feed/data/models/tweet_session_model.dart';
 import 'package:penhas/app/features/feed/domain/entities/tweet_request_option.dart';
 
-import '../../../../../utils/helper.mocks.dart';
 import '../../../../../utils/json_util.dart';
 
+class MockHttpClient extends Mock implements http.Client {}
+
+class MockApiServerConfigure extends Mock implements IApiServerConfigure {}
+
 void main() {
-  late final MockHttpClient apiClient = MockHttpClient();
-  late final MockIApiServerConfigure serverConfigure =
-      MockIApiServerConfigure();
+  late Uri serverEndpoint;
+  late http.Client apiClient;
   late ITweetDataSource dataSource;
-  final Uri serverEndpoint = Uri.https('api.anyserver.io', '/');
+  late IApiServerConfigure serverConfigure;
   const String sessionToken = 'my_really.long.JWT';
 
   setUp(() {
+    apiClient = MockHttpClient();
+    serverConfigure = MockApiServerConfigure();
+    serverEndpoint = Uri.https('api.anyserver.io', '/');
+    dataSource = TweetDataSource(
+      apiClient: apiClient,
+      serverConfiguration: serverConfigure,
+    );
+
     dataSource = TweetDataSource(
       apiClient: apiClient,
       serverConfiguration: serverConfigure,
     );
 
     // MockApiServerConfigure configuration
-    when(serverConfigure.baseUri).thenAnswer((_) => serverEndpoint);
-    when(serverConfigure.apiToken)
+    when(() => serverConfigure.baseUri).thenAnswer((_) => serverEndpoint);
+    when(() => serverConfigure.apiToken)
         .thenAnswer((_) => Future.value(sessionToken));
-    when(serverConfigure.userAgent)
+    when(() => serverConfigure.userAgent)
         .thenAnswer((_) => Future.value('iOS 11.4/Simulator/1.0.0'));
+  });
+
+  setUpAll(() {
+    registerFallbackValue(Uri());
   });
 
   Future<Map<String, String>> _setUpHttpHeader() async {
@@ -39,7 +54,7 @@ void main() {
     };
   }
 
-  Uri _setuHttpRequest(String path, Map<String, String> queryParameters) {
+  Uri _setUpHttpRequest(String path, Map<String, String> queryParameters) {
     return Uri(
       scheme: serverEndpoint.scheme,
       host: serverEndpoint.host,
@@ -48,17 +63,13 @@ void main() {
     );
   }
 
-  PostExpectation<Future<http.Response>> _mockGetRequest() {
-    return when(
-      apiClient.get(
-        any,
-        headers: anyNamed('headers'),
-      ),
-    );
-  }
-
   void _setUpMockGetHttpClientSuccess200(String? bodyContent) {
-    _mockGetRequest().thenAnswer(
+    when(
+      () => apiClient.get(
+        any(),
+        headers: any(named: 'headers'),
+      ),
+    ).thenAnswer(
       (_) async => http.Response(
         bodyContent!,
         200,
@@ -69,7 +80,7 @@ void main() {
     );
   }
 
-  group('FeedDataSource', () {
+  group(TweetDataSource, () {
     group('fetch()', () {
       String? bodyContent;
       TweetRequestOption? requestOption;
@@ -80,32 +91,37 @@ void main() {
         requestOption = const TweetRequestOption();
       });
 
-      test('should perform a GET with X-API-Key', () async {
-        // arrange
-        const endPointPath = '/timeline';
-        final queryParameters = {
-          'rows': '100',
-        };
-        final headers = await _setUpHttpHeader();
-        final request = _setuHttpRequest(endPointPath, queryParameters);
-        _setUpMockGetHttpClientSuccess200(bodyContent);
-        // act
-        await dataSource.fetch(option: requestOption);
-        // assert
-        verify(apiClient.get(request, headers: headers));
-      });
-      test('should get a valid TweetSession for a successful request',
-          () async {
-        // arrange
-        _setUpMockGetHttpClientSuccess200(bodyContent);
-        final jsonData =
-            await JsonUtil.getJson(from: 'feed/retrieve_response.json');
-        final expected = TweetSessionModel.fromJson(jsonData);
-        // act
-        final received = await dataSource.fetch(option: requestOption);
-        // assert
-        expect(expected, received);
-      });
+      test(
+        'perform a GET with X-API-Key',
+        () async {
+          // arrange
+          const endPointPath = '/timeline';
+          final queryParameters = {
+            'rows': '100',
+          };
+          final headers = await _setUpHttpHeader();
+          final request = _setUpHttpRequest(endPointPath, queryParameters);
+          _setUpMockGetHttpClientSuccess200(bodyContent);
+          // act
+          await dataSource.fetch(option: requestOption);
+          // assert
+          verify(() => apiClient.get(request, headers: headers));
+        },
+      );
+      test(
+        'get a valid TweetSession for a successful request',
+        () async {
+          // arrange
+          _setUpMockGetHttpClientSuccess200(bodyContent);
+          final jsonData =
+              await JsonUtil.getJson(from: 'feed/retrieve_response.json');
+          final expected = TweetSessionModel.fromJson(jsonData);
+          // act
+          final received = await dataSource.fetch(option: requestOption);
+          // assert
+          expect(expected, received);
+        },
+      );
     });
   });
 }

--- a/test/app/features/feed/data/datasources/tweet_data_source_like_test.dart
+++ b/test/app/features/feed/data/datasources/tweet_data_source_like_test.dart
@@ -1,31 +1,43 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
-import 'package:mockito/mockito.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:penhas/app/core/network/api_server_configure.dart';
 import 'package:penhas/app/features/feed/data/datasources/tweet_data_source.dart';
 import 'package:penhas/app/features/feed/data/models/tweet_model.dart';
 import 'package:penhas/app/features/feed/domain/entities/tweet_engage_request_option.dart';
 
-import '../../../../../utils/helper.mocks.dart';
 import '../../../../../utils/json_util.dart';
 
+class MockHttpClient extends Mock implements http.Client {}
+
+class MockApiServerConfigure extends Mock implements IApiServerConfigure {}
+
 void main() {
-  late final MockHttpClient apiClient = MockHttpClient();
-  late final MockIApiServerConfigure serverConfigure =
-      MockIApiServerConfigure();
-  late final ITweetDataSource dataSource = TweetDataSource(
-    apiClient: apiClient,
-    serverConfiguration: serverConfigure,
-  );
-  final Uri serverEndpoint = Uri.https('api.anyserver.io', '/');
+  late Uri serverEndpoint;
+  late http.Client apiClient;
+  late ITweetDataSource dataSource;
+  late IApiServerConfigure serverConfigure;
   const String sessionToken = 'my_really.long.JWT';
 
   setUp(() {
+    apiClient = MockHttpClient();
+    serverConfigure = MockApiServerConfigure();
+    serverEndpoint = Uri.https('api.anyserver.io', '/');
+    dataSource = TweetDataSource(
+      apiClient: apiClient,
+      serverConfiguration: serverConfigure,
+    );
+
     // MockApiServerConfigure configuration
-    when(serverConfigure.baseUri).thenAnswer((_) => serverEndpoint);
-    when(serverConfigure.apiToken)
+    when(() => serverConfigure.baseUri).thenAnswer((_) => serverEndpoint);
+    when(() => serverConfigure.apiToken)
         .thenAnswer((_) => Future.value(sessionToken));
-    when(serverConfigure.userAgent)
+    when(() => serverConfigure.userAgent)
         .thenAnswer((_) => Future.value('iOS 11.4/Simulator/1.0.0'));
+  });
+
+  setUpAll(() {
+    registerFallbackValue(Uri());
   });
 
   Future<Map<String, String>> _setUpHttpHeader() async {
@@ -37,7 +49,7 @@ void main() {
     };
   }
 
-  Uri _setuHttpRequest(String path, Map<String, String> queryParameters) {
+  Uri _setUpHttpRequest(String path, Map<String, String> queryParameters) {
     return Uri(
       scheme: serverEndpoint.scheme,
       host: serverEndpoint.host,
@@ -46,18 +58,14 @@ void main() {
     );
   }
 
-  PostExpectation<Future<http.Response>> _mockPostRequest() {
-    return when(
-      apiClient.post(
-        any,
-        headers: anyNamed('headers'),
-        body: anyNamed('body'),
-      ),
-    );
-  }
-
   void _setUpMockPostHttpClientSuccess200(String? bodyContent) {
-    _mockPostRequest().thenAnswer(
+    when(
+      () => apiClient.post(
+        any(),
+        headers: any(named: 'headers'),
+        body: any(named: 'body'),
+      ),
+    ).thenAnswer(
       (_) async => http.Response(
         bodyContent!,
         200,
@@ -68,7 +76,7 @@ void main() {
     );
   }
 
-  group('FeedDataSource', () {
+  group(TweetDataSource, () {
     group('like()', () {
       String? bodyContent;
       TweetEngageRequestOption? requestOption;
@@ -78,30 +86,36 @@ void main() {
             JsonUtil.getStringSync(from: 'feed/tweet_like_response.json');
         requestOption = TweetEngageRequestOption(tweetId: '200520T0032210001');
       });
-      test('should perform a POST with X-API-Key', () async {
-        // arrange
-        final endPointPath = '/timeline/${requestOption!.tweetId}/like';
-        final queryParameters = <String, String>{};
+      test(
+        'perform a POST with X-API-Key',
+        () async {
+          // arrange
+          final endPointPath = '/timeline/${requestOption!.tweetId}/like';
+          final queryParameters = <String, String>{};
 
-        final headers = await _setUpHttpHeader();
-        final request = _setuHttpRequest(endPointPath, queryParameters);
-        _setUpMockPostHttpClientSuccess200(bodyContent);
-        // act
-        await dataSource.like(option: requestOption);
-        // assert
-        verify(apiClient.post(request, headers: headers));
-      });
-      test('should get a valid ValidField for a successful request', () async {
-        // arrange
-        _setUpMockPostHttpClientSuccess200(bodyContent);
-        final jsonData =
-            await JsonUtil.getJson(from: 'feed/tweet_like_response.json');
-        final expected = TweetModel.fromJson(jsonData['tweet']);
-        // act
-        final received = await dataSource.like(option: requestOption);
-        // assert
-        expect(expected, received);
-      });
+          final headers = await _setUpHttpHeader();
+          final request = _setUpHttpRequest(endPointPath, queryParameters);
+          _setUpMockPostHttpClientSuccess200(bodyContent);
+          // act
+          await dataSource.like(option: requestOption);
+          // assert
+          verify(() => apiClient.post(request, headers: headers));
+        },
+      );
+      test(
+        'get a valid ValidField for a successful request',
+        () async {
+          // arrange
+          _setUpMockPostHttpClientSuccess200(bodyContent);
+          final jsonData =
+              await JsonUtil.getJson(from: 'feed/tweet_like_response.json');
+          final expected = TweetModel.fromJson(jsonData['tweet']);
+          // act
+          final received = await dataSource.like(option: requestOption);
+          // assert
+          expect(expected, received);
+        },
+      );
     });
   });
 }

--- a/test/app/features/feed/data/datasources/tweet_data_source_reply_test.dart
+++ b/test/app/features/feed/data/datasources/tweet_data_source_reply_test.dart
@@ -1,34 +1,44 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
-import 'package:mockito/mockito.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:penhas/app/core/network/api_server_configure.dart';
 import 'package:penhas/app/features/feed/data/datasources/tweet_data_source.dart';
 import 'package:penhas/app/features/feed/data/models/tweet_model.dart';
 import 'package:penhas/app/features/feed/domain/entities/tweet_engage_request_option.dart';
 import 'package:penhas/app/features/feed/domain/entities/tweet_entity.dart';
 
-import '../../../../../utils/helper.mocks.dart';
 import '../../../../../utils/json_util.dart';
 
+class MockHttpClient extends Mock implements http.Client {}
+
+class MockApiServerConfigure extends Mock implements IApiServerConfigure {}
+
 void main() {
-  late final MockHttpClient apiClient = MockHttpClient();
+  late Uri serverEndpoint;
+  late http.Client apiClient;
   late ITweetDataSource dataSource;
-  late final MockIApiServerConfigure serverConfigure =
-      MockIApiServerConfigure();
-  late final Uri serverEndpoint = Uri.https('api.anyserver.io', '/');
+  late IApiServerConfigure serverConfigure;
   const String sessionToken = 'my_really.long.JWT';
 
   setUp(() {
+    apiClient = MockHttpClient();
+    serverConfigure = MockApiServerConfigure();
+    serverEndpoint = Uri.https('api.anyserver.io', '/');
     dataSource = TweetDataSource(
       apiClient: apiClient,
       serverConfiguration: serverConfigure,
     );
 
     // MockApiServerConfigure configuration
-    when(serverConfigure.baseUri).thenAnswer((_) => serverEndpoint);
-    when(serverConfigure.apiToken)
+    when(() => serverConfigure.baseUri).thenAnswer((_) => serverEndpoint);
+    when(() => serverConfigure.apiToken)
         .thenAnswer((_) => Future.value(sessionToken));
-    when(serverConfigure.userAgent)
+    when(() => serverConfigure.userAgent)
         .thenAnswer((_) => Future.value('iOS 11.4/Simulator/1.0.0'));
+  });
+
+  setUpAll(() {
+    registerFallbackValue(Uri());
   });
 
   Future<Map<String, String>> _setUpHttpHeader() async {
@@ -40,7 +50,7 @@ void main() {
     };
   }
 
-  Uri _setuHttpRequest(String path, Map<String, String> queryParameters) {
+  Uri _setUpHttpRequest(String path, Map<String, String> queryParameters) {
     return Uri(
       scheme: serverEndpoint.scheme,
       host: serverEndpoint.host,
@@ -49,18 +59,14 @@ void main() {
     );
   }
 
-  PostExpectation<Future<http.Response>> _mockPostRequest() {
-    return when(
-      apiClient.post(
-        any,
-        headers: anyNamed('headers'),
-        body: anyNamed('body'),
-      ),
-    );
-  }
-
   void _setUpMockPostHttpClientSuccess200(String? bodyContent) {
-    _mockPostRequest().thenAnswer(
+    when(
+      () => apiClient.post(
+        any(),
+        headers: any(named: 'headers'),
+        body: any(named: 'body'),
+      ),
+    ).thenAnswer(
       (_) async => http.Response(
         bodyContent!,
         200,
@@ -71,7 +77,7 @@ void main() {
     );
   }
 
-  group('FeedDataSource', () {
+  group(TweetDataSource, () {
     group('reply()', () {
       String? bodyContent;
       TweetEngageRequestOption? requestOption;
@@ -84,45 +90,51 @@ void main() {
           message: 'um breve comentario',
         );
       });
-      test('should perform a POST with X-API-Key', () async {
-        // arrange
-        final endPointPath = '/timeline/${requestOption!.tweetId}/comment';
-        final bodyRequest = Uri.encodeComponent('um breve comentario');
-        final headers = await _setUpHttpHeader();
-        final request = _setuHttpRequest(endPointPath, {});
-        _setUpMockPostHttpClientSuccess200(bodyContent);
-        // act
-        await dataSource.reply(option: requestOption);
-        // assert
-        verify(
-          apiClient.post(
-            request,
-            headers: headers,
-            body: 'content=$bodyRequest',
-          ),
-        );
-      });
-      test('should get a valid ValidField for a successful request', () async {
-        // arrange
-        _setUpMockPostHttpClientSuccess200(bodyContent);
-        final expected = TweetModel(
-          id: '200608T1809090001',
-          userName: 'rosa',
-          clientId: 551,
-          createdAt: '2020-06-08 18:09:09',
-          totalReply: 0,
-          totalLikes: 0,
-          anonymous: false,
-          content: 'um breve comentario',
-          avatar: 'https://elasv2-api.appcivico.com/avatar/padrao.svg',
-          meta: const TweetMeta(liked: false, owner: true),
-          lastReply: const [],
-        );
-        // act
-        final received = await dataSource.reply(option: requestOption);
-        // assert
-        expect(expected, received);
-      });
+      test(
+        'perform a POST with X-API-Key',
+        () async {
+          // arrange
+          final endPointPath = '/timeline/${requestOption!.tweetId}/comment';
+          final bodyRequest = Uri.encodeComponent('um breve comentario');
+          final headers = await _setUpHttpHeader();
+          final request = _setUpHttpRequest(endPointPath, {});
+          _setUpMockPostHttpClientSuccess200(bodyContent);
+          // act
+          await dataSource.reply(option: requestOption);
+          // assert
+          verify(
+            () => apiClient.post(
+              request,
+              headers: headers,
+              body: 'content=$bodyRequest',
+            ),
+          ).called(1);
+        },
+      );
+      test(
+        'get a valid ValidField for a successful request',
+        () async {
+          // arrange
+          _setUpMockPostHttpClientSuccess200(bodyContent);
+          final expected = TweetModel(
+            id: '200608T1809090001',
+            userName: 'rosa',
+            clientId: 551,
+            createdAt: '2020-06-08 18:09:09',
+            totalReply: 0,
+            totalLikes: 0,
+            anonymous: false,
+            content: 'um breve comentario',
+            avatar: 'https://elasv2-api.appcivico.com/avatar/padrao.svg',
+            meta: const TweetMeta(liked: false, owner: true),
+            lastReply: const [],
+          );
+          // act
+          final received = await dataSource.reply(option: requestOption);
+          // assert
+          expect(expected, received);
+        },
+      );
     });
   });
 }


### PR DESCRIPTION
## Objetivo

Migrar os testes do TweetDataSource que estão utilizando o mockito. O mockito está sendo removido como dependência do projeto.

## Execução

Ajustado os teste para utilizar o mocktail.