### PR TITLE
TweetFilterPreferenceDataSource migrado para mocktail

### DIFF
--- a/test/app/features/feed/data/datasources/tweet_filter_data_source_test.dart
+++ b/test/app/features/feed/data/datasources/tweet_filter_data_source_test.dart
@@ -1,33 +1,43 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
-import 'package:mockito/mockito.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:penhas/app/core/network/api_server_configure.dart';
 import 'package:penhas/app/features/feed/data/datasources/tweet_filter_preference_data_source.dart';
 import 'package:penhas/app/features/feed/data/models/tweet_filter_session_model.dart';
 
-import '../../../../../utils/helper.mocks.dart';
 import '../../../../../utils/json_util.dart';
 
+class MockHttpClient extends Mock implements http.Client {}
+
+class MockApiServerConfigure extends Mock implements IApiServerConfigure {}
+
 void main() {
-  late final MockHttpClient apiClient = MockHttpClient();
+  late Uri serverEndpoint;
+  late http.Client apiClient;
   late ITweetFilterPreferenceDataSource dataSource;
-  late final MockIApiServerConfigure serverConfigure =
-      MockIApiServerConfigure();
-  Uri? serverEndpoint;
+  late IApiServerConfigure serverConfigure;
   const String sessionToken = 'my_really.long.JWT';
 
   setUp(() {
+    apiClient = MockHttpClient();
+    serverConfigure = MockApiServerConfigure();
     serverEndpoint = Uri.https('api.anyserver.io', '/');
+
     dataSource = TweetFilterPreferenceDataSource(
       apiClient: apiClient,
       serverConfiguration: serverConfigure,
     );
 
     // MockApiServerConfigure configuration
-    when(serverConfigure.baseUri).thenAnswer((_) => serverEndpoint!);
-    when(serverConfigure.apiToken)
+    when(() => serverConfigure.baseUri).thenAnswer((_) => serverEndpoint);
+    when(() => serverConfigure.apiToken)
         .thenAnswer((_) => Future.value(sessionToken));
-    when(serverConfigure.userAgent)
+    when(() => serverConfigure.userAgent)
         .thenAnswer((_) => Future.value('iOS 11.4/Simulator/1.0.0'));
+  });
+
+  setUpAll(() {
+    registerFallbackValue(Uri());
   });
 
   Future<Map<String, String>> _setUpHttpHeader() async {
@@ -39,26 +49,22 @@ void main() {
     };
   }
 
-  Uri _setuHttpRequest(String path, Map<String, String> queryParameters) {
+  Uri _setUpHttpRequest(String path, Map<String, String> queryParameters) {
     return Uri(
-      scheme: serverEndpoint!.scheme,
-      host: serverEndpoint!.host,
+      scheme: serverEndpoint.scheme,
+      host: serverEndpoint.host,
       path: path,
       queryParameters: queryParameters.isEmpty ? null : queryParameters,
     );
   }
 
-  PostExpectation<Future<http.Response>> _mockGetRequest() {
-    return when(
-      apiClient.get(
-        any,
-        headers: anyNamed('headers'),
-      ),
-    );
-  }
-
   void _setUpMockGetHttpClientSuccess200(String? bodyContent) {
-    _mockGetRequest().thenAnswer(
+    when(
+      () => apiClient.get(
+        any(),
+        headers: any(named: 'headers'),
+      ),
+    ).thenAnswer(
       (_) async => http.Response(
         bodyContent!,
         200,
@@ -69,8 +75,8 @@ void main() {
     );
   }
 
-  group('TweetFilterPreferenceDataSource', () {
-    String? bodyContent;
+  group(TweetFilterPreferenceDataSource, () {
+    late String bodyContent;
 
     setUp(() {
       bodyContent =
@@ -78,20 +84,19 @@ void main() {
     });
 
     group('fetch()', () {
-      test('should perform a GET with X-API-Key', () async {
+      test('perform a GET with X-API-Key', () async {
         // arrange
         const endPointPath = '/filter-tags';
         final headers = await _setUpHttpHeader();
-        final request = _setuHttpRequest(endPointPath, {});
+        final request = _setUpHttpRequest(endPointPath, {});
         _setUpMockGetHttpClientSuccess200(bodyContent);
         // act
         await dataSource.fetch();
         // assert
-        verify(apiClient.get(request, headers: headers));
+        verify(() => apiClient.get(request, headers: headers)).called(1);
       });
 
-      test(
-          'should get a valid TweetFilterSessionModel for a successful request',
+      test('get a valid TweetFilterSessionModel for a successful request',
           () async {
         // arrange
         _setUpMockGetHttpClientSuccess200(bodyContent);


### PR DESCRIPTION
## Objetivo

Migrar os testes do TweetFilterPreferenceDataSource que estão utilizando o mockito. O mockito está sendo removido como dependência do projeto.

## Execução

Ajustado os teste para utilizar o mocktail.