### PR TITLE
UserProfileRepository migrado para mocktail

### DIFF
--- a/test/app/features/profile/data/repositories/user_profile_repository_test.dart
+++ b/test/app/features/profile/data/repositories/user_profile_repository_test.dart
@@ -58,10 +58,10 @@ void main() {
         () async {
           // arrange
           _setUpMockPost();
-          final actual = right(const ValidField());
+          final expected = right(const ValidField());
           const toggle = true;
           // act
-          final expected = await sut.stealthMode(toggle: toggle);
+          final actual = await sut.stealthMode(toggle: toggle);
           // assert
           expect(actual, expected);
         },
@@ -89,12 +89,12 @@ void main() {
         () async {
           // arrange
           _setUpMockPost();
-          final actual = right(const ValidField());
+          final expected = right(const ValidField());
           const toggle = false;
           // act
-          final matcher = await sut.anonymousMode(toggle: toggle);
+          final actual = await sut.anonymousMode(toggle: toggle);
           // assert
-          expect(actual, matcher);
+          expect(actual, expected);
         },
       );
     });

--- a/test/app/features/profile/data/repositories/user_profile_repository_test.dart
+++ b/test/app/features/profile/data/repositories/user_profile_repository_test.dart
@@ -1,60 +1,75 @@
 import 'package:dartz/dartz.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mockito/mockito.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:penhas/app/core/entities/valid_fiel.dart';
+import 'package:penhas/app/core/network/api_client.dart';
+import 'package:penhas/app/core/network/api_server_configure.dart';
 import 'package:penhas/app/features/main_menu/domain/repositories/user_profile_repository.dart';
 
-import '../../../../../utils/helper.mocks.dart';
+class MockApiProvider extends Mock implements IApiProvider {}
+
+class MockApiServerConfigure extends Mock implements IApiServerConfigure {}
 
 void main() {
-  late final MockIApiProvider apiProvider = MockIApiProvider();
-  late final MockIApiServerConfigure serverConfiguration =
-      MockIApiServerConfigure();
-  late final IUserProfileRepository sut = UserProfileRepository(
-    apiProvider: apiProvider,
-    serverConfiguration: serverConfiguration,
-  );
+  late IUserProfileRepository sut;
+  late IApiProvider apiProvider;
+  late IApiServerConfigure serverConfiguration;
+
+  setUpAll(() {
+    apiProvider = MockApiProvider();
+    serverConfiguration = MockApiServerConfigure();
+    sut = UserProfileRepository(
+      apiProvider: apiProvider,
+      serverConfiguration: serverConfiguration,
+    );
+  });
 
   void _setUpMockPost() {
     when(
-      apiProvider.post(
-        path: anyNamed('path'),
-        parameters: anyNamed('parameters'),
+      () => apiProvider.post(
+        path: any(named: 'path'),
+        parameters: any(named: 'parameters'),
       ),
     ).thenAnswer((_) async => Future.value(''));
   }
 
-  group('UserProfileRepository', () {
+  group(UserProfileRepository, () {
     group('stealth mode', () {
-      test('should hit endpoint /me/modo-camuflado-toggle', () async {
-        // arrange
-        _setUpMockPost();
-        final endPoint = ['me', 'modo-camuflado-toggle'].join('/');
-        final parameters = {'active': '1'};
-        // act
-        await sut.stealthMode(toggle: true);
-        // assert
-        verify(
-          apiProvider.post(
-            path: endPoint,
-            parameters: parameters,
-          ),
-        );
-      });
-      test('should receive ValidField', () async {
-        // arrange
-        _setUpMockPost();
-        final actual = right(const ValidField());
-        const toggle = true;
-        // act
-        final expected = await sut.stealthMode(toggle: toggle);
-        // assert
-        expect(actual, expected);
-      });
+      test(
+        'hit endpoint /me/modo-camuflado-toggle',
+        () async {
+          // arrange
+          _setUpMockPost();
+          final endPoint = ['me', 'modo-camuflado-toggle'].join('/');
+          final parameters = {'active': '1'};
+          // act
+          await sut.stealthMode(toggle: true);
+          // assert
+          verify(
+            () => apiProvider.post(
+              path: endPoint,
+              parameters: parameters,
+            ),
+          ).called(1);
+        },
+      );
+      test(
+        'receive ValidField',
+        () async {
+          // arrange
+          _setUpMockPost();
+          final actual = right(const ValidField());
+          const toggle = true;
+          // act
+          final expected = await sut.stealthMode(toggle: toggle);
+          // assert
+          expect(actual, expected);
+        },
+      );
     });
 
     group('anonymous mode', () {
-      test('should hit endpoint /me/modo-anonimo-toggle', () async {
+      test('hit endpoint /me/modo-anonimo-toggle', () async {
         // arrange
         _setUpMockPost();
         final endPoint = ['me', 'modo-anonimo-toggle'].join('/');
@@ -63,22 +78,25 @@ void main() {
         await sut.anonymousMode(toggle: true);
         // assert
         verify(
-          apiProvider.post(
+          () => apiProvider.post(
             path: endPoint,
             parameters: parameters,
           ),
-        );
+        ).called(1);
       });
-      test('should receive ValidField', () async {
-        // arrange
-        _setUpMockPost();
-        final actual = right(const ValidField());
-        const toggle = false;
-        // act
-        final matcher = await sut.anonymousMode(toggle: toggle);
-        // assert
-        expect(actual, matcher);
-      });
+      test(
+        'receive ValidField',
+        () async {
+          // arrange
+          _setUpMockPost();
+          final actual = right(const ValidField());
+          const toggle = false;
+          // act
+          final matcher = await sut.anonymousMode(toggle: toggle);
+          // assert
+          expect(actual, matcher);
+        },
+      );
     });
   });
 }


### PR DESCRIPTION
## Objetivo

Migrar os testes do UserProfileRepository que estão utilizando o mockito. O mockito está sendo removido como dependência do projeto.

## Execução

Ajustado os teste para utilizar o mocktail.