### PR TITLE
Controllers migrado para mocktail

### DIFF
--- a/test/app/features/mainboard/presentation/mainboard/mainboard_controller_test.dart
+++ b/test/app/features/mainboard/presentation/mainboard/mainboard_controller_test.dart
@@ -1,18 +1,19 @@
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_modular_test/flutter_modular_test.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:penhas/app/core/network/network_info.dart';
-
 import 'package:penhas/app/features/mainboard/presentation/mainboard/mainboard_module.dart';
 
 import '../../../../../utils/aditional_bind_module.dart';
-import '../../../../../utils/helper.mocks.dart';
+
+class MockNetworkInfo extends Mock implements INetworkInfo {}
 
 void main() {
   initModules([
     AditionalBindModule(
       binds: [
-        Bind.singleton<INetworkInfo>((i) => MockINetworkInfo()),
+        Bind.singleton<INetworkInfo>((i) => MockNetworkInfo()),
       ],
     ),
     MainboardModule(),

--- a/test/app/features/quiz/presentation/quiz_controller_test.dart
+++ b/test/app/features/quiz/presentation/quiz_controller_test.dart
@@ -1,18 +1,22 @@
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_modular_test/flutter_modular_test.dart';
 import 'package:flutter_test/flutter_test.dart';
-
+import 'package:mocktail/mocktail.dart';
+import 'package:penhas/app/core/managers/location_services.dart';
 import 'package:penhas/app/features/quiz/presentation/quiz/quiz_module.dart';
 
 import '../../../../utils/aditional_bind_module.dart';
-import '../../../../utils/helper.mocks.dart';
+
+class MockLocationServices extends Mock implements ILocationServices {}
 
 void main() {
   initModules([
     QuizModule(),
-    AditionalBindModule(binds: [
-      Bind.singleton((i) => MockILocationServices()),
-    ],),
+    AditionalBindModule(
+      binds: [
+        Bind.singleton((i) => MockLocationServices()),
+      ],
+    ),
   ]);
   // QuizController quiz;
   //


### PR DESCRIPTION
## Objetivo

Migrar os testes dos  QuizController e MainboardController que estão utilizando o mockito. O mockito está sendo removido como dependência do projeto.

## Execução

Apesar dos testes dos controllers QuizController e MainboardController estarem desativados, foi necessário migrar a dependência do mockito para não travar o processo de desativação e remoção do mockito do projeto.
