### PR TITLE
Correção da sincronização das atualizações dos tweets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Corrigido
+- Comportamento ao curtir e comentar tweets
+
 ## [3.2.0] - 2023-02-23
 
 ### Modificado

--- a/lib/app/core/extension/list.dart
+++ b/lib/app/core/extension/list.dart
@@ -1,0 +1,29 @@
+extension ListExt<T> on List<T> {
+  bool removeFirstWhere(bool Function(T) test) =>
+      doOnFirst(test, (index, item) {
+        removeAt(index);
+      });
+
+  bool updateFirstWhere(
+    bool Function(T item) test,
+    T Function(T item) update,
+  ) =>
+      doOnFirst(
+        test,
+        (index, item) => this[index] = update(item),
+      );
+
+  bool doOnFirst(
+    bool Function(T item) test,
+    void Function(int index, T item) action,
+  ) {
+    for (var index = 0; index < length; index++) {
+      var item = this[index];
+      if (test(item)) {
+        action(index, item);
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/lib/app/features/feed/data/models/tweet_model.dart
+++ b/lib/app/features/feed/data/models/tweet_model.dart
@@ -1,4 +1,4 @@
-import 'package:penhas/app/features/feed/domain/entities/tweet_entity.dart';
+import '../../domain/entities/tweet_entity.dart';
 
 class TweetModel extends TweetEntity {
   TweetModel({

--- a/lib/app/features/feed/data/models/tweet_model.dart
+++ b/lib/app/features/feed/data/models/tweet_model.dart
@@ -2,14 +2,14 @@ import 'package:penhas/app/features/feed/domain/entities/tweet_entity.dart';
 
 class TweetModel extends TweetEntity {
   TweetModel({
-    required String? id,
-    required String? userName,
+    required String id,
+    required String userName,
     required int clientId,
-    required String? createdAt,
+    required String createdAt,
     required int totalReply,
     required int totalLikes,
     required bool anonymous,
-    required String? content,
+    required String content,
     required String avatar,
     required TweetMeta meta,
     String? parentId,

--- a/lib/app/features/feed/domain/entities/tweet_entity.dart
+++ b/lib/app/features/feed/domain/entities/tweet_entity.dart
@@ -15,21 +15,21 @@ class TweetEntity extends TweetTiles {
     required this.avatar,
     required this.meta,
     this.parentId,
-    this.lastReply,
+    this.lastReply = const [],
   });
 
-  final String? id;
+  final String id;
   final String? parentId;
-  final String? userName;
+  final String userName;
   final int clientId;
-  final String? createdAt;
+  final String createdAt;
   final int totalReply;
   final int totalLikes;
   final bool anonymous;
-  final String? content;
-  final String? avatar;
+  final String content;
+  final String avatar;
   final TweetMeta meta;
-  final List<TweetEntity?>? lastReply;
+  final List<TweetEntity> lastReply;
 
   @override
   List<Object?> get props => [
@@ -59,7 +59,7 @@ class TweetEntity extends TweetTiles {
     String? avatar,
     TweetMeta? meta,
     String? parentId,
-    List<TweetEntity?>? lastReply,
+    List<TweetEntity>? lastReply,
   }) {
     return TweetEntity(
       id: id ?? this.id,

--- a/lib/app/features/feed/domain/error/tweet_removed_error.dart
+++ b/lib/app/features/feed/domain/error/tweet_removed_error.dart
@@ -1,0 +1,3 @@
+import '../../../../core/error/failures.dart';
+
+class TweetRemovedError extends Failure {}

--- a/lib/app/features/feed/domain/usecases/feed_use_cases.dart
+++ b/lib/app/features/feed/domain/usecases/feed_use_cases.dart
@@ -66,7 +66,7 @@ class FeedUseCases {
         .doOnCancel(() => _tweetReplyMap.remove(id))
         .map<Either<Failure, FeedCache>>(
           (cache) => cache.containsKey(id)
-              ? right(FeedCache(tweets: cache[id]!))
+              ? right(FeedCache(tweets: cache[id]!.sublist(0)))
               : left(TweetRemovedError()),
         )
         .distinct();

--- a/lib/app/features/feed/presentation/detail_tweet/detail_tweet_controller.dart
+++ b/lib/app/features/feed/presentation/detail_tweet/detail_tweet_controller.dart
@@ -34,7 +34,7 @@ abstract class _DetailTweetControllerBase with Store, MapFailureMessage {
     this.tweetId,
     this.commentId,
   ) : isWithoutGoToParentAction = tweet != null {
-    listTweets = ObservableList.of([if (tweet != null) tweet]);
+    listTweets = ObservableList.of([]);
     _listenDetailUpdates();
   }
 

--- a/lib/app/features/feed/presentation/detail_tweet/detail_tweet_page.dart
+++ b/lib/app/features/feed/presentation/detail_tweet/detail_tweet_page.dart
@@ -1,18 +1,20 @@
 import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:mobx/mobx.dart';
-import 'package:penhas/app/features/authentication/presentation/shared/snack_bar_handler.dart';
-import 'package:penhas/app/features/feed/domain/entities/tweet_entity.dart';
-import 'package:penhas/app/features/feed/presentation/detail_tweet/detail_tweet_controller.dart';
-import 'package:penhas/app/features/feed/presentation/stores/tweet_controller.dart';
-import 'package:penhas/app/features/feed/presentation/tweet/widgets/tweet_body.dart';
-import 'package:penhas/app/features/feed/presentation/tweet/widgets/tweet_bottom.dart';
-import 'package:penhas/app/features/feed/presentation/tweet/widgets/tweet_title.dart';
-import 'package:penhas/app/shared/design_system/colors.dart';
-import 'package:penhas/app/shared/design_system/text_styles.dart';
 import 'package:scroll_to_index/scroll_to_index.dart';
+
+import '../../../../shared/design_system/colors.dart';
+import '../../../../shared/design_system/text_styles.dart';
+import '../../../authentication/presentation/shared/snack_bar_handler.dart';
+import '../../domain/entities/tweet_entity.dart';
+import '../stores/tweet_controller.dart';
+import '../tweet/widgets/tweet_body.dart';
+import '../tweet/widgets/tweet_bottom.dart';
+import '../tweet/widgets/tweet_title.dart';
+import 'detail_tweet_controller.dart';
 
 Color _defaultColor = Colors.white;
 Color _highlightColor = DesignSystemColors.ligthPurple.withOpacity(0.1);
@@ -63,6 +65,7 @@ class _DetailTweetPageState
       d();
     }
     _scrollController.dispose();
+    controller.dispose();
   }
 
   @override
@@ -99,7 +102,7 @@ class _DetailTweetPageState
     }
     return Column(
       children: [
-        ShowParentTweetWidget(widget.tweetController, parentId),
+        _ShowParentTweetWidget(widget.tweetController, parentId),
         Flexible(child: _buildTweetList()),
       ],
     );
@@ -256,7 +259,7 @@ class _ReplyTweetState extends State<_ReplyTweet> {
               TweetBody(content: _tweet.content),
               TweetBottom(tweet: _tweet, controller: controller),
               if (_isComment && _tweet.totalReply > 0)
-                ShowReplyWidget(controller, _tweet),
+                _ShowReplyWidget(controller, _tweet),
             ],
           ),
         ),
@@ -290,8 +293,8 @@ class _ReplyTweetState extends State<_ReplyTweet> {
   }
 }
 
-class ShowReplyWidget extends StatelessWidget {
-  const ShowReplyWidget(this.controller, this.tweet);
+class _ShowReplyWidget extends StatelessWidget {
+  const _ShowReplyWidget(this.controller, this.tweet);
 
   final ITweetController controller;
   final TweetEntity tweet;
@@ -306,8 +309,8 @@ class ShowReplyWidget extends StatelessWidget {
       );
 }
 
-class ShowParentTweetWidget extends StatelessWidget {
-  const ShowParentTweetWidget(this.controller, this.tweetId);
+class _ShowParentTweetWidget extends StatelessWidget {
+  const _ShowParentTweetWidget(this.controller, this.tweetId);
 
   final ITweetController controller;
   final String tweetId;

--- a/lib/app/features/feed/presentation/feed_controller.dart
+++ b/lib/app/features/feed/presentation/feed_controller.dart
@@ -2,14 +2,15 @@ import 'dart:async';
 
 import 'package:dartz/dartz.dart';
 import 'package:mobx/mobx.dart';
-import 'package:penhas/app/core/error/failures.dart';
-import 'package:penhas/app/core/managers/modules_sevices.dart';
-import 'package:penhas/app/features/authentication/presentation/shared/map_failure_message.dart';
-import 'package:penhas/app/features/authentication/presentation/shared/page_progress_indicator.dart';
-import 'package:penhas/app/features/feed/domain/entities/tweet_entity.dart';
-import 'package:penhas/app/features/feed/domain/states/feed_security_state.dart';
-import 'package:penhas/app/features/feed/domain/usecases/feed_use_cases.dart';
-import 'package:penhas/app/features/help_center/domain/usecases/security_mode_action_feature.dart';
+
+import '../../../core/error/failures.dart';
+import '../../../core/managers/modules_sevices.dart';
+import '../../authentication/presentation/shared/map_failure_message.dart';
+import '../../authentication/presentation/shared/page_progress_indicator.dart';
+import '../../help_center/domain/usecases/security_mode_action_feature.dart';
+import '../domain/entities/tweet_entity.dart';
+import '../domain/states/feed_security_state.dart';
+import '../domain/usecases/feed_use_cases.dart';
 
 part 'feed_controller.g.dart';
 
@@ -124,7 +125,8 @@ abstract class _FeedControllerBase with Store, MapFailureMessage {
   }
 
   void _registerDataSource() {
-    _streamCache = useCase.dataSource
+    _streamCache = useCase
+        .tweetList()
         .listen((cache) => listTweets = cache.tweets.asObservable());
   }
 

--- a/lib/app/features/feed/presentation/tweet/reply_tweet.dart
+++ b/lib/app/features/feed/presentation/tweet/reply_tweet.dart
@@ -1,12 +1,13 @@
 import 'package:flutter/material.dart';
-import 'package:penhas/app/features/feed/domain/entities/tweet_entity.dart';
-import 'package:penhas/app/features/feed/presentation/stores/tweet_controller.dart';
-import 'package:penhas/app/features/feed/presentation/tweet/widgets/tweet_avatar.dart';
-import 'package:penhas/app/features/feed/presentation/tweet/widgets/tweet_body.dart';
-import 'package:penhas/app/features/feed/presentation/tweet/widgets/tweet_bottom.dart';
-import 'package:penhas/app/features/feed/presentation/tweet/widgets/tweet_title.dart';
-import 'package:penhas/app/shared/design_system/colors.dart';
-import 'package:penhas/app/shared/design_system/text_styles.dart';
+
+import '../../../../shared/design_system/colors.dart';
+import '../../../../shared/design_system/text_styles.dart';
+import '../../domain/entities/tweet_entity.dart';
+import '../stores/tweet_controller.dart';
+import 'widgets/tweet_avatar.dart';
+import 'widgets/tweet_body.dart';
+import 'widgets/tweet_bottom.dart';
+import 'widgets/tweet_title.dart';
 
 class ReplyTweet extends StatelessWidget {
   const ReplyTweet({
@@ -98,10 +99,10 @@ class ReplyTweet extends StatelessWidget {
   }
 
   List<Widget> _expandeRepliedTweeters(BuildContext context) {
-    return tweet.lastReply!
+    return tweet.lastReply
         .map(
           (e) => _RepliedTweet(
-            repliedTweet: e!,
+            repliedTweet: e,
             parentTweet: tweet,
             controller: controller,
           ),
@@ -120,6 +121,7 @@ class ReplyTweet extends StatelessWidget {
                   color: DesignSystemColors.warnGrey,
                 ),
               ),
+              // ignore: deprecated_member_use
               FlatButton(
                 onPressed: () => controller.detail(tweet),
                 color: Colors.white,

--- a/lib/app/features/feed/presentation/tweet/tweet.dart
+++ b/lib/app/features/feed/presentation/tweet/tweet.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:penhas/app/features/feed/domain/entities/tweet_entity.dart';
-import 'package:penhas/app/features/feed/presentation/stores/tweet_controller.dart';
-import 'package:penhas/app/features/feed/presentation/tweet/reply_tweet.dart';
-import 'package:penhas/app/features/feed/presentation/tweet/single_tweet.dart';
+
+import '../../domain/entities/tweet_entity.dart';
+import '../stores/tweet_controller.dart';
+import 'reply_tweet.dart';
+import 'single_tweet.dart';
 
 class Tweet extends StatelessWidget {
   const Tweet({

--- a/lib/app/features/feed/presentation/tweet/tweet.dart
+++ b/lib/app/features/feed/presentation/tweet/tweet.dart
@@ -16,8 +16,7 @@ class Tweet extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final hasRepliedTweet =
-        model.lastReply != null && model.lastReply!.isNotEmpty;
+    final hasRepliedTweet = model.lastReply.isNotEmpty;
     return hasRepliedTweet
         ? ReplyTweet(context: context, tweet: model, controller: controller)
         : SingleTweet(context: context, tweet: model, controller: controller);

--- a/lib/app/features/feed/presentation/tweet/widgets/tweet_avatar.dart
+++ b/lib/app/features/feed/presentation/tweet/widgets/tweet_avatar.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:penhas/app/features/feed/domain/entities/tweet_entity.dart';
-import 'package:penhas/app/features/feed/domain/states/feed_router_type.dart';
+
+import '../../../domain/entities/tweet_entity.dart';
+import '../../../domain/states/feed_router_type.dart';
 
 class TweetAvatar extends StatelessWidget {
   const TweetAvatar({
@@ -25,7 +26,7 @@ class TweetAvatar extends StatelessWidget {
 extension _PrivateMethod on TweetAvatar {
   Widget avatar() {
     return SvgPicture.network(
-      tweet.avatar!,
+      tweet.avatar,
       //color: DesignSystemColors.darkIndigo,
       height: 36,
     );
@@ -36,6 +37,7 @@ extension _PrivateMethod on TweetAvatar {
   }
 
   Widget authenticatedAvatar() {
+    // ignore: deprecated_member_use
     return FlatButton(
       onPressed: () => showUserProfile(),
       color: Colors.transparent,

--- a/lib/app/features/feed/presentation/tweet/widgets/tweet_bottom.dart
+++ b/lib/app/features/feed/presentation/tweet/widgets/tweet_bottom.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:penhas/app/features/feed/domain/entities/tweet_entity.dart';
-import 'package:penhas/app/features/feed/presentation/stores/tweet_controller.dart';
-import 'package:penhas/app/shared/design_system/colors.dart';
-import 'package:penhas/app/shared/design_system/text_styles.dart';
+
+import '../../../../../shared/design_system/colors.dart';
+import '../../../../../shared/design_system/text_styles.dart';
+import '../../../domain/entities/tweet_entity.dart';
+import '../../stores/tweet_controller.dart';
 
 class TweetBottom extends StatefulWidget {
   const TweetBottom({

--- a/lib/app/features/feed/presentation/tweet/widgets/tweet_bottom.dart
+++ b/lib/app/features/feed/presentation/tweet/widgets/tweet_bottom.dart
@@ -22,6 +22,9 @@ class _TweetBottomState extends State<TweetBottom> {
   late bool _isLiked;
   late int _likeCount;
 
+  bool get _allowReply => widget.tweet.meta.canReply;
+  bool get _isReplyVisible => _allowReply || widget.tweet.totalReply > 0;
+
   @override
   void initState() {
     super.initState();
@@ -30,12 +33,11 @@ class _TweetBottomState extends State<TweetBottom> {
   }
 
   @override
-  void dispose() {
-    super.dispose();
+  void didUpdateWidget(covariant TweetBottom oldWidget) {
+    _isLiked = widget.tweet.meta.liked;
+    _likeCount = widget.tweet.totalLikes;
+    super.didUpdateWidget(oldWidget);
   }
-
-  bool get _allowReply => widget.tweet.meta.canReply;
-  bool get _isReplyVisible => _allowReply || widget.tweet.totalReply > 0;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/app/features/feed/presentation/tweet/widgets/tweet_title.dart
+++ b/lib/app/features/feed/presentation/tweet/widgets/tweet_title.dart
@@ -1,11 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:penhas/app/features/feed/domain/entities/tweet_entity.dart';
-import 'package:penhas/app/features/feed/domain/states/feed_router_type.dart';
-import 'package:penhas/app/features/feed/presentation/stores/tweet_controller.dart';
-import 'package:penhas/app/shared/design_system/text_styles.dart';
 import 'package:timeago/timeago.dart' as timeago;
+
+import '../../../../../shared/design_system/text_styles.dart';
+import '../../../domain/entities/tweet_entity.dart';
+import '../../../domain/states/feed_router_type.dart';
+import '../../stores/tweet_controller.dart';
 
 class TweetTitle extends StatelessWidget {
   const TweetTitle({
@@ -158,7 +159,7 @@ class TweetTitle extends StatelessWidget {
       children: <Widget>[
         Expanded(
           flex: 2,
-          child: Text(tweet.userName!, style: kTextStyleFeedTweetTitle),
+          child: Text(tweet.userName, style: kTextStyleFeedTweetTitle),
         ),
         if (isDetail) _buildDetailTime() else _buildTime(),
         if (controller == null)
@@ -176,6 +177,7 @@ class TweetTitle extends StatelessWidget {
     return Row(
       children: <Widget>[
         Expanded(
+          // ignore: deprecated_member_use
           child: FlatButton(
             onPressed: () => _showUserProfile(),
             color: Colors.transparent,
@@ -200,7 +202,7 @@ class TweetTitle extends StatelessWidget {
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
-        Text(tweet.userName!, style: kTextStyleFeedTweetTitle),
+        Text(tweet.userName, style: kTextStyleFeedTweetTitle),
         if (isDetail) _buildDetailTime() else _buildTime(),
       ],
     );

--- a/test/app/features/feed/domain/usecases/feed_use_cases_comment_test.dart
+++ b/test/app/features/feed/domain/usecases/feed_use_cases_comment_test.dart
@@ -26,7 +26,7 @@ void main() {
   });
 
   setUpAll(() {
-    registerFallbackValue(TweetRequestOption());
+    registerFallbackValue(const TweetRequestOption());
     registerFallbackValue(TweetEngageRequestOption(tweetId: ''));
   });
 
@@ -147,7 +147,7 @@ void main() {
           );
 
           // assert
-          expectLater(sut.dataSource, emits(expected));
+          expectLater(sut.tweetList(), emits(expected));
         },
       );
 
@@ -197,7 +197,7 @@ void main() {
           );
 
           // assert
-          expectLater(sut.dataSource, emits(expected));
+          expectLater(sut.tweetList(), emits(expected));
         },
       );
 

--- a/test/app/features/feed/domain/usecases/feed_use_cases_create_test.dart
+++ b/test/app/features/feed/domain/usecases/feed_use_cases_create_test.dart
@@ -25,7 +25,7 @@ void main() {
   });
 
   setUpAll(() {
-    registerFallbackValue(TweetRequestOption());
+    registerFallbackValue(const TweetRequestOption());
     registerFallbackValue(TweetCreateRequestOption(message: ''));
   });
 
@@ -37,7 +37,7 @@ void main() {
       verifyNoMoreInteractions(repository);
     });
     group('create()', () {
-      int? maxRowsPerRequest;
+      late int maxRowsPerRequest;
 
       setUp(() {
         maxRowsPerRequest = 5;

--- a/test/app/features/feed/domain/usecases/feed_use_cases_delete_test.dart
+++ b/test/app/features/feed/domain/usecases/feed_use_cases_delete_test.dart
@@ -27,7 +27,7 @@ void main() {
   });
 
   setUpAll(() {
-    registerFallbackValue(TweetRequestOption());
+    registerFallbackValue(const TweetRequestOption());
     registerFallbackValue(TweetEngageRequestOption(tweetId: ''));
   });
 
@@ -160,6 +160,7 @@ void main() {
           // arrange
           final tweet = TweetEntity(
             id: 'id_3',
+            parentId: 'id_1',
             userName: 'user_3',
             clientId: 3,
             createdAt: '2020-06-09',
@@ -220,7 +221,7 @@ void main() {
           // act
           final received = await sut.delete(tweet);
           // assert
-          expect(expected, received);
+          expect(received, expected);
         });
       },
     );

--- a/test/app/features/feed/domain/usecases/feed_use_cases_detail_test.dart
+++ b/test/app/features/feed/domain/usecases/feed_use_cases_detail_test.dart
@@ -39,7 +39,7 @@ void main() {
   });
 
   setUpAll(() {
-    registerFallbackValue(TweetRequestOption());
+    registerFallbackValue(const TweetRequestOption());
     registerFallbackValue(TweetEngageRequestOption(tweetId: ''));
   });
 
@@ -117,9 +117,9 @@ void main() {
           );
           final expected = right(const FeedCache(tweets: []));
           // act
-          final received = await sut.fetchTweetDetail(tweetRequest.id);
+          await sut.fetchTweetDetail(tweetRequest.id);
           // assert
-          expect(received, expected);
+          expect(sut.tweetDetail(tweetRequest.id), emitsThrough(expected));
         },
       );
       test(
@@ -145,9 +145,9 @@ void main() {
             ),
           );
           // act
-          final received = await sut.fetchTweetDetail(tweetRequest.id);
+          await sut.fetchTweetDetail(tweetRequest.id);
           // assert
-          expect(expected, received);
+          expect(sut.tweetDetail(tweetRequest.id), emitsThrough(expected));
         },
       );
     });
@@ -229,7 +229,7 @@ void main() {
                 rows: maxRowsPerRequest,
               ),
             ),
-          );
+          ).called(1);
         },
       );
       test(
@@ -281,9 +281,9 @@ void main() {
             ),
           );
           // act
-          final received = await sut.fetchNewestTweetDetail(tweetRequest.id);
+          await sut.fetchNewestTweetDetail(tweetRequest.id);
           // assert
-          expect(expected, received);
+          expect(sut.tweetDetail(tweetRequest.id), emitsThrough(expected));
         },
       );
       test(
@@ -329,9 +329,9 @@ void main() {
             ),
           );
           // act
-          final received = await sut.fetchNewestTweetDetail(tweetRequest.id);
+          await sut.fetchNewestTweetDetail(tweetRequest.id);
           // assert
-          expect(expected, received);
+          expect(sut.tweetDetail(tweetRequest.id), emitsThrough(expected));
         },
       );
     });

--- a/test/app/features/feed/domain/usecases/feed_use_cases_fetch_test.dart
+++ b/test/app/features/feed/domain/usecases/feed_use_cases_fetch_test.dart
@@ -27,7 +27,7 @@ void main() {
   });
 
   setUpAll(() {
-    registerFallbackValue(TweetRequestOption());
+    registerFallbackValue(const TweetRequestOption());
     registerFallbackValue(TweetEngageRequestOption(tweetId: ''));
   });
 
@@ -206,7 +206,7 @@ void main() {
       );
     });
     group('fetchOldestTweet()', () {
-      int? maxRowsPerRequet;
+      late int maxRowsPerRequet;
       late TweetSessionEntity firstSessionResponse;
       late TweetSessionEntity secondSessionResponse;
       late TweetSessionEntity thirdSessionResponse;
@@ -363,12 +363,12 @@ void main() {
           verifyInOrder([
             () => repository.fetch(
                   option: TweetRequestOption(
-                    rows: maxRowsPerRequet!,
+                    rows: maxRowsPerRequet,
                   ),
                 ),
             () => repository.fetch(
                   option: TweetRequestOption(
-                    rows: maxRowsPerRequet!,
+                    rows: maxRowsPerRequet,
                     nextPageToken: '_next_page_request_1_',
                   ),
                 ),
@@ -406,12 +406,12 @@ void main() {
           verifyInOrder([
             () => repository.fetch(
                   option: TweetRequestOption(
-                    rows: maxRowsPerRequet!,
+                    rows: maxRowsPerRequet,
                   ),
                 ),
             () => repository.fetch(
                   option: TweetRequestOption(
-                    rows: maxRowsPerRequet!,
+                    rows: maxRowsPerRequet,
                     nextPageToken: '_next_page_request_1_',
                   ),
                 ),

--- a/test/app/features/feed/domain/usecases/feed_use_cases_like_test.dart
+++ b/test/app/features/feed/domain/usecases/feed_use_cases_like_test.dart
@@ -26,7 +26,7 @@ void main() {
   });
 
   setUpAll(() {
-    registerFallbackValue(TweetRequestOption());
+    registerFallbackValue(const TweetRequestOption());
     registerFallbackValue(TweetEngageRequestOption(tweetId: ''));
   });
 
@@ -61,6 +61,7 @@ void main() {
         );
         tweetEntity3 = TweetEntity(
           id: 'id_3',
+          parentId: 'id_2',
           userName: 'user_6',
           clientId: 6,
           createdAt: '2020-03-01 00:00:01',
@@ -158,11 +159,11 @@ void main() {
         // act
         final received = await sut.like(tweetEntity3);
         // assert
-        expect(expected, received);
+        expect(received, expected);
       });
     });
     group('unlike()', () {
-      int? maxRowsPerRequet;
+      late int maxRowsPerRequet;
       late TweetSessionEntity firstSessionResponse;
       late TweetEntity tweetEntity1;
       late TweetEntity tweetEntity2;
@@ -185,6 +186,7 @@ void main() {
         );
         tweetEntity3 = TweetEntity(
           id: 'id_3',
+          parentId: 'id_2',
           userName: 'user_6',
           clientId: 6,
           createdAt: '2020-03-01 00:00:01',
@@ -282,7 +284,7 @@ void main() {
         // act
         final received = await sut.unlike(tweetEntity3);
         // assert
-        expect(expected, received);
+        expect(received, expected);
       });
     });
   });


### PR DESCRIPTION
## Objetivo

Melhorar a experiência do usuário ao interagir com as publicações (curtir, responder e excluir), para isso foi corrigido a sincronização do cache feito em memória, que antes era necessário fechar e reabir o app para poder ver a interação.

## Mudanças

- Implementa `didUpdateWidget` do `TweetBottom` que é onde fica as ações de curtir e comentar, juntamente com seus contadores;
- Transforma as propriedades `id`, `userName`, `createdAt` e `content` das classes `TweetEntity` e `TweetModel` para não nullable, pois isso foi uma incosistência gerada durante a migração para o nullsafety;
- Refatoração da classe `FeedUseCases` para utilizar um stream em `_tweetReplyMap`, deixando as telas mais reativas e melhoria da lógica de atualização;
- Adiciona o comportamento de voltar para a tela anterior quando a publicação principal for removida;
- Ajustes nos imports relativos para adequar ao linter.