### PR TITLE
Ajusta cor do background (barrier color) das dialogs

### DIFF
--- a/lib/app/core/extension/asuka.dart
+++ b/lib/app/core/extension/asuka.dart
@@ -2,6 +2,8 @@ import 'package:asuka/asuka.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 
+import '../../shared/design_system/colors.dart';
+
 extension Dialog on IModularNavigator {
   Future showDialog({
     required WidgetBuilder builder,
@@ -10,5 +12,6 @@ extension Dialog on IModularNavigator {
       Asuka.showDialog(
         builder: builder,
         barrierDismissible: barrierDismissible,
+        barrierColor: DesignSystemColors.dialogBarrierColor,
       );
 }

--- a/lib/app/core/extension/asuka.dart
+++ b/lib/app/core/extension/asuka.dart
@@ -5,11 +5,11 @@ import 'package:flutter_modular/flutter_modular.dart';
 import '../../shared/design_system/colors.dart';
 
 extension Dialog on IModularNavigator {
-  Future showDialog({
+  Future<T?> showDialog<T>({
     required WidgetBuilder builder,
     bool barrierDismissible = true,
   }) =>
-      Asuka.showDialog(
+      Asuka.showDialog<T>(
         builder: builder,
         barrierDismissible: barrierDismissible,
         barrierColor: DesignSystemColors.dialogBarrierColor,

--- a/lib/app/shared/design_system/colors.dart
+++ b/lib/app/shared/design_system/colors.dart
@@ -1,4 +1,4 @@
-import 'dart:ui';
+import 'package:flutter/material.dart';
 
 class DesignSystemColors {
   static const ligthPurple = Color.fromRGBO(160, 101, 255, 1);
@@ -26,13 +26,14 @@ class DesignSystemColors {
   static const bluishPurple = Color.fromRGBO(129, 51, 255, 1);
   static const systemBackgroundColor = Color.fromRGBO(248, 248, 248, 1);
   static const splashColor = Color.fromARGB(16, 0, 0, 0);
+  static const dialogBarrierColor = Colors.black54;
+
   static Color hexColor(String value) {
     String hexColor = value.toUpperCase().replaceAll('#', '');
     if (hexColor.length == 6) {
       hexColor = 'FF$hexColor';
     }
 
-    final foo = Color(int.parse(hexColor, radix: 16));
-    return foo;
+    return Color(int.parse(hexColor, radix: 16));
   }
 }


### PR DESCRIPTION
## Objetivo

Padronizar o backdrop das dialogs que estavam transparente.


<table>
<tr>
<th>Antes</th>
<th>Depois</th>
</tr>
<tr>
<td>
<img src="https://user-images.githubusercontent.com/9375141/222869937-65a2e463-1d31-49fd-a0ec-be2360d72a72.png" alt="Captura de tela da página inicial do aplicativo utilizando o dialog de denuncia como exemplo de como estava antes, com o backdrop totalmente transparente" />
</td>
<td>
<img src="https://user-images.githubusercontent.com/9375141/222869966-d3ece9c0-8be0-4f6a-8d01-0d388022ccaf.png" alt="Captura de tela da página inicial do aplicativo utilizando o dialog de denuncia como exemplo de como ficou depois das alterações, com o backdrop preto com 54% de transparência" />
</td>
</tr>
</table>

## Mudanças

- Define o `barrierColor` na extensão `showDialog`;
- (Bônus) Remove uma variável com nome aleatório na função que faz parse da cor de `String` para `int`.