### PR TITLE
Adiciona componente BottomSheetActionsContentWidget

### DIFF
--- a/lib/app/app_widget.dart
+++ b/lib/app/app_widget.dart
@@ -4,6 +4,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 
+import 'shared/design_system/theme.dart';
+
 class AppWidget extends StatelessWidget {
   static FirebaseAnalytics get _analytics => FirebaseAnalytics.instance;
   static FirebaseAnalyticsObserver observer =
@@ -15,9 +17,7 @@ class AppWidget extends StatelessWidget {
     return MaterialApp(
       title: 'PenhaS',
       builder: Asuka.builder,
-      theme: ThemeData(
-        textTheme: Theme.of(context).textTheme.apply(fontFamily: 'Lato'),
-      ),
+      theme: AppTheme.of(context),
       localizationsDelegates: const [
         GlobalWidgetsLocalizations.delegate,
         GlobalMaterialLocalizations.delegate,

--- a/lib/app/shared/design_system/theme.dart
+++ b/lib/app/shared/design_system/theme.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+abstract class AppTheme {
+  static ThemeData of(BuildContext context) {
+    final base = Theme.of(context);
+    return ThemeData(
+      bottomSheetTheme: base.bottomSheetTheme.copyWith(
+        backgroundColor: Colors.transparent,
+      ),
+    );
+  }
+}

--- a/lib/app/shared/widgets/bottom_sheet_actions_widget.dart
+++ b/lib/app/shared/widgets/bottom_sheet_actions_widget.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+
+class BottomSheetActionsContentWidget extends StatefulWidget {
+  BottomSheetActionsContentWidget({
+    Key? key,
+    required this.actions,
+  }) : super(key: key) {
+    assert(actions.isNotEmpty);
+  }
+
+  final List<Widget> actions;
+
+  @override
+  State<BottomSheetActionsContentWidget> createState() =>
+      _BottomSheetActionsContentWidgetState();
+}
+
+class _BottomSheetActionsContentWidgetState
+    extends State<BottomSheetActionsContentWidget> {
+  List<Widget> get actions => widget.actions;
+
+  @override
+  Widget build(BuildContext context) => Container(
+        padding: const EdgeInsets.only(top: 5),
+        constraints: const BoxConstraints(minHeight: 150),
+        decoration: const BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.only(
+            topLeft: Radius.circular(20),
+            topRight: Radius.circular(20),
+          ),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            const _BottomSheetDivider(),
+            ...actions,
+          ],
+        ),
+      );
+}
+
+class _BottomSheetDivider extends StatelessWidget {
+  const _BottomSheetDivider({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) => LayoutBuilder(
+        builder: (context, constraints) => Container(
+          width: constraints.maxWidth * .2,
+          height: 5,
+          decoration: BoxDecoration(
+            color: Theme.of(context).dividerColor,
+            borderRadius: const BorderRadius.all(
+              Radius.circular(10),
+            ),
+          ),
+        ),
+      );
+}


### PR DESCRIPTION
## Objetivo

Padronizar o bottom sheet de ações que será utilizado para as opções do perfil, posteriormente pode ser utilizado em outras telas para evitar duplicidade de código e melhorar/facilitar manutenção.

<img width="400" src="https://user-images.githubusercontent.com/9375141/222890240-3f84b6e3-a3f8-4e9d-bc43-c865ddbce867.png" alt="Captura de tela de um exemplo de uso do componente de bottom sheet com as opções de Denunciar e Bloquear" />


## Alterações

- Incluido o tema no widget principal já com a cor de background do bottom sheet, evitando assim a necessidade de definir sempre que for utilizar `backgroundColor: Colors.transparent`;
- Incluido o widget `BottomSheetActionsContentWidget`.