### PR TITLE
Adiciona funcionalidade de bloqueio de usuário(a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Adicionado
 - Funcionalidade para reportar perfil
+- Funcionalidade para bloquear perfil
 
 ### Corrigido
 - Comportamento ao curtir, comentar e excluir tweets

--- a/lib/app/features/mainboard/presentation/mainboard/mainboard_page.dart
+++ b/lib/app/features/mainboard/presentation/mainboard/mainboard_page.dart
@@ -2,17 +2,19 @@ import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:penhas/app/features/main_menu/presentation/penhas_drawer_page.dart';
-import 'package:penhas/app/features/mainboard/domain/states/mainboard_state.dart';
-import 'package:penhas/app/features/mainboard/presentation/mainboard/mainboard_controller.dart';
-import 'package:penhas/app/features/mainboard/presentation/mainboard/pages/mainboard_app_bar_page.dart';
-import 'package:penhas/app/features/mainboard/presentation/mainboard/pages/mainboard_body_page.dart';
-import 'package:penhas/app/features/mainboard/presentation/mainboard/pages/mainboard_bottom_navigation_page.dart';
-import 'package:penhas/app/shared/design_system/colors.dart';
+
+import '../../../../shared/design_system/colors.dart';
+import '../../../main_menu/presentation/penhas_drawer_page.dart';
+import '../../domain/states/mainboard_state.dart';
+import 'mainboard_controller.dart';
+import 'pages/mainboard_app_bar_page.dart';
+import 'pages/mainboard_body_page.dart';
+import 'pages/mainboard_bottom_navigation_page.dart';
 
 class MainboardPage extends StatefulWidget {
   const MainboardPage({Key? key, this.title = 'Mainboard'}) : super(key: key);
 
+  static final mainBoardKey = GlobalKey<ScaffoldState>();
   final String title;
 
   @override
@@ -86,9 +88,12 @@ extension _SecurityModeBuilder on _MainboardPageState {
       ),
       drawer: const PenhasDrawerPage(),
       backgroundColor: Colors.white,
-      body: MainboardBodyPage(
-        pages: controller.mainboardStore.pages,
-        pageController: controller.mainboardStore.pageController,
+      body: Scaffold(
+        key: MainboardPage.mainBoardKey,
+        body: MainboardBodyPage(
+          pages: controller.mainboardStore.pages,
+          pageController: controller.mainboardStore.pageController,
+        ),
       ),
       floatingActionButton: _buildFab(),
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
@@ -109,9 +114,12 @@ extension _SecurityModeBuilder on _MainboardPageState {
       ),
       drawer: const PenhasDrawerPage(),
       backgroundColor: Colors.white,
-      body: MainboardBodyPage(
-        pages: controller.mainboardStore.pages,
-        pageController: controller.mainboardStore.pageController,
+      body: Scaffold(
+        key: MainboardPage.mainBoardKey,
+        body: MainboardBodyPage(
+          pages: controller.mainboardStore.pages,
+          pageController: controller.mainboardStore.pageController,
+        ),
       ),
       bottomNavigationBar: MainboardBottomNavigationPage(
         currentPage: controller.mainboardStore.selectedPage,

--- a/lib/app/features/users/data/repositories/users_repository.dart
+++ b/lib/app/features/users/data/repositories/users_repository.dart
@@ -91,7 +91,7 @@ class UsersRepository implements IUsersRepository {
   @override
   Future<Either<Failure, ValidField>> block(String clientId) async {
     try {
-      const endPoint = '/profile-block';
+      const endPoint = '/block-profile';
       final response = await _apiProvider!.post(
           path: endPoint,
           parameters: {'cliente_id': clientId}).parseValidField();

--- a/lib/app/features/users/domain/usecases/block_user_usecase.dart
+++ b/lib/app/features/users/domain/usecases/block_user_usecase.dart
@@ -3,16 +3,26 @@ import 'package:meta/meta.dart';
 
 import '../../../../core/entities/valid_fiel.dart';
 import '../../../../core/error/failures.dart';
+import '../../../../shared/logger/log.dart';
+import '../../../feed/domain/usecases/feed_use_cases.dart';
 import '../../data/repositories/users_repository.dart';
 
 @immutable
 class BlockUserUseCase {
   const BlockUserUseCase({
     required IUsersRepository repository,
-  }) : _repository = repository;
+    required FeedUseCases feedUseCases,
+  })  : _repository = repository,
+        _feedUseCases = feedUseCases;
 
   final IUsersRepository _repository;
+  final FeedUseCases _feedUseCases;
 
-  Future<Either<Failure, ValidField>> call(String clientId) =>
-      _repository.block(clientId);
+  Future<Either<Failure, ValidField>> call(String clientId) async {
+    final result = await _repository.block(clientId);
+
+    await _feedUseCases.reloadTweetFeed().catchError(catchErrorLogger);
+
+    return result;
+  }
 }

--- a/lib/app/features/users/domain/usecases/block_user_usecase.dart
+++ b/lib/app/features/users/domain/usecases/block_user_usecase.dart
@@ -1,0 +1,18 @@
+import 'package:dartz/dartz.dart';
+import 'package:meta/meta.dart';
+
+import '../../../../core/entities/valid_fiel.dart';
+import '../../../../core/error/failures.dart';
+import '../../data/repositories/users_repository.dart';
+
+@immutable
+class BlockUserUseCase {
+  const BlockUserUseCase({
+    required IUsersRepository repository,
+  }) : _repository = repository;
+
+  final IUsersRepository _repository;
+
+  Future<Either<Failure, ValidField>> call(String clientId) =>
+      _repository.block(clientId);
+}

--- a/lib/app/features/users/presentation/user_profile_controller.dart
+++ b/lib/app/features/users/presentation/user_profile_controller.dart
@@ -98,10 +98,14 @@ abstract class _UserProfileControllerBase with Store, MapFailureMessage {
       _handleFailure,
       (result) => UserProfileReaction.showSnackBar(
         result.message ?? 'Bloqueado com sucesso',
+        inMainboardPage: true,
       ),
     );
 
-    Modular.to.pop();
+    if (result.isRight()) {
+      await Future.delayed(const Duration(milliseconds: 300));
+      Modular.to.pop();
+    }
   }
 
   UserProfileReaction? _handleChatChannelSuccess(ChatChannelOpenEntity chat) {

--- a/lib/app/features/users/presentation/user_profile_controller.dart
+++ b/lib/app/features/users/presentation/user_profile_controller.dart
@@ -93,10 +93,15 @@ abstract class _UserProfileControllerBase with Store, MapFailureMessage {
   Future<void> onConfirmBlockPressed() async {
     reaction = UserProfileReaction.showProgressDialog();
     final result = await _blockUser('${_person.profile.clientId}');
+
     reaction = result.fold(
       _handleFailure,
-      (_) => UserProfileReaction.dismissProgressDialog(),
+      (result) => UserProfileReaction.showSnackBar(
+        result.message ?? 'Bloqueado com sucesso',
+      ),
     );
+
+    Modular.to.pop();
   }
 
   UserProfileReaction? _handleChatChannelSuccess(ChatChannelOpenEntity chat) {

--- a/lib/app/features/users/presentation/user_profile_controller.dart
+++ b/lib/app/features/users/presentation/user_profile_controller.dart
@@ -6,6 +6,7 @@ import '../../authentication/presentation/shared/map_failure_message.dart';
 import '../../chat/domain/entities/chat_channel_open_entity.dart';
 import '../../chat/domain/usecases/get_chat_channel_token_usecase.dart';
 import '../domain/entities/user_detail_entity.dart';
+import '../domain/usecases/block_user_usecase.dart';
 import '../domain/usecases/report_user_usecase.dart';
 import 'user_profile_state.dart';
 
@@ -17,7 +18,8 @@ class UserProfileController extends _UserProfileControllerBase
     required UserDetailEntity person,
     required GetChatChannelTokenUseCase getChatChannelToken,
     required ReportUserUseCase reportUser,
-  }) : super(person, getChatChannelToken, reportUser);
+    required BlockUserUseCase blockUser,
+  }) : super(person, getChatChannelToken, reportUser, blockUser);
 }
 
 abstract class _UserProfileControllerBase with Store, MapFailureMessage {
@@ -25,12 +27,14 @@ abstract class _UserProfileControllerBase with Store, MapFailureMessage {
     this._person,
     this._getChatChannelToken,
     this._reportUser,
+    this._blockUser,
   ) {
     _init();
   }
 
   final UserDetailEntity _person;
   final GetChatChannelTokenUseCase _getChatChannelToken;
+  final BlockUserUseCase _blockUser;
   final ReportUserUseCase _reportUser;
 
   @observable
@@ -64,6 +68,9 @@ abstract class _UserProfileControllerBase with Store, MapFailureMessage {
   void onOptionSelected(UserProfileSelectedOption? option) {
     reaction = option?.when(
       report: () => UserProfileReaction.askReportReasonDialog(),
+      block: () => UserProfileReaction.showBlockConfirmationDialog(
+        'Deseja realmente bloquear ${_person.profile.nickname}?',
+      ),
     );
   }
 
@@ -79,6 +86,16 @@ abstract class _UserProfileControllerBase with Store, MapFailureMessage {
       (result) => UserProfileReaction.showSnackBar(
         result.message ?? 'Reportado com sucesso',
       ),
+    );
+  }
+
+  @action
+  Future<void> onConfirmBlockPressed() async {
+    reaction = UserProfileReaction.showProgressDialog();
+    final result = await _blockUser('${_person.profile.clientId}');
+    reaction = result.fold(
+      _handleFailure,
+      (_) => UserProfileReaction.dismissProgressDialog(),
     );
   }
 

--- a/lib/app/features/users/presentation/user_profile_controller.g.dart
+++ b/lib/app/features/users/presentation/user_profile_controller.g.dart
@@ -71,6 +71,15 @@ mixin _$UserProfileController on _UserProfileControllerBase, Store {
         .run(() => super.onSendReportPressed(reason));
   }
 
+  final _$onConfirmBlockPressedAsyncAction =
+      AsyncAction('_UserProfileControllerBase.onConfirmBlockPressed');
+
+  @override
+  Future<void> onConfirmBlockPressed() {
+    return _$onConfirmBlockPressedAsyncAction
+        .run(() => super.onConfirmBlockPressed());
+  }
+
   final _$_UserProfileControllerBaseActionController =
       ActionController(name: '_UserProfileControllerBase');
 

--- a/lib/app/features/users/presentation/user_profile_dialogs.dart
+++ b/lib/app/features/users/presentation/user_profile_dialogs.dart
@@ -20,6 +20,14 @@ class ProfileOptionsBottomSheet extends StatelessWidget {
           onTap: () =>
               Navigator.pop(context, UserProfileSelectedOption.report()),
         ),
+        ListTile(
+          leading: SvgPicture.asset(
+            'assets/images/svg/tweet_action/tweet_action_block.svg',
+          ),
+          title: const Text('Bloquear'),
+          onTap: () =>
+              Navigator.pop(context, UserProfileSelectedOption.block()),
+        ),
       ]);
 }
 
@@ -71,4 +79,37 @@ class ReportUserDialog extends StatelessWidget {
       ],
     );
   }
+}
+
+class UserBlockConfirmationDialog extends StatelessWidget {
+  const UserBlockConfirmationDialog({
+    Key? key,
+    required this.message,
+  }) : super(key: key);
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) => AlertDialog(
+        title: const Text(
+          'Bloquear usuário',
+          style: kTextStyleAlertDialogTitle,
+        ),
+        content: Text(message),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(10.0),
+        ),
+        actions: <Widget>[
+          // ignore: deprecated_member_use
+          FlatButton(
+            child: const Text('Sim'),
+            onPressed: () => Navigator.pop(context, true),
+          ),
+          // ignore: deprecated_member_use
+          FlatButton(
+            child: const Text('Não'),
+            onPressed: () => Navigator.pop(context),
+          ),
+        ],
+      );
 }

--- a/lib/app/features/users/presentation/user_profile_module.dart
+++ b/lib/app/features/users/presentation/user_profile_module.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_modular/flutter_modular.dart';
 
+import '../domain/usecases/block_user_usecase.dart';
 import '../domain/usecases/report_user_usecase.dart';
 import 'user_profile_controller.dart';
 import 'user_profile_page.dart';
@@ -16,6 +17,9 @@ class UserProfileModule extends Module {
         ),
         Bind.factory(
           (i) => ReportUserUseCase(repository: i()),
+        ),
+        Bind.factory(
+          (i) => BlockUserUseCase(repository: i()),
         ),
       ];
 

--- a/lib/app/features/users/presentation/user_profile_module.dart
+++ b/lib/app/features/users/presentation/user_profile_module.dart
@@ -13,6 +13,7 @@ class UserProfileModule extends Module {
             person: i.args?.data,
             getChatChannelToken: i(),
             reportUser: i(),
+            blockUser: i(),
           ),
         ),
         Bind.factory(

--- a/lib/app/features/users/presentation/user_profile_module.dart
+++ b/lib/app/features/users/presentation/user_profile_module.dart
@@ -20,7 +20,10 @@ class UserProfileModule extends Module {
           (i) => ReportUserUseCase(repository: i()),
         ),
         Bind.factory(
-          (i) => BlockUserUseCase(repository: i()),
+          (i) => BlockUserUseCase(
+            repository: i(),
+            feedUseCases: i(),
+          ),
         ),
       ];
 

--- a/lib/app/features/users/presentation/user_profile_page.dart
+++ b/lib/app/features/users/presentation/user_profile_page.dart
@@ -10,6 +10,7 @@ import '../../../shared/design_system/button_shape.dart';
 import '../../../shared/design_system/colors.dart';
 import '../../authentication/presentation/shared/page_progress_indicator.dart';
 import '../../authentication/presentation/shared/snack_bar_handler.dart';
+import '../../mainboard/presentation/mainboard/mainboard_page.dart';
 import '../domain/entities/user_detail_entity.dart';
 import '../domain/entities/user_detail_profile_entity.dart';
 import 'user_profile_controller.dart';
@@ -258,9 +259,12 @@ extension _UserProfilePagePrivate on _UserProfilePageState {
     Navigator.pop(context);
   }
 
-  void _showSnackBar(String message) {
+  void _showSnackBar(String message, bool inMainboardPage) {
     _dismissProgressDialog();
-    showSnackBar(scaffoldKey: _scaffoldKey, message: message);
+    showSnackBar(
+      scaffoldKey: inMainboardPage ? MainboardPage.mainBoardKey : _scaffoldKey,
+      message: message,
+    );
   }
 
   TextStyle get nameStyle => const TextStyle(

--- a/lib/app/features/users/presentation/user_profile_page.dart
+++ b/lib/app/features/users/presentation/user_profile_page.dart
@@ -85,6 +85,7 @@ extension _UserProfilePagePrivate on _UserProfilePageState {
   void _handleReaction(UserProfileReaction? reaction) {
     reaction?.when(
       showProfileOptions: _showProfileOptions,
+      showBlockConfirmationDialog: _showBlockConfirmationDialog,
       askReportReasonDialog: _askReportReasonDialog,
       showProgressDialog: _showProgressDialog,
       dismissProgressDialog: _dismissProgressDialog,
@@ -227,6 +228,16 @@ extension _UserProfilePagePrivate on _UserProfilePageState {
 
     if (reason != null) {
       controller.onSendReportPressed(reason);
+    }
+  }
+
+  void _showBlockConfirmationDialog(String message) async {
+    final confirm = await Modular.to.showDialog(
+      builder: (_) => UserBlockConfirmationDialog(message: message),
+    );
+
+    if (confirm == true) {
+      controller.onConfirmBlockPressed();
     }
   }
 

--- a/lib/app/features/users/presentation/user_profile_state.dart
+++ b/lib/app/features/users/presentation/user_profile_state.dart
@@ -19,8 +19,10 @@ class UserMenuState with _$UserMenuState {
 
 @freezed
 class UserProfileReaction with _$UserProfileReaction {
-  factory UserProfileReaction.showSnackBar(String message) =
-      _ReactionShowSnackBar;
+  factory UserProfileReaction.showSnackBar(
+    String message, {
+    @Default(false) bool inMainboardPage,
+  }) = _ReactionShowSnackBar;
   factory UserProfileReaction.showProfileOptions() =
       _ReactionShowProfileOptions;
   factory UserProfileReaction.askReportReasonDialog([

--- a/lib/app/features/users/presentation/user_profile_state.dart
+++ b/lib/app/features/users/presentation/user_profile_state.dart
@@ -26,6 +26,8 @@ class UserProfileReaction with _$UserProfileReaction {
   factory UserProfileReaction.askReportReasonDialog([
     @Default(null) String? reason,
   ]) = _ReactionAskReportReasonDialog;
+  factory UserProfileReaction.showBlockConfirmationDialog(String message) =
+      _ReactionShowBlockConfirmationDialog;
   factory UserProfileReaction.showProgressDialog() =
       _ReactionShowProgressDialog;
   factory UserProfileReaction.dismissProgressDialog() =
@@ -35,4 +37,5 @@ class UserProfileReaction with _$UserProfileReaction {
 @freezed
 class UserProfileSelectedOption with _$UserProfileSelectedOption {
   factory UserProfileSelectedOption.report() = _SelectedOptionReport;
+  factory UserProfileSelectedOption.block() = _SelectedOptionBlock;
 }

--- a/lib/app/features/users/presentation/user_profile_state.freezed.dart
+++ b/lib/app/features/users/presentation/user_profile_state.freezed.dart
@@ -792,6 +792,13 @@ class _$UserProfileReactionTearOff {
     );
   }
 
+  _ReactionShowBlockConfirmationDialog showBlockConfirmationDialog(
+      String message) {
+    return _ReactionShowBlockConfirmationDialog(
+      message,
+    );
+  }
+
   _ReactionShowProgressDialog showProgressDialog() {
     return _ReactionShowProgressDialog();
   }
@@ -811,6 +818,7 @@ mixin _$UserProfileReaction {
     required TResult Function(String message) showSnackBar,
     required TResult Function() showProfileOptions,
     required TResult Function(String? reason) askReportReasonDialog,
+    required TResult Function(String message) showBlockConfirmationDialog,
     required TResult Function() showProgressDialog,
     required TResult Function() dismissProgressDialog,
   }) =>
@@ -820,6 +828,7 @@ mixin _$UserProfileReaction {
     TResult Function(String message)? showSnackBar,
     TResult Function()? showProfileOptions,
     TResult Function(String? reason)? askReportReasonDialog,
+    TResult Function(String message)? showBlockConfirmationDialog,
     TResult Function()? showProgressDialog,
     TResult Function()? dismissProgressDialog,
   }) =>
@@ -829,6 +838,7 @@ mixin _$UserProfileReaction {
     TResult Function(String message)? showSnackBar,
     TResult Function()? showProfileOptions,
     TResult Function(String? reason)? askReportReasonDialog,
+    TResult Function(String message)? showBlockConfirmationDialog,
     TResult Function()? showProgressDialog,
     TResult Function()? dismissProgressDialog,
     required TResult orElse(),
@@ -841,6 +851,8 @@ mixin _$UserProfileReaction {
         showProfileOptions,
     required TResult Function(_ReactionAskReportReasonDialog value)
         askReportReasonDialog,
+    required TResult Function(_ReactionShowBlockConfirmationDialog value)
+        showBlockConfirmationDialog,
     required TResult Function(_ReactionShowProgressDialog value)
         showProgressDialog,
     required TResult Function(_ReactionDismissProgressDialog value)
@@ -853,6 +865,8 @@ mixin _$UserProfileReaction {
     TResult Function(_ReactionShowProfileOptions value)? showProfileOptions,
     TResult Function(_ReactionAskReportReasonDialog value)?
         askReportReasonDialog,
+    TResult Function(_ReactionShowBlockConfirmationDialog value)?
+        showBlockConfirmationDialog,
     TResult Function(_ReactionShowProgressDialog value)? showProgressDialog,
     TResult Function(_ReactionDismissProgressDialog value)?
         dismissProgressDialog,
@@ -864,6 +878,8 @@ mixin _$UserProfileReaction {
     TResult Function(_ReactionShowProfileOptions value)? showProfileOptions,
     TResult Function(_ReactionAskReportReasonDialog value)?
         askReportReasonDialog,
+    TResult Function(_ReactionShowBlockConfirmationDialog value)?
+        showBlockConfirmationDialog,
     TResult Function(_ReactionShowProgressDialog value)? showProgressDialog,
     TResult Function(_ReactionDismissProgressDialog value)?
         dismissProgressDialog,
@@ -958,6 +974,7 @@ class _$_ReactionShowSnackBar implements _ReactionShowSnackBar {
     required TResult Function(String message) showSnackBar,
     required TResult Function() showProfileOptions,
     required TResult Function(String? reason) askReportReasonDialog,
+    required TResult Function(String message) showBlockConfirmationDialog,
     required TResult Function() showProgressDialog,
     required TResult Function() dismissProgressDialog,
   }) {
@@ -970,6 +987,7 @@ class _$_ReactionShowSnackBar implements _ReactionShowSnackBar {
     TResult Function(String message)? showSnackBar,
     TResult Function()? showProfileOptions,
     TResult Function(String? reason)? askReportReasonDialog,
+    TResult Function(String message)? showBlockConfirmationDialog,
     TResult Function()? showProgressDialog,
     TResult Function()? dismissProgressDialog,
   }) {
@@ -982,6 +1000,7 @@ class _$_ReactionShowSnackBar implements _ReactionShowSnackBar {
     TResult Function(String message)? showSnackBar,
     TResult Function()? showProfileOptions,
     TResult Function(String? reason)? askReportReasonDialog,
+    TResult Function(String message)? showBlockConfirmationDialog,
     TResult Function()? showProgressDialog,
     TResult Function()? dismissProgressDialog,
     required TResult orElse(),
@@ -1000,6 +1019,8 @@ class _$_ReactionShowSnackBar implements _ReactionShowSnackBar {
         showProfileOptions,
     required TResult Function(_ReactionAskReportReasonDialog value)
         askReportReasonDialog,
+    required TResult Function(_ReactionShowBlockConfirmationDialog value)
+        showBlockConfirmationDialog,
     required TResult Function(_ReactionShowProgressDialog value)
         showProgressDialog,
     required TResult Function(_ReactionDismissProgressDialog value)
@@ -1015,6 +1036,8 @@ class _$_ReactionShowSnackBar implements _ReactionShowSnackBar {
     TResult Function(_ReactionShowProfileOptions value)? showProfileOptions,
     TResult Function(_ReactionAskReportReasonDialog value)?
         askReportReasonDialog,
+    TResult Function(_ReactionShowBlockConfirmationDialog value)?
+        showBlockConfirmationDialog,
     TResult Function(_ReactionShowProgressDialog value)? showProgressDialog,
     TResult Function(_ReactionDismissProgressDialog value)?
         dismissProgressDialog,
@@ -1029,6 +1052,8 @@ class _$_ReactionShowSnackBar implements _ReactionShowSnackBar {
     TResult Function(_ReactionShowProfileOptions value)? showProfileOptions,
     TResult Function(_ReactionAskReportReasonDialog value)?
         askReportReasonDialog,
+    TResult Function(_ReactionShowBlockConfirmationDialog value)?
+        showBlockConfirmationDialog,
     TResult Function(_ReactionShowProgressDialog value)? showProgressDialog,
     TResult Function(_ReactionDismissProgressDialog value)?
         dismissProgressDialog,
@@ -1097,6 +1122,7 @@ class _$_ReactionShowProfileOptions implements _ReactionShowProfileOptions {
     required TResult Function(String message) showSnackBar,
     required TResult Function() showProfileOptions,
     required TResult Function(String? reason) askReportReasonDialog,
+    required TResult Function(String message) showBlockConfirmationDialog,
     required TResult Function() showProgressDialog,
     required TResult Function() dismissProgressDialog,
   }) {
@@ -1109,6 +1135,7 @@ class _$_ReactionShowProfileOptions implements _ReactionShowProfileOptions {
     TResult Function(String message)? showSnackBar,
     TResult Function()? showProfileOptions,
     TResult Function(String? reason)? askReportReasonDialog,
+    TResult Function(String message)? showBlockConfirmationDialog,
     TResult Function()? showProgressDialog,
     TResult Function()? dismissProgressDialog,
   }) {
@@ -1121,6 +1148,7 @@ class _$_ReactionShowProfileOptions implements _ReactionShowProfileOptions {
     TResult Function(String message)? showSnackBar,
     TResult Function()? showProfileOptions,
     TResult Function(String? reason)? askReportReasonDialog,
+    TResult Function(String message)? showBlockConfirmationDialog,
     TResult Function()? showProgressDialog,
     TResult Function()? dismissProgressDialog,
     required TResult orElse(),
@@ -1139,6 +1167,8 @@ class _$_ReactionShowProfileOptions implements _ReactionShowProfileOptions {
         showProfileOptions,
     required TResult Function(_ReactionAskReportReasonDialog value)
         askReportReasonDialog,
+    required TResult Function(_ReactionShowBlockConfirmationDialog value)
+        showBlockConfirmationDialog,
     required TResult Function(_ReactionShowProgressDialog value)
         showProgressDialog,
     required TResult Function(_ReactionDismissProgressDialog value)
@@ -1154,6 +1184,8 @@ class _$_ReactionShowProfileOptions implements _ReactionShowProfileOptions {
     TResult Function(_ReactionShowProfileOptions value)? showProfileOptions,
     TResult Function(_ReactionAskReportReasonDialog value)?
         askReportReasonDialog,
+    TResult Function(_ReactionShowBlockConfirmationDialog value)?
+        showBlockConfirmationDialog,
     TResult Function(_ReactionShowProgressDialog value)? showProgressDialog,
     TResult Function(_ReactionDismissProgressDialog value)?
         dismissProgressDialog,
@@ -1168,6 +1200,8 @@ class _$_ReactionShowProfileOptions implements _ReactionShowProfileOptions {
     TResult Function(_ReactionShowProfileOptions value)? showProfileOptions,
     TResult Function(_ReactionAskReportReasonDialog value)?
         askReportReasonDialog,
+    TResult Function(_ReactionShowBlockConfirmationDialog value)?
+        showBlockConfirmationDialog,
     TResult Function(_ReactionShowProgressDialog value)? showProgressDialog,
     TResult Function(_ReactionDismissProgressDialog value)?
         dismissProgressDialog,
@@ -1258,6 +1292,7 @@ class _$_ReactionAskReportReasonDialog
     required TResult Function(String message) showSnackBar,
     required TResult Function() showProfileOptions,
     required TResult Function(String? reason) askReportReasonDialog,
+    required TResult Function(String message) showBlockConfirmationDialog,
     required TResult Function() showProgressDialog,
     required TResult Function() dismissProgressDialog,
   }) {
@@ -1270,6 +1305,7 @@ class _$_ReactionAskReportReasonDialog
     TResult Function(String message)? showSnackBar,
     TResult Function()? showProfileOptions,
     TResult Function(String? reason)? askReportReasonDialog,
+    TResult Function(String message)? showBlockConfirmationDialog,
     TResult Function()? showProgressDialog,
     TResult Function()? dismissProgressDialog,
   }) {
@@ -1282,6 +1318,7 @@ class _$_ReactionAskReportReasonDialog
     TResult Function(String message)? showSnackBar,
     TResult Function()? showProfileOptions,
     TResult Function(String? reason)? askReportReasonDialog,
+    TResult Function(String message)? showBlockConfirmationDialog,
     TResult Function()? showProgressDialog,
     TResult Function()? dismissProgressDialog,
     required TResult orElse(),
@@ -1300,6 +1337,8 @@ class _$_ReactionAskReportReasonDialog
         showProfileOptions,
     required TResult Function(_ReactionAskReportReasonDialog value)
         askReportReasonDialog,
+    required TResult Function(_ReactionShowBlockConfirmationDialog value)
+        showBlockConfirmationDialog,
     required TResult Function(_ReactionShowProgressDialog value)
         showProgressDialog,
     required TResult Function(_ReactionDismissProgressDialog value)
@@ -1315,6 +1354,8 @@ class _$_ReactionAskReportReasonDialog
     TResult Function(_ReactionShowProfileOptions value)? showProfileOptions,
     TResult Function(_ReactionAskReportReasonDialog value)?
         askReportReasonDialog,
+    TResult Function(_ReactionShowBlockConfirmationDialog value)?
+        showBlockConfirmationDialog,
     TResult Function(_ReactionShowProgressDialog value)? showProgressDialog,
     TResult Function(_ReactionDismissProgressDialog value)?
         dismissProgressDialog,
@@ -1329,6 +1370,8 @@ class _$_ReactionAskReportReasonDialog
     TResult Function(_ReactionShowProfileOptions value)? showProfileOptions,
     TResult Function(_ReactionAskReportReasonDialog value)?
         askReportReasonDialog,
+    TResult Function(_ReactionShowBlockConfirmationDialog value)?
+        showBlockConfirmationDialog,
     TResult Function(_ReactionShowProgressDialog value)? showProgressDialog,
     TResult Function(_ReactionDismissProgressDialog value)?
         dismissProgressDialog,
@@ -1348,6 +1391,184 @@ abstract class _ReactionAskReportReasonDialog implements UserProfileReaction {
   String? get reason;
   @JsonKey(ignore: true)
   _$ReactionAskReportReasonDialogCopyWith<_ReactionAskReportReasonDialog>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$ReactionShowBlockConfirmationDialogCopyWith<$Res> {
+  factory _$ReactionShowBlockConfirmationDialogCopyWith(
+          _ReactionShowBlockConfirmationDialog value,
+          $Res Function(_ReactionShowBlockConfirmationDialog) then) =
+      __$ReactionShowBlockConfirmationDialogCopyWithImpl<$Res>;
+  $Res call({String message});
+}
+
+/// @nodoc
+class __$ReactionShowBlockConfirmationDialogCopyWithImpl<$Res>
+    extends _$UserProfileReactionCopyWithImpl<$Res>
+    implements _$ReactionShowBlockConfirmationDialogCopyWith<$Res> {
+  __$ReactionShowBlockConfirmationDialogCopyWithImpl(
+      _ReactionShowBlockConfirmationDialog _value,
+      $Res Function(_ReactionShowBlockConfirmationDialog) _then)
+      : super(_value, (v) => _then(v as _ReactionShowBlockConfirmationDialog));
+
+  @override
+  _ReactionShowBlockConfirmationDialog get _value =>
+      super._value as _ReactionShowBlockConfirmationDialog;
+
+  @override
+  $Res call({
+    Object? message = freezed,
+  }) {
+    return _then(_ReactionShowBlockConfirmationDialog(
+      message == freezed
+          ? _value.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$_ReactionShowBlockConfirmationDialog
+    implements _ReactionShowBlockConfirmationDialog {
+  _$_ReactionShowBlockConfirmationDialog(this.message);
+
+  @override
+  final String message;
+
+  @override
+  String toString() {
+    return 'UserProfileReaction.showBlockConfirmationDialog(message: $message)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _ReactionShowBlockConfirmationDialog &&
+            const DeepCollectionEquality().equals(other.message, message));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(message));
+
+  @JsonKey(ignore: true)
+  @override
+  _$ReactionShowBlockConfirmationDialogCopyWith<
+          _ReactionShowBlockConfirmationDialog>
+      get copyWith => __$ReactionShowBlockConfirmationDialogCopyWithImpl<
+          _ReactionShowBlockConfirmationDialog>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(String message) showSnackBar,
+    required TResult Function() showProfileOptions,
+    required TResult Function(String? reason) askReportReasonDialog,
+    required TResult Function(String message) showBlockConfirmationDialog,
+    required TResult Function() showProgressDialog,
+    required TResult Function() dismissProgressDialog,
+  }) {
+    return showBlockConfirmationDialog(message);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function(String message)? showSnackBar,
+    TResult Function()? showProfileOptions,
+    TResult Function(String? reason)? askReportReasonDialog,
+    TResult Function(String message)? showBlockConfirmationDialog,
+    TResult Function()? showProgressDialog,
+    TResult Function()? dismissProgressDialog,
+  }) {
+    return showBlockConfirmationDialog?.call(message);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(String message)? showSnackBar,
+    TResult Function()? showProfileOptions,
+    TResult Function(String? reason)? askReportReasonDialog,
+    TResult Function(String message)? showBlockConfirmationDialog,
+    TResult Function()? showProgressDialog,
+    TResult Function()? dismissProgressDialog,
+    required TResult orElse(),
+  }) {
+    if (showBlockConfirmationDialog != null) {
+      return showBlockConfirmationDialog(message);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_ReactionShowSnackBar value) showSnackBar,
+    required TResult Function(_ReactionShowProfileOptions value)
+        showProfileOptions,
+    required TResult Function(_ReactionAskReportReasonDialog value)
+        askReportReasonDialog,
+    required TResult Function(_ReactionShowBlockConfirmationDialog value)
+        showBlockConfirmationDialog,
+    required TResult Function(_ReactionShowProgressDialog value)
+        showProgressDialog,
+    required TResult Function(_ReactionDismissProgressDialog value)
+        dismissProgressDialog,
+  }) {
+    return showBlockConfirmationDialog(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(_ReactionShowSnackBar value)? showSnackBar,
+    TResult Function(_ReactionShowProfileOptions value)? showProfileOptions,
+    TResult Function(_ReactionAskReportReasonDialog value)?
+        askReportReasonDialog,
+    TResult Function(_ReactionShowBlockConfirmationDialog value)?
+        showBlockConfirmationDialog,
+    TResult Function(_ReactionShowProgressDialog value)? showProgressDialog,
+    TResult Function(_ReactionDismissProgressDialog value)?
+        dismissProgressDialog,
+  }) {
+    return showBlockConfirmationDialog?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_ReactionShowSnackBar value)? showSnackBar,
+    TResult Function(_ReactionShowProfileOptions value)? showProfileOptions,
+    TResult Function(_ReactionAskReportReasonDialog value)?
+        askReportReasonDialog,
+    TResult Function(_ReactionShowBlockConfirmationDialog value)?
+        showBlockConfirmationDialog,
+    TResult Function(_ReactionShowProgressDialog value)? showProgressDialog,
+    TResult Function(_ReactionDismissProgressDialog value)?
+        dismissProgressDialog,
+    required TResult orElse(),
+  }) {
+    if (showBlockConfirmationDialog != null) {
+      return showBlockConfirmationDialog(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _ReactionShowBlockConfirmationDialog
+    implements UserProfileReaction {
+  factory _ReactionShowBlockConfirmationDialog(String message) =
+      _$_ReactionShowBlockConfirmationDialog;
+
+  String get message;
+  @JsonKey(ignore: true)
+  _$ReactionShowBlockConfirmationDialogCopyWith<
+          _ReactionShowBlockConfirmationDialog>
       get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -1398,6 +1619,7 @@ class _$_ReactionShowProgressDialog implements _ReactionShowProgressDialog {
     required TResult Function(String message) showSnackBar,
     required TResult Function() showProfileOptions,
     required TResult Function(String? reason) askReportReasonDialog,
+    required TResult Function(String message) showBlockConfirmationDialog,
     required TResult Function() showProgressDialog,
     required TResult Function() dismissProgressDialog,
   }) {
@@ -1410,6 +1632,7 @@ class _$_ReactionShowProgressDialog implements _ReactionShowProgressDialog {
     TResult Function(String message)? showSnackBar,
     TResult Function()? showProfileOptions,
     TResult Function(String? reason)? askReportReasonDialog,
+    TResult Function(String message)? showBlockConfirmationDialog,
     TResult Function()? showProgressDialog,
     TResult Function()? dismissProgressDialog,
   }) {
@@ -1422,6 +1645,7 @@ class _$_ReactionShowProgressDialog implements _ReactionShowProgressDialog {
     TResult Function(String message)? showSnackBar,
     TResult Function()? showProfileOptions,
     TResult Function(String? reason)? askReportReasonDialog,
+    TResult Function(String message)? showBlockConfirmationDialog,
     TResult Function()? showProgressDialog,
     TResult Function()? dismissProgressDialog,
     required TResult orElse(),
@@ -1440,6 +1664,8 @@ class _$_ReactionShowProgressDialog implements _ReactionShowProgressDialog {
         showProfileOptions,
     required TResult Function(_ReactionAskReportReasonDialog value)
         askReportReasonDialog,
+    required TResult Function(_ReactionShowBlockConfirmationDialog value)
+        showBlockConfirmationDialog,
     required TResult Function(_ReactionShowProgressDialog value)
         showProgressDialog,
     required TResult Function(_ReactionDismissProgressDialog value)
@@ -1455,6 +1681,8 @@ class _$_ReactionShowProgressDialog implements _ReactionShowProgressDialog {
     TResult Function(_ReactionShowProfileOptions value)? showProfileOptions,
     TResult Function(_ReactionAskReportReasonDialog value)?
         askReportReasonDialog,
+    TResult Function(_ReactionShowBlockConfirmationDialog value)?
+        showBlockConfirmationDialog,
     TResult Function(_ReactionShowProgressDialog value)? showProgressDialog,
     TResult Function(_ReactionDismissProgressDialog value)?
         dismissProgressDialog,
@@ -1469,6 +1697,8 @@ class _$_ReactionShowProgressDialog implements _ReactionShowProgressDialog {
     TResult Function(_ReactionShowProfileOptions value)? showProfileOptions,
     TResult Function(_ReactionAskReportReasonDialog value)?
         askReportReasonDialog,
+    TResult Function(_ReactionShowBlockConfirmationDialog value)?
+        showBlockConfirmationDialog,
     TResult Function(_ReactionShowProgressDialog value)? showProgressDialog,
     TResult Function(_ReactionDismissProgressDialog value)?
         dismissProgressDialog,
@@ -1534,6 +1764,7 @@ class _$_ReactionDismissProgressDialog
     required TResult Function(String message) showSnackBar,
     required TResult Function() showProfileOptions,
     required TResult Function(String? reason) askReportReasonDialog,
+    required TResult Function(String message) showBlockConfirmationDialog,
     required TResult Function() showProgressDialog,
     required TResult Function() dismissProgressDialog,
   }) {
@@ -1546,6 +1777,7 @@ class _$_ReactionDismissProgressDialog
     TResult Function(String message)? showSnackBar,
     TResult Function()? showProfileOptions,
     TResult Function(String? reason)? askReportReasonDialog,
+    TResult Function(String message)? showBlockConfirmationDialog,
     TResult Function()? showProgressDialog,
     TResult Function()? dismissProgressDialog,
   }) {
@@ -1558,6 +1790,7 @@ class _$_ReactionDismissProgressDialog
     TResult Function(String message)? showSnackBar,
     TResult Function()? showProfileOptions,
     TResult Function(String? reason)? askReportReasonDialog,
+    TResult Function(String message)? showBlockConfirmationDialog,
     TResult Function()? showProgressDialog,
     TResult Function()? dismissProgressDialog,
     required TResult orElse(),
@@ -1576,6 +1809,8 @@ class _$_ReactionDismissProgressDialog
         showProfileOptions,
     required TResult Function(_ReactionAskReportReasonDialog value)
         askReportReasonDialog,
+    required TResult Function(_ReactionShowBlockConfirmationDialog value)
+        showBlockConfirmationDialog,
     required TResult Function(_ReactionShowProgressDialog value)
         showProgressDialog,
     required TResult Function(_ReactionDismissProgressDialog value)
@@ -1591,6 +1826,8 @@ class _$_ReactionDismissProgressDialog
     TResult Function(_ReactionShowProfileOptions value)? showProfileOptions,
     TResult Function(_ReactionAskReportReasonDialog value)?
         askReportReasonDialog,
+    TResult Function(_ReactionShowBlockConfirmationDialog value)?
+        showBlockConfirmationDialog,
     TResult Function(_ReactionShowProgressDialog value)? showProgressDialog,
     TResult Function(_ReactionDismissProgressDialog value)?
         dismissProgressDialog,
@@ -1605,6 +1842,8 @@ class _$_ReactionDismissProgressDialog
     TResult Function(_ReactionShowProfileOptions value)? showProfileOptions,
     TResult Function(_ReactionAskReportReasonDialog value)?
         askReportReasonDialog,
+    TResult Function(_ReactionShowBlockConfirmationDialog value)?
+        showBlockConfirmationDialog,
     TResult Function(_ReactionShowProgressDialog value)? showProgressDialog,
     TResult Function(_ReactionDismissProgressDialog value)?
         dismissProgressDialog,
@@ -1628,6 +1867,10 @@ class _$UserProfileSelectedOptionTearOff {
   _SelectedOptionReport report() {
     return _SelectedOptionReport();
   }
+
+  _SelectedOptionBlock block() {
+    return _SelectedOptionBlock();
+  }
 }
 
 /// @nodoc
@@ -1638,32 +1881,38 @@ mixin _$UserProfileSelectedOption {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function() report,
+    required TResult Function() block,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
     TResult Function()? report,
+    TResult Function()? block,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
     TResult Function()? report,
+    TResult Function()? block,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
     required TResult Function(_SelectedOptionReport value) report,
+    required TResult Function(_SelectedOptionBlock value) block,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
     TResult Function(_SelectedOptionReport value)? report,
+    TResult Function(_SelectedOptionBlock value)? block,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
     TResult Function(_SelectedOptionReport value)? report,
+    TResult Function(_SelectedOptionBlock value)? block,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -1728,6 +1977,7 @@ class _$_SelectedOptionReport implements _SelectedOptionReport {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function() report,
+    required TResult Function() block,
   }) {
     return report();
   }
@@ -1736,6 +1986,7 @@ class _$_SelectedOptionReport implements _SelectedOptionReport {
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
     TResult Function()? report,
+    TResult Function()? block,
   }) {
     return report?.call();
   }
@@ -1744,6 +1995,7 @@ class _$_SelectedOptionReport implements _SelectedOptionReport {
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
     TResult Function()? report,
+    TResult Function()? block,
     required TResult orElse(),
   }) {
     if (report != null) {
@@ -1756,6 +2008,7 @@ class _$_SelectedOptionReport implements _SelectedOptionReport {
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
     required TResult Function(_SelectedOptionReport value) report,
+    required TResult Function(_SelectedOptionBlock value) block,
   }) {
     return report(this);
   }
@@ -1764,6 +2017,7 @@ class _$_SelectedOptionReport implements _SelectedOptionReport {
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
     TResult Function(_SelectedOptionReport value)? report,
+    TResult Function(_SelectedOptionBlock value)? block,
   }) {
     return report?.call(this);
   }
@@ -1772,6 +2026,7 @@ class _$_SelectedOptionReport implements _SelectedOptionReport {
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
     TResult Function(_SelectedOptionReport value)? report,
+    TResult Function(_SelectedOptionBlock value)? block,
     required TResult orElse(),
   }) {
     if (report != null) {
@@ -1783,4 +2038,109 @@ class _$_SelectedOptionReport implements _SelectedOptionReport {
 
 abstract class _SelectedOptionReport implements UserProfileSelectedOption {
   factory _SelectedOptionReport() = _$_SelectedOptionReport;
+}
+
+/// @nodoc
+abstract class _$SelectedOptionBlockCopyWith<$Res> {
+  factory _$SelectedOptionBlockCopyWith(_SelectedOptionBlock value,
+          $Res Function(_SelectedOptionBlock) then) =
+      __$SelectedOptionBlockCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$SelectedOptionBlockCopyWithImpl<$Res>
+    extends _$UserProfileSelectedOptionCopyWithImpl<$Res>
+    implements _$SelectedOptionBlockCopyWith<$Res> {
+  __$SelectedOptionBlockCopyWithImpl(
+      _SelectedOptionBlock _value, $Res Function(_SelectedOptionBlock) _then)
+      : super(_value, (v) => _then(v as _SelectedOptionBlock));
+
+  @override
+  _SelectedOptionBlock get _value => super._value as _SelectedOptionBlock;
+}
+
+/// @nodoc
+
+class _$_SelectedOptionBlock implements _SelectedOptionBlock {
+  _$_SelectedOptionBlock();
+
+  @override
+  String toString() {
+    return 'UserProfileSelectedOption.block()';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _SelectedOptionBlock);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() report,
+    required TResult Function() block,
+  }) {
+    return block();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function()? report,
+    TResult Function()? block,
+  }) {
+    return block?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? report,
+    TResult Function()? block,
+    required TResult orElse(),
+  }) {
+    if (block != null) {
+      return block();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_SelectedOptionReport value) report,
+    required TResult Function(_SelectedOptionBlock value) block,
+  }) {
+    return block(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(_SelectedOptionReport value)? report,
+    TResult Function(_SelectedOptionBlock value)? block,
+  }) {
+    return block?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_SelectedOptionReport value)? report,
+    TResult Function(_SelectedOptionBlock value)? block,
+    required TResult orElse(),
+  }) {
+    if (block != null) {
+      return block(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _SelectedOptionBlock implements UserProfileSelectedOption {
+  factory _SelectedOptionBlock() = _$_SelectedOptionBlock;
 }

--- a/lib/app/features/users/presentation/user_profile_state.freezed.dart
+++ b/lib/app/features/users/presentation/user_profile_state.freezed.dart
@@ -775,9 +775,11 @@ abstract class _MenuStateVisible implements UserMenuState {
 class _$UserProfileReactionTearOff {
   const _$UserProfileReactionTearOff();
 
-  _ReactionShowSnackBar showSnackBar(String message) {
+  _ReactionShowSnackBar showSnackBar(String message,
+      {bool inMainboardPage = false}) {
     return _ReactionShowSnackBar(
       message,
+      inMainboardPage: inMainboardPage,
     );
   }
 
@@ -815,7 +817,8 @@ const $UserProfileReaction = _$UserProfileReactionTearOff();
 mixin _$UserProfileReaction {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(String message) showSnackBar,
+    required TResult Function(String message, bool inMainboardPage)
+        showSnackBar,
     required TResult Function() showProfileOptions,
     required TResult Function(String? reason) askReportReasonDialog,
     required TResult Function(String message) showBlockConfirmationDialog,
@@ -825,7 +828,7 @@ mixin _$UserProfileReaction {
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult Function(String message)? showSnackBar,
+    TResult Function(String message, bool inMainboardPage)? showSnackBar,
     TResult Function()? showProfileOptions,
     TResult Function(String? reason)? askReportReasonDialog,
     TResult Function(String message)? showBlockConfirmationDialog,
@@ -835,7 +838,7 @@ mixin _$UserProfileReaction {
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(String message)? showSnackBar,
+    TResult Function(String message, bool inMainboardPage)? showSnackBar,
     TResult Function()? showProfileOptions,
     TResult Function(String? reason)? askReportReasonDialog,
     TResult Function(String message)? showBlockConfirmationDialog,
@@ -910,7 +913,7 @@ abstract class _$ReactionShowSnackBarCopyWith<$Res> {
   factory _$ReactionShowSnackBarCopyWith(_ReactionShowSnackBar value,
           $Res Function(_ReactionShowSnackBar) then) =
       __$ReactionShowSnackBarCopyWithImpl<$Res>;
-  $Res call({String message});
+  $Res call({String message, bool inMainboardPage});
 }
 
 /// @nodoc
@@ -927,12 +930,17 @@ class __$ReactionShowSnackBarCopyWithImpl<$Res>
   @override
   $Res call({
     Object? message = freezed,
+    Object? inMainboardPage = freezed,
   }) {
     return _then(_ReactionShowSnackBar(
       message == freezed
           ? _value.message
           : message // ignore: cast_nullable_to_non_nullable
               as String,
+      inMainboardPage: inMainboardPage == freezed
+          ? _value.inMainboardPage
+          : inMainboardPage // ignore: cast_nullable_to_non_nullable
+              as bool,
     ));
   }
 }
@@ -940,14 +948,17 @@ class __$ReactionShowSnackBarCopyWithImpl<$Res>
 /// @nodoc
 
 class _$_ReactionShowSnackBar implements _ReactionShowSnackBar {
-  _$_ReactionShowSnackBar(this.message);
+  _$_ReactionShowSnackBar(this.message, {this.inMainboardPage = false});
 
   @override
   final String message;
+  @JsonKey()
+  @override
+  final bool inMainboardPage;
 
   @override
   String toString() {
-    return 'UserProfileReaction.showSnackBar(message: $message)';
+    return 'UserProfileReaction.showSnackBar(message: $message, inMainboardPage: $inMainboardPage)';
   }
 
   @override
@@ -955,12 +966,16 @@ class _$_ReactionShowSnackBar implements _ReactionShowSnackBar {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _ReactionShowSnackBar &&
-            const DeepCollectionEquality().equals(other.message, message));
+            const DeepCollectionEquality().equals(other.message, message) &&
+            const DeepCollectionEquality()
+                .equals(other.inMainboardPage, inMainboardPage));
   }
 
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, const DeepCollectionEquality().hash(message));
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(message),
+      const DeepCollectionEquality().hash(inMainboardPage));
 
   @JsonKey(ignore: true)
   @override
@@ -971,33 +986,34 @@ class _$_ReactionShowSnackBar implements _ReactionShowSnackBar {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(String message) showSnackBar,
+    required TResult Function(String message, bool inMainboardPage)
+        showSnackBar,
     required TResult Function() showProfileOptions,
     required TResult Function(String? reason) askReportReasonDialog,
     required TResult Function(String message) showBlockConfirmationDialog,
     required TResult Function() showProgressDialog,
     required TResult Function() dismissProgressDialog,
   }) {
-    return showSnackBar(message);
+    return showSnackBar(message, inMainboardPage);
   }
 
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult Function(String message)? showSnackBar,
+    TResult Function(String message, bool inMainboardPage)? showSnackBar,
     TResult Function()? showProfileOptions,
     TResult Function(String? reason)? askReportReasonDialog,
     TResult Function(String message)? showBlockConfirmationDialog,
     TResult Function()? showProgressDialog,
     TResult Function()? dismissProgressDialog,
   }) {
-    return showSnackBar?.call(message);
+    return showSnackBar?.call(message, inMainboardPage);
   }
 
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(String message)? showSnackBar,
+    TResult Function(String message, bool inMainboardPage)? showSnackBar,
     TResult Function()? showProfileOptions,
     TResult Function(String? reason)? askReportReasonDialog,
     TResult Function(String message)? showBlockConfirmationDialog,
@@ -1006,7 +1022,7 @@ class _$_ReactionShowSnackBar implements _ReactionShowSnackBar {
     required TResult orElse(),
   }) {
     if (showSnackBar != null) {
-      return showSnackBar(message);
+      return showSnackBar(message, inMainboardPage);
     }
     return orElse();
   }
@@ -1067,9 +1083,11 @@ class _$_ReactionShowSnackBar implements _ReactionShowSnackBar {
 }
 
 abstract class _ReactionShowSnackBar implements UserProfileReaction {
-  factory _ReactionShowSnackBar(String message) = _$_ReactionShowSnackBar;
+  factory _ReactionShowSnackBar(String message, {bool inMainboardPage}) =
+      _$_ReactionShowSnackBar;
 
   String get message;
+  bool get inMainboardPage;
   @JsonKey(ignore: true)
   _$ReactionShowSnackBarCopyWith<_ReactionShowSnackBar> get copyWith =>
       throw _privateConstructorUsedError;
@@ -1119,7 +1137,8 @@ class _$_ReactionShowProfileOptions implements _ReactionShowProfileOptions {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(String message) showSnackBar,
+    required TResult Function(String message, bool inMainboardPage)
+        showSnackBar,
     required TResult Function() showProfileOptions,
     required TResult Function(String? reason) askReportReasonDialog,
     required TResult Function(String message) showBlockConfirmationDialog,
@@ -1132,7 +1151,7 @@ class _$_ReactionShowProfileOptions implements _ReactionShowProfileOptions {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult Function(String message)? showSnackBar,
+    TResult Function(String message, bool inMainboardPage)? showSnackBar,
     TResult Function()? showProfileOptions,
     TResult Function(String? reason)? askReportReasonDialog,
     TResult Function(String message)? showBlockConfirmationDialog,
@@ -1145,7 +1164,7 @@ class _$_ReactionShowProfileOptions implements _ReactionShowProfileOptions {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(String message)? showSnackBar,
+    TResult Function(String message, bool inMainboardPage)? showSnackBar,
     TResult Function()? showProfileOptions,
     TResult Function(String? reason)? askReportReasonDialog,
     TResult Function(String message)? showBlockConfirmationDialog,
@@ -1289,7 +1308,8 @@ class _$_ReactionAskReportReasonDialog
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(String message) showSnackBar,
+    required TResult Function(String message, bool inMainboardPage)
+        showSnackBar,
     required TResult Function() showProfileOptions,
     required TResult Function(String? reason) askReportReasonDialog,
     required TResult Function(String message) showBlockConfirmationDialog,
@@ -1302,7 +1322,7 @@ class _$_ReactionAskReportReasonDialog
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult Function(String message)? showSnackBar,
+    TResult Function(String message, bool inMainboardPage)? showSnackBar,
     TResult Function()? showProfileOptions,
     TResult Function(String? reason)? askReportReasonDialog,
     TResult Function(String message)? showBlockConfirmationDialog,
@@ -1315,7 +1335,7 @@ class _$_ReactionAskReportReasonDialog
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(String message)? showSnackBar,
+    TResult Function(String message, bool inMainboardPage)? showSnackBar,
     TResult Function()? showProfileOptions,
     TResult Function(String? reason)? askReportReasonDialog,
     TResult Function(String message)? showBlockConfirmationDialog,
@@ -1465,7 +1485,8 @@ class _$_ReactionShowBlockConfirmationDialog
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(String message) showSnackBar,
+    required TResult Function(String message, bool inMainboardPage)
+        showSnackBar,
     required TResult Function() showProfileOptions,
     required TResult Function(String? reason) askReportReasonDialog,
     required TResult Function(String message) showBlockConfirmationDialog,
@@ -1478,7 +1499,7 @@ class _$_ReactionShowBlockConfirmationDialog
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult Function(String message)? showSnackBar,
+    TResult Function(String message, bool inMainboardPage)? showSnackBar,
     TResult Function()? showProfileOptions,
     TResult Function(String? reason)? askReportReasonDialog,
     TResult Function(String message)? showBlockConfirmationDialog,
@@ -1491,7 +1512,7 @@ class _$_ReactionShowBlockConfirmationDialog
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(String message)? showSnackBar,
+    TResult Function(String message, bool inMainboardPage)? showSnackBar,
     TResult Function()? showProfileOptions,
     TResult Function(String? reason)? askReportReasonDialog,
     TResult Function(String message)? showBlockConfirmationDialog,
@@ -1616,7 +1637,8 @@ class _$_ReactionShowProgressDialog implements _ReactionShowProgressDialog {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(String message) showSnackBar,
+    required TResult Function(String message, bool inMainboardPage)
+        showSnackBar,
     required TResult Function() showProfileOptions,
     required TResult Function(String? reason) askReportReasonDialog,
     required TResult Function(String message) showBlockConfirmationDialog,
@@ -1629,7 +1651,7 @@ class _$_ReactionShowProgressDialog implements _ReactionShowProgressDialog {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult Function(String message)? showSnackBar,
+    TResult Function(String message, bool inMainboardPage)? showSnackBar,
     TResult Function()? showProfileOptions,
     TResult Function(String? reason)? askReportReasonDialog,
     TResult Function(String message)? showBlockConfirmationDialog,
@@ -1642,7 +1664,7 @@ class _$_ReactionShowProgressDialog implements _ReactionShowProgressDialog {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(String message)? showSnackBar,
+    TResult Function(String message, bool inMainboardPage)? showSnackBar,
     TResult Function()? showProfileOptions,
     TResult Function(String? reason)? askReportReasonDialog,
     TResult Function(String message)? showBlockConfirmationDialog,
@@ -1761,7 +1783,8 @@ class _$_ReactionDismissProgressDialog
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(String message) showSnackBar,
+    required TResult Function(String message, bool inMainboardPage)
+        showSnackBar,
     required TResult Function() showProfileOptions,
     required TResult Function(String? reason) askReportReasonDialog,
     required TResult Function(String message) showBlockConfirmationDialog,
@@ -1774,7 +1797,7 @@ class _$_ReactionDismissProgressDialog
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult Function(String message)? showSnackBar,
+    TResult Function(String message, bool inMainboardPage)? showSnackBar,
     TResult Function()? showProfileOptions,
     TResult Function(String? reason)? askReportReasonDialog,
     TResult Function(String message)? showBlockConfirmationDialog,
@@ -1787,7 +1810,7 @@ class _$_ReactionDismissProgressDialog
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(String message)? showSnackBar,
+    TResult Function(String message, bool inMainboardPage)? showSnackBar,
     TResult Function()? showProfileOptions,
     TResult Function(String? reason)? askReportReasonDialog,
     TResult Function(String message)? showBlockConfirmationDialog,

--- a/test/app/features/users/data/repositories/users_repository_block_test.dart
+++ b/test/app/features/users/data/repositories/users_repository_block_test.dart
@@ -63,7 +63,7 @@ void main() {
 
       // assert
       verify(() =>
-          apiProvider.post(path: '/profile-block', parameters: parameters));
+          apiProvider.post(path: '/block-profile', parameters: parameters));
     });
 
     test('should receive success message', () async {

--- a/test/app/features/users/domain/usecases/block_user_usecase_test.dart
+++ b/test/app/features/users/domain/usecases/block_user_usecase_test.dart
@@ -1,0 +1,53 @@
+import 'package:dartz/dartz.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:penhas/app/core/entities/valid_fiel.dart';
+import 'package:penhas/app/core/error/failures.dart';
+import 'package:penhas/app/features/users/data/repositories/users_repository.dart';
+import 'package:penhas/app/features/users/domain/usecases/block_user_usecase.dart';
+
+class MockUsersRepository extends Mock implements IUsersRepository {}
+
+void main() {
+  late BlockUserUseCase sut;
+  late MockUsersRepository mockRepository;
+
+  setUp(() {
+    mockRepository = MockUsersRepository();
+    sut = BlockUserUseCase(repository: mockRepository);
+  });
+
+  group(BlockUserUseCase, () {
+    const clientId = '456';
+
+    test('should call block from repository', () async {
+      // arrange
+      const validField = ValidField(message: 'deu bom!');
+      when(() => mockRepository.block(clientId))
+          .thenAnswer((_) async => right(validField));
+
+      // act
+      final result = await sut(clientId);
+
+      // assert
+      expect(result, right(validField));
+      verify(() => mockRepository.block(clientId));
+      verifyNoMoreInteractions(mockRepository);
+    });
+
+    test('should return failure when repository returns failure', () async {
+      // arrange
+      final failure = ServerFailure();
+      when(() => mockRepository.block(clientId))
+          .thenAnswer((_) async => left(failure));
+
+      // act
+      final result = await sut(clientId);
+
+      // assert
+      expect(result, left(failure));
+      verify(() => mockRepository.block(clientId));
+      verifyNoMoreInteractions(mockRepository);
+    });
+  });
+}

--- a/test/app/features/users/domain/usecases/block_user_usecase_test.dart
+++ b/test/app/features/users/domain/usecases/block_user_usecase_test.dart
@@ -3,51 +3,100 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:penhas/app/core/entities/valid_fiel.dart';
 import 'package:penhas/app/core/error/failures.dart';
+import 'package:penhas/app/features/feed/domain/usecases/feed_use_cases.dart';
 import 'package:penhas/app/features/users/data/repositories/users_repository.dart';
 import 'package:penhas/app/features/users/domain/usecases/block_user_usecase.dart';
 
 class MockUsersRepository extends Mock implements IUsersRepository {}
 
+class MockFeedUseCases extends Mock implements FeedUseCases {}
+
 void main() {
   late BlockUserUseCase sut;
-  late MockUsersRepository mockRepository;
+
+  late IUsersRepository mockRepository;
+  late FeedUseCases mockFeedUseCases;
 
   setUp(() {
     mockRepository = MockUsersRepository();
-    sut = BlockUserUseCase(repository: mockRepository);
+    mockFeedUseCases = MockFeedUseCases();
+
+    sut = BlockUserUseCase(
+      repository: mockRepository,
+      feedUseCases: mockFeedUseCases,
+    );
+
+    when(() => mockFeedUseCases.reloadTweetFeed())
+        .thenAnswer((_) async => right(const FeedCache(tweets: [])));
   });
 
   group(BlockUserUseCase, () {
     const clientId = '456';
 
-    test('should call block from repository', () async {
-      // arrange
-      const validField = ValidField(message: 'deu bom!');
-      when(() => mockRepository.block(clientId))
-          .thenAnswer((_) async => right(validField));
+    test(
+      'should call block from repository',
+      () async {
+        // arrange
+        const validField = ValidField(message: 'deu bom!');
+        when(() => mockRepository.block(clientId))
+            .thenAnswer((_) async => right(validField));
 
-      // act
-      final result = await sut(clientId);
+        // act
+        await sut(clientId);
 
-      // assert
-      expect(result, right(validField));
-      verify(() => mockRepository.block(clientId));
-      verifyNoMoreInteractions(mockRepository);
-    });
+        // assert
+        verify(() => mockRepository.block(clientId)).called(1);
+        verifyNoMoreInteractions(mockRepository);
+      },
+    );
 
-    test('should return failure when repository returns failure', () async {
-      // arrange
-      final failure = ServerFailure();
-      when(() => mockRepository.block(clientId))
-          .thenAnswer((_) async => left(failure));
+    test(
+      'should return ValidField from repository when success',
+      () async {
+        // arrange
+        const validField = ValidField(message: 'deu bom!');
+        when(() => mockRepository.block(clientId))
+            .thenAnswer((_) async => right(validField));
 
-      // act
-      final result = await sut(clientId);
+        // act
+        final result = await sut(clientId);
 
-      // assert
-      expect(result, left(failure));
-      verify(() => mockRepository.block(clientId));
-      verifyNoMoreInteractions(mockRepository);
-    });
+        // assert
+        expect(result, right(validField));
+      },
+    );
+
+    test(
+      'should return failure when fails',
+      () async {
+        // arrange
+        final failure = ServerFailure();
+        when(() => mockRepository.block(clientId))
+            .thenAnswer((_) async => left(failure));
+
+        // act
+        final result = await sut(clientId);
+
+        // assert
+        expect(result, left(failure));
+      },
+    );
+
+    test(
+      'should call reloadTweetFeed from FeedUseCases when success',
+      () async {
+        // arrange
+        const validField = ValidField(message: 'deu bom!');
+        when(() => mockRepository.block(clientId))
+            .thenAnswer((_) async => right(validField));
+
+        // act
+        await sut(clientId);
+
+        // assert
+        verify(() => mockFeedUseCases.reloadTweetFeed()).called(1);
+        verifyNoMoreInteractions(mockFeedUseCases);
+      },
+    );
   });
 }

--- a/test/app/features/users/presentation/user_profile_controller_test.dart
+++ b/test/app/features/users/presentation/user_profile_controller_test.dart
@@ -89,6 +89,7 @@ void main() {
             person: user,
             getChatChannelToken: mockGetChatChannelTokenUseCase,
             reportUser: mockReportUserUseCase,
+            blockUser: mockBlockUserUseCase,
           );
 
           // assert
@@ -110,6 +111,7 @@ void main() {
             person: user,
             getChatChannelToken: mockGetChatChannelTokenUseCase,
             reportUser: mockReportUserUseCase,
+            blockUser: mockBlockUserUseCase,
           );
 
           // assert
@@ -233,6 +235,22 @@ void main() {
           );
         },
       );
+
+      test(
+        'should set reaction to showBlockConfirmationDialog when option is block',
+        () async {
+          // act
+          controller.onOptionSelected(UserProfileSelectedOption.block());
+
+          // assert
+          expect(
+            controller.reaction,
+            UserProfileReaction.showBlockConfirmationDialog(
+              'Deseja realmente bloquear ${user.profile.nickname}?',
+            ),
+          );
+        },
+      );
     });
 
     group('onSendReportPressed', () {
@@ -343,6 +361,122 @@ void main() {
             controller.reaction,
             UserProfileReaction.showSnackBar(message),
           );
+        },
+      );
+    });
+
+    group('onConfirmBlockPressed', () {
+      setUp(() {
+        when(() => mockNavigator.pop()).thenAnswer((_) async {});
+      });
+
+      test(
+        'should call BlockUserUseCase',
+        () async {
+          // arrange
+          when(
+            () => mockBlockUserUseCase('$clientId'),
+          ).thenAnswer(
+            (_) async => right(const ValidField(message: 'message')),
+          );
+
+          // act
+          controller.onConfirmBlockPressed();
+
+          // assert
+          verify(
+            () => mockBlockUserUseCase('$clientId'),
+          ).called(1);
+        },
+      );
+
+      test(
+        'should set reaction to showProgressDialog',
+        () async {
+          // arrange
+          when(
+            () => mockBlockUserUseCase('$clientId'),
+          ).thenAnswer(
+            (_) => Future.delayed(const Duration(seconds: 1)).then(
+              (_) => right(
+                const ValidField(message: 'message'),
+              ),
+            ),
+          );
+
+          // act
+          controller.onConfirmBlockPressed();
+
+          // assert
+          expect(
+            controller.reaction,
+            UserProfileReaction.showProgressDialog(),
+          );
+        },
+      );
+
+      test(
+        'should set reaction to showSnackBar when success',
+        () async {
+          // arrange
+          const message = 'Bloqueado com sucesso';
+          when(
+            () => mockBlockUserUseCase('$clientId'),
+          ).thenAnswer(
+            (_) async => right(const ValidField(message: message)),
+          );
+
+          // act
+          await controller.onConfirmBlockPressed();
+
+          // assert
+          expect(
+            controller.reaction,
+            UserProfileReaction.showSnackBar(message),
+          );
+        },
+      );
+
+      test(
+        'should set reaction to showSnackBar when error',
+        () async {
+          // arrange
+          const message = 'Não deixo você bloquear!';
+          when(
+            () => mockBlockUserUseCase('$clientId'),
+          ).thenAnswer(
+            (_) async => left(
+              ServerSideFormFieldValidationFailure(message: message),
+            ),
+          );
+
+          // act
+          await controller.onConfirmBlockPressed();
+
+          // assert
+          expect(
+            controller.reaction,
+            UserProfileReaction.showSnackBar(message),
+          );
+        },
+      );
+
+      test(
+        'should pop navigation when success',
+        () async {
+          // arrange
+          const message = 'Reportado com sucesso';
+          when(
+            () => mockBlockUserUseCase('$clientId'),
+          ).thenAnswer(
+            (_) async => right(const ValidField(message: message)),
+          );
+
+          // act
+          await controller.onConfirmBlockPressed();
+
+          // assert
+          verify(() => mockNavigator.pop()).called(1);
         },
       );
     });

--- a/test/app/features/users/presentation/user_profile_controller_test.dart
+++ b/test/app/features/users/presentation/user_profile_controller_test.dart
@@ -8,6 +8,7 @@ import 'package:penhas/app/features/chat/domain/entities/chat_channel_open_entit
 import 'package:penhas/app/features/chat/domain/usecases/get_chat_channel_token_usecase.dart';
 import 'package:penhas/app/features/users/domain/entities/user_detail_entity.dart';
 import 'package:penhas/app/features/users/domain/entities/user_detail_profile_entity.dart';
+import 'package:penhas/app/features/users/domain/usecases/block_user_usecase.dart';
 import 'package:penhas/app/features/users/domain/usecases/report_user_usecase.dart';
 import 'package:penhas/app/features/users/presentation/user_profile_controller.dart';
 import 'package:penhas/app/features/users/presentation/user_profile_state.dart';
@@ -17,6 +18,8 @@ class MockGetChatChannelTokenUseCase extends Mock
 
 class MockReportUserUseCase extends Mock implements ReportUserUseCase {}
 
+class MockBlockUserUseCase extends Mock implements BlockUserUseCase {}
+
 class MockModularNavigator extends Mock implements IModularNavigator {}
 
 void main() {
@@ -25,6 +28,7 @@ void main() {
 
     late GetChatChannelTokenUseCase mockGetChatChannelTokenUseCase;
     late ReportUserUseCase mockReportUserUseCase;
+    late BlockUserUseCase mockBlockUserUseCase;
 
     late IModularNavigator mockNavigator;
     const clientId = 123;
@@ -45,11 +49,13 @@ void main() {
     setUp(() {
       mockGetChatChannelTokenUseCase = MockGetChatChannelTokenUseCase();
       mockReportUserUseCase = MockReportUserUseCase();
+      mockBlockUserUseCase = MockBlockUserUseCase();
 
       controller = UserProfileController(
         person: user,
         getChatChannelToken: mockGetChatChannelTokenUseCase,
         reportUser: mockReportUserUseCase,
+        blockUser: mockBlockUserUseCase,
       );
 
       mockNavigator = Modular.navigatorDelegate = MockModularNavigator();


### PR DESCRIPTION
## Objetivo
Atender aos critérios da guideline da Google para UGC (User Generated Content), incluindo a opção de bloquear usuário.

<img width="400" src="https://user-images.githubusercontent.com/9375141/223278011-440f2026-c0df-4945-86cf-f252e94871f0.png" alt="Tela de perfil de usuário mostrando o componente de bottom sheet com a opção de bloquear usuária(o)" />

<img width="400" src="https://user-images.githubusercontent.com/9375141/223278171-a395ad1e-cc10-4c19-994c-f6715cd25141.png" alt="Tela de perfil de usuário mostrando o dialog após clicar na opção de bloquear, solicitando sua confirmação" />


closes #57

## Alterações

- :warning: Foi necessário criar um débito técnico que será corrigido após ajustar a questão do `showSnackBar` obsoleto, que implica no duplo `Scaffold` em [mainboard_page.dart](https://github.com/institutoazmina/penhas-app/blob/c37a3f5dc8c0d726b6ef5fd26dd728b34e6d41b4/lib/app/features/mainboard/presentation/mainboard/mainboard_page.dart) necessário para exibir a mensagem de sucesso na timeline/home.