### PR TITLE
Correção do crash na lógica para determinar o signo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Corrigido
+- Crash e lógica do horóscopo
+
 ## [3.3.0] - 2023-03-06
 
 ### Adicionado

--- a/lib/app/features/zodiac/domain/entities/zodiac_sign_aquarius.dart
+++ b/lib/app/features/zodiac/domain/entities/zodiac_sign_aquarius.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:penhas/app/features/zodiac/domain/entities/izodiac.dart';
-import 'package:penhas/app/shared/design_system/colors.dart';
+
+import '../../../../shared/design_system/colors.dart';
+import 'izodiac.dart';
 
 class ZodiacSignAquarius implements IZodiac {
   @override

--- a/lib/app/features/zodiac/domain/entities/zodiac_sign_aries.dart
+++ b/lib/app/features/zodiac/domain/entities/zodiac_sign_aries.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:penhas/app/features/zodiac/domain/entities/izodiac.dart';
-import 'package:penhas/app/shared/design_system/colors.dart';
+
+import '../../../../shared/design_system/colors.dart';
+import 'izodiac.dart';
 
 class ZodiacSignAries implements IZodiac {
   @override

--- a/lib/app/features/zodiac/domain/entities/zodiac_sign_cancer.dart
+++ b/lib/app/features/zodiac/domain/entities/zodiac_sign_cancer.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:penhas/app/features/zodiac/domain/entities/izodiac.dart';
-import 'package:penhas/app/shared/design_system/colors.dart';
+
+import '../../../../shared/design_system/colors.dart';
+import 'izodiac.dart';
 
 class ZodiacSignCancer implements IZodiac {
   @override

--- a/lib/app/features/zodiac/domain/entities/zodiac_sign_capricorn.dart
+++ b/lib/app/features/zodiac/domain/entities/zodiac_sign_capricorn.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:penhas/app/features/zodiac/domain/entities/izodiac.dart';
-import 'package:penhas/app/shared/design_system/colors.dart';
+
+import '../../../../shared/design_system/colors.dart';
+import 'izodiac.dart';
 
 class ZodiacSignCapricorn implements IZodiac {
   @override

--- a/lib/app/features/zodiac/domain/entities/zodiac_sign_gemini.dart
+++ b/lib/app/features/zodiac/domain/entities/zodiac_sign_gemini.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:penhas/app/features/zodiac/domain/entities/izodiac.dart';
-import 'package:penhas/app/shared/design_system/colors.dart';
+
+import '../../../../shared/design_system/colors.dart';
+import 'izodiac.dart';
 
 class ZodiacSignGemini implements IZodiac {
   @override

--- a/lib/app/features/zodiac/domain/entities/zodiac_sign_leo.dart
+++ b/lib/app/features/zodiac/domain/entities/zodiac_sign_leo.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:penhas/app/features/zodiac/domain/entities/izodiac.dart';
-import 'package:penhas/app/shared/design_system/colors.dart';
+
+import '../../../../shared/design_system/colors.dart';
+import 'izodiac.dart';
 
 class ZodiacSignLeo implements IZodiac {
   @override

--- a/lib/app/features/zodiac/domain/entities/zodiac_sign_libra.dart
+++ b/lib/app/features/zodiac/domain/entities/zodiac_sign_libra.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:penhas/app/features/zodiac/domain/entities/izodiac.dart';
-import 'package:penhas/app/shared/design_system/colors.dart';
+
+import '../../../../shared/design_system/colors.dart';
+import 'izodiac.dart';
 
 class ZodiacSignLibra implements IZodiac {
   @override

--- a/lib/app/features/zodiac/domain/entities/zodiac_sign_pisces.dart
+++ b/lib/app/features/zodiac/domain/entities/zodiac_sign_pisces.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:penhas/app/features/zodiac/domain/entities/izodiac.dart';
-import 'package:penhas/app/shared/design_system/colors.dart';
+
+import '../../../../shared/design_system/colors.dart';
+import 'izodiac.dart';
 
 class ZodiacSignPisces implements IZodiac {
   @override

--- a/lib/app/features/zodiac/domain/entities/zodiac_sign_sagittarius.dart
+++ b/lib/app/features/zodiac/domain/entities/zodiac_sign_sagittarius.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:penhas/app/features/zodiac/domain/entities/izodiac.dart';
-import 'package:penhas/app/shared/design_system/colors.dart';
+
+import '../../../../shared/design_system/colors.dart';
+import 'izodiac.dart';
 
 class ZodiacSignSagittarius implements IZodiac {
   @override

--- a/lib/app/features/zodiac/domain/entities/zodiac_sign_scorpio.dart
+++ b/lib/app/features/zodiac/domain/entities/zodiac_sign_scorpio.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:penhas/app/features/zodiac/domain/entities/izodiac.dart';
-import 'package:penhas/app/shared/design_system/colors.dart';
+
+import '../../../../shared/design_system/colors.dart';
+import 'izodiac.dart';
 
 class ZodiacSignScorpio implements IZodiac {
   @override

--- a/lib/app/features/zodiac/domain/entities/zodiac_sign_taurus.dart
+++ b/lib/app/features/zodiac/domain/entities/zodiac_sign_taurus.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:penhas/app/features/zodiac/domain/entities/izodiac.dart';
-import 'package:penhas/app/shared/design_system/colors.dart';
+
+import '../../../../shared/design_system/colors.dart';
+import 'izodiac.dart';
 
 class ZodiacSignTaurus implements IZodiac {
   @override

--- a/lib/app/features/zodiac/domain/entities/zodiac_sign_virgo.dart
+++ b/lib/app/features/zodiac/domain/entities/zodiac_sign_virgo.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:penhas/app/features/zodiac/domain/entities/izodiac.dart';
-import 'package:penhas/app/shared/design_system/colors.dart';
+
+import '../../../../shared/design_system/colors.dart';
+import 'izodiac.dart';
 
 class ZodiacSignVirgo implements IZodiac {
   @override

--- a/lib/app/features/zodiac/domain/usecases/zodiac.dart
+++ b/lib/app/features/zodiac/domain/usecases/zodiac.dart
@@ -1,16 +1,16 @@
-import 'package:penhas/app/features/zodiac/domain/entities/izodiac.dart';
-import 'package:penhas/app/features/zodiac/domain/entities/zodiac_sign_aquarius.dart';
-import 'package:penhas/app/features/zodiac/domain/entities/zodiac_sign_aries.dart';
-import 'package:penhas/app/features/zodiac/domain/entities/zodiac_sign_cancer.dart';
-import 'package:penhas/app/features/zodiac/domain/entities/zodiac_sign_capricorn.dart';
-import 'package:penhas/app/features/zodiac/domain/entities/zodiac_sign_gemini.dart';
-import 'package:penhas/app/features/zodiac/domain/entities/zodiac_sign_leo.dart';
-import 'package:penhas/app/features/zodiac/domain/entities/zodiac_sign_libra.dart';
-import 'package:penhas/app/features/zodiac/domain/entities/zodiac_sign_pisces.dart';
-import 'package:penhas/app/features/zodiac/domain/entities/zodiac_sign_sagittarius.dart';
-import 'package:penhas/app/features/zodiac/domain/entities/zodiac_sign_scorpio.dart';
-import 'package:penhas/app/features/zodiac/domain/entities/zodiac_sign_taurus.dart';
-import 'package:penhas/app/features/zodiac/domain/entities/zodiac_sign_virgo.dart';
+import '../entities/izodiac.dart';
+import '../entities/zodiac_sign_aquarius.dart';
+import '../entities/zodiac_sign_aries.dart';
+import '../entities/zodiac_sign_cancer.dart';
+import '../entities/zodiac_sign_capricorn.dart';
+import '../entities/zodiac_sign_gemini.dart';
+import '../entities/zodiac_sign_leo.dart';
+import '../entities/zodiac_sign_libra.dart';
+import '../entities/zodiac_sign_pisces.dart';
+import '../entities/zodiac_sign_sagittarius.dart';
+import '../entities/zodiac_sign_scorpio.dart';
+import '../entities/zodiac_sign_taurus.dart';
+import '../entities/zodiac_sign_virgo.dart';
 
 class Zodiac {
   final List<IZodiac> _signNames = [
@@ -30,7 +30,7 @@ class Zodiac {
   ];
 
   IZodiac sign(DateTime birthdate) {
-    const List<int> signDays = [0, 22, 20, 21, 21, 22, 23, 23, 23, 23, 22, 22];
+    final signDays = [0, 21, 20, 21, 21, 21, 21, 23, 23, 23, 23, 22, 22];
 
     if (birthdate.day < signDays[birthdate.month]) {
       return _signNames[birthdate.month - 1];

--- a/test/app/features/zodiac/domain/usecases/zodiac_test.dart
+++ b/test/app/features/zodiac/domain/usecases/zodiac_test.dart
@@ -1,0 +1,325 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:penhas/app/features/zodiac/domain/entities/zodiac_sign_aquarius.dart';
+import 'package:penhas/app/features/zodiac/domain/entities/zodiac_sign_aries.dart';
+import 'package:penhas/app/features/zodiac/domain/entities/zodiac_sign_cancer.dart';
+import 'package:penhas/app/features/zodiac/domain/entities/zodiac_sign_capricorn.dart';
+import 'package:penhas/app/features/zodiac/domain/entities/zodiac_sign_gemini.dart';
+import 'package:penhas/app/features/zodiac/domain/entities/zodiac_sign_leo.dart';
+import 'package:penhas/app/features/zodiac/domain/entities/zodiac_sign_libra.dart';
+import 'package:penhas/app/features/zodiac/domain/entities/zodiac_sign_pisces.dart';
+import 'package:penhas/app/features/zodiac/domain/entities/zodiac_sign_sagittarius.dart';
+import 'package:penhas/app/features/zodiac/domain/entities/zodiac_sign_scorpio.dart';
+import 'package:penhas/app/features/zodiac/domain/entities/zodiac_sign_taurus.dart';
+import 'package:penhas/app/features/zodiac/domain/entities/zodiac_sign_virgo.dart';
+import 'package:penhas/app/features/zodiac/domain/usecases/zodiac.dart';
+
+void main() {
+  group(Zodiac, () {
+    late Zodiac sut;
+
+    setUp(() {
+      sut = Zodiac();
+    });
+
+    group('sign', () {
+      group('should return ZodiacSignAries when bithdate is', () {
+        test('03/21', () {
+          // arrange
+          final birthdate = DateTime.parse('1990-03-21');
+
+          // act
+          final result = sut.sign(birthdate);
+
+          // assert
+          expect(result, isA<ZodiacSignAries>());
+        });
+
+        test('04/20', () {
+          // arrange
+          final birthdate = DateTime.parse('1990-04-20');
+
+          // act
+          final result = sut.sign(birthdate);
+
+          // assert
+          expect(result, isA<ZodiacSignAries>());
+        });
+      });
+
+      group('should return ZodiacSignTaurus when bithdate is', () {
+        test('04/21', () {
+          // arrange
+          final birthdate = DateTime.parse('1991-04-21');
+
+          // act
+          final result = sut.sign(birthdate);
+
+          // assert
+          expect(result, isA<ZodiacSignTaurus>());
+        });
+
+        test('05/03', () {
+          // arrange
+          final birthdate = DateTime.parse('1991-05-03');
+
+          // act
+          final result = sut.sign(birthdate);
+
+          // assert
+          expect(result, isA<ZodiacSignTaurus>());
+        });
+
+        test('05/20', () {
+          // arrange
+          final birthdate = DateTime.parse('1991-05-20');
+
+          // act
+          final result = sut.sign(birthdate);
+
+          // assert
+          expect(result, isA<ZodiacSignTaurus>());
+        });
+      });
+
+      group('should return ZodiacSignGemini when bithdate is', () {
+        test('05/21', () {
+          // arrange
+          final birthdate = DateTime.parse('1992-05-21');
+
+          // act
+          final result = sut.sign(birthdate);
+
+          // assert
+          expect(result, isA<ZodiacSignGemini>());
+        });
+
+        test('06/20', () {
+          // arrange
+          final birthdate = DateTime.parse('1992-06-20');
+
+          // act
+          final result = sut.sign(birthdate);
+
+          // assert
+          expect(result, isA<ZodiacSignGemini>());
+        });
+      });
+
+      group('should return ZodiacSignCancer when bithdate is', () {
+        test('06/21', () {
+          // arrange
+          final birthdate = DateTime.parse('1993-06-21');
+
+          // act
+          final result = sut.sign(birthdate);
+
+          // assert
+          expect(result, isA<ZodiacSignCancer>());
+        });
+
+        test('07/22', () {
+          // arrange
+          final birthdate = DateTime.parse('1993-07-22');
+
+          // act
+          final result = sut.sign(birthdate);
+
+          // assert
+          expect(result, isA<ZodiacSignCancer>());
+        });
+      });
+
+      group('should return ZodiacSignLeo when bithdate is', () {
+        test('07/23', () {
+          // arrange
+          final birthdate = DateTime.parse('1994-07-23');
+
+          // act
+          final result = sut.sign(birthdate);
+
+          // assert
+          expect(result, isA<ZodiacSignLeo>());
+        });
+
+        test('08/22', () {
+          // arrange
+          final birthdate = DateTime.parse('1994-08-22');
+
+          // act
+          final result = sut.sign(birthdate);
+
+          // assert
+          expect(result, isA<ZodiacSignLeo>());
+        });
+      });
+
+      group('should return ZodiacSignVirgo when bithdate is', () {
+        test('08/23', () {
+          // arrange
+          final birthdate = DateTime.parse('1995-08-23');
+
+          // act
+          final result = sut.sign(birthdate);
+
+          // assert
+          expect(result, isA<ZodiacSignVirgo>());
+        });
+
+        test('09/22', () {
+          // arrange
+          final birthdate = DateTime.parse('1995-09-22');
+
+          // act
+          final result = sut.sign(birthdate);
+
+          // assert
+          expect(result, isA<ZodiacSignVirgo>());
+        });
+      });
+
+      group('should return ZodiacSignLibra when bithdate is', () {
+        test('09/23', () {
+          // arrange
+          final birthdate = DateTime.parse('1996-09-23');
+
+          // act
+          final result = sut.sign(birthdate);
+
+          // assert
+          expect(result, isA<ZodiacSignLibra>());
+        });
+
+        test('10/22', () {
+          // arrange
+          final birthdate = DateTime.parse('1996-10-22');
+
+          // act
+          final result = sut.sign(birthdate);
+
+          // assert
+          expect(result, isA<ZodiacSignLibra>());
+        });
+      });
+
+      group('should return ZodiacSignScorpio when bithdate is', () {
+        test('10/23', () {
+          // arrange
+          final birthdate = DateTime.parse('1997-10-23');
+
+          // act
+          final result = sut.sign(birthdate);
+
+          // assert
+          expect(result, isA<ZodiacSignScorpio>());
+        });
+
+        test('11/21', () {
+          // arrange
+          final birthdate = DateTime.parse('1997-11-21');
+
+          // act
+          final result = sut.sign(birthdate);
+
+          // assert
+          expect(result, isA<ZodiacSignScorpio>());
+        });
+      });
+
+      group('should return ZodiacSignSagittarius when bithdate is', () {
+        test('11/22', () {
+          // arrange
+          final birthdate = DateTime.parse('1998-11-22');
+
+          // act
+          final result = sut.sign(birthdate);
+
+          // assert
+          expect(result, isA<ZodiacSignSagittarius>());
+        });
+
+        test('12/21', () {
+          // arrange
+          final birthdate = DateTime.parse('1998-12-21');
+
+          // act
+          final result = sut.sign(birthdate);
+
+          // assert
+          expect(result, isA<ZodiacSignSagittarius>());
+        });
+      });
+
+      group('should return ZodiacSignCapricorn when bithdate is', () {
+        test('12/22', () {
+          // arrange
+          final birthdate = DateTime.parse('1999-12-22');
+
+          // act
+          final result = sut.sign(birthdate);
+
+          // assert
+          expect(result, isA<ZodiacSignCapricorn>());
+        });
+
+        test('01/20', () {
+          // arrange
+          final birthdate = DateTime.parse('1999-01-20');
+
+          // act
+          final result = sut.sign(birthdate);
+
+          // assert
+          expect(result, isA<ZodiacSignCapricorn>());
+        });
+      });
+
+      group('should return ZodiacSignAquarius when bithdate is', () {
+        test('01/21', () {
+          // arrange
+          final birthdate = DateTime.parse('2000-01-21');
+
+          // act
+          final result = sut.sign(birthdate);
+
+          // assert
+          expect(result, isA<ZodiacSignAquarius>());
+        });
+
+        test('02/19', () {
+          // arrange
+          final birthdate = DateTime.parse('2000-02-19');
+
+          // act
+          final result = sut.sign(birthdate);
+
+          // assert
+          expect(result, isA<ZodiacSignAquarius>());
+        });
+      });
+
+      group('should return ZodiacSignPisces when bithdate is', () {
+        test('02/20', () {
+          // arrange
+          final birthdate = DateTime.parse('2000-02-20');
+
+          // act
+          final result = sut.sign(birthdate);
+
+          // assert
+          expect(result, isA<ZodiacSignPisces>());
+        });
+
+        test('03/20', () {
+          // arrange
+          final birthdate = DateTime.parse('2000-03-20');
+
+          // act
+          final result = sut.sign(birthdate);
+
+          // assert
+          expect(result, isA<ZodiacSignPisces>());
+        });
+      });
+    });
+  });
+}

--- a/test/app/features/zodiac/domain/usecases/zodiac_test.dart
+++ b/test/app/features/zodiac/domain/usecases/zodiac_test.dart
@@ -22,7 +22,7 @@ void main() {
     });
 
     group('sign', () {
-      group('should return ZodiacSignAries when bithdate is', () {
+      group('should return ZodiacSignAries when birthdate is', () {
         test('03/21', () {
           // arrange
           final birthdate = DateTime.parse('1990-03-21');
@@ -46,7 +46,7 @@ void main() {
         });
       });
 
-      group('should return ZodiacSignTaurus when bithdate is', () {
+      group('should return ZodiacSignTaurus when birthdate is', () {
         test('04/21', () {
           // arrange
           final birthdate = DateTime.parse('1991-04-21');
@@ -81,7 +81,7 @@ void main() {
         });
       });
 
-      group('should return ZodiacSignGemini when bithdate is', () {
+      group('should return ZodiacSignGemini when birthdate is', () {
         test('05/21', () {
           // arrange
           final birthdate = DateTime.parse('1992-05-21');
@@ -105,7 +105,7 @@ void main() {
         });
       });
 
-      group('should return ZodiacSignCancer when bithdate is', () {
+      group('should return ZodiacSignCancer when birthdate is', () {
         test('06/21', () {
           // arrange
           final birthdate = DateTime.parse('1993-06-21');
@@ -129,7 +129,7 @@ void main() {
         });
       });
 
-      group('should return ZodiacSignLeo when bithdate is', () {
+      group('should return ZodiacSignLeo when birthdate is', () {
         test('07/23', () {
           // arrange
           final birthdate = DateTime.parse('1994-07-23');
@@ -153,7 +153,7 @@ void main() {
         });
       });
 
-      group('should return ZodiacSignVirgo when bithdate is', () {
+      group('should return ZodiacSignVirgo when birthdate is', () {
         test('08/23', () {
           // arrange
           final birthdate = DateTime.parse('1995-08-23');
@@ -177,7 +177,7 @@ void main() {
         });
       });
 
-      group('should return ZodiacSignLibra when bithdate is', () {
+      group('should return ZodiacSignLibra when birthdate is', () {
         test('09/23', () {
           // arrange
           final birthdate = DateTime.parse('1996-09-23');
@@ -201,7 +201,7 @@ void main() {
         });
       });
 
-      group('should return ZodiacSignScorpio when bithdate is', () {
+      group('should return ZodiacSignScorpio when birthdate is', () {
         test('10/23', () {
           // arrange
           final birthdate = DateTime.parse('1997-10-23');
@@ -225,7 +225,7 @@ void main() {
         });
       });
 
-      group('should return ZodiacSignSagittarius when bithdate is', () {
+      group('should return ZodiacSignSagittarius when birthdate is', () {
         test('11/22', () {
           // arrange
           final birthdate = DateTime.parse('1998-11-22');
@@ -249,7 +249,7 @@ void main() {
         });
       });
 
-      group('should return ZodiacSignCapricorn when bithdate is', () {
+      group('should return ZodiacSignCapricorn when birthdate is', () {
         test('12/22', () {
           // arrange
           final birthdate = DateTime.parse('1999-12-22');
@@ -273,7 +273,7 @@ void main() {
         });
       });
 
-      group('should return ZodiacSignAquarius when bithdate is', () {
+      group('should return ZodiacSignAquarius when birthdate is', () {
         test('01/21', () {
           // arrange
           final birthdate = DateTime.parse('2000-01-21');
@@ -297,7 +297,7 @@ void main() {
         });
       });
 
-      group('should return ZodiacSignPisces when bithdate is', () {
+      group('should return ZodiacSignPisces when birthdate is', () {
         test('02/20', () {
           // arrange
           final birthdate = DateTime.parse('2000-02-20');


### PR DESCRIPTION
## Objetivo

Corrigir crash causado ao mostrar o horóscopo e também os signos mostrados errados.

## Alterações

- Atualizado os dias para fazer comparação com a data de aniversário;
- Aproveitando e atualzando os imports nos arquivos de signos.