### PR TITLE
Cobertura de teste do DesignSystemColors

### DIFF
--- a/lib/app/shared/design_system/logo.dart
+++ b/lib/app/shared/design_system/logo.dart
@@ -16,7 +16,7 @@
 import 'package:flutter/widgets.dart';
 
 class DesignSystemLogo {
-  DesignSystemLogo._();
+  DesignSystemLogo._(); // coverage:ignore-line
 
   static const _kFontFam = 'DesignSystemLogo';
 

--- a/test/app/shared/design_system/colors_test.dart
+++ b/test/app/shared/design_system/colors_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:penhas/app/shared/design_system/colors.dart';
+
+void main() {
+  group('DesignSystemColors', () {
+    test('hexColor correctly convert a hex string to a Color', () {
+      const hexColor = '#AABBCC';
+      const hexColorWithoutHash = 'AABBCC';
+      const expectedColor = Color(0xFFAABBCC);
+
+      expect(DesignSystemColors.hexColor(hexColor), expectedColor);
+      expect(DesignSystemColors.hexColor(hexColorWithoutHash), expectedColor);
+    });
+
+    test('hexColor correctly convert a hex string with alpha to a Color', () {
+      const hexColor = '#AABBCCDD';
+      const hexColorWithoutHash = 'AABBCCDD';
+      const expectedColor = Color(0xAABBCCDD);
+
+      expect(DesignSystemColors.hexColor(hexColor), expectedColor);
+      expect(DesignSystemColors.hexColor(hexColorWithoutHash), expectedColor);
+    });
+  });
+}

--- a/test/app/shared/design_system/colors_test.dart
+++ b/test/app/shared/design_system/colors_test.dart
@@ -21,5 +21,10 @@ void main() {
       expect(DesignSystemColors.hexColor(hexColor), expectedColor);
       expect(DesignSystemColors.hexColor(hexColorWithoutHash), expectedColor);
     });
+
+    test('return a Exceptions for an invalid hexColor', () {
+      expect(() => DesignSystemColors.hexColor('invalid_hex'),
+          throwsA(isA<Exception>()));
+    });
   });
 }

--- a/test/app/shared/design_system/colors_test.dart
+++ b/test/app/shared/design_system/colors_test.dart
@@ -22,7 +22,7 @@ void main() {
       expect(DesignSystemColors.hexColor(hexColorWithoutHash), expectedColor);
     });
 
-    test('return a Exceptions for an invalid hexColor', () {
+    test('return Exception for an invalid hexColor', () {
       expect(() => DesignSystemColors.hexColor('invalid_hex'),
           throwsA(isA<Exception>()));
     });


### PR DESCRIPTION
## Objetivo

Escrever testes para o DesignSystemColors e atingir a meta de cobertura para esta classe

## Execução

1. Criado os testes para o DesignSystemColors
2. Desativado coverage onde não é possível testar
