### PR TITLE
[Bugfix] Nossa assinatura do mapFailureMessage cria warnning no FeedController

### DIFF
--- a/lib/app/features/feed/presentation/feed_controller.dart
+++ b/lib/app/features/feed/presentation/feed_controller.dart
@@ -105,7 +105,7 @@ abstract class _FeedControllerBase with Store, MapFailureMessage {
     final failureMessage = mapFailureMessage(failure);
 
     if (state.isEmpty) {
-      state = FeedState.error(failureMessage!);
+      state = FeedState.error(failureMessage);
     } else {
       errorMessage = failureMessage;
     }


### PR DESCRIPTION
# Objetivo

O pr (pull request) #75 introduz um warning no código.

Foi alterado a assinatura do método [mapFailureMessage](https://github.com/institutoazmina/penhas-app/blob/847d5a1e6b1d149e66df0b2a22ebda5af591bb8f/lib/app/features/authentication/presentation/shared/map_failure_message.dart#L12) sem ajustar quem consome este método.

Neste momento está ocorrendo warnning no FeedController devido ao `force unwrap` que era utilizado antes.

# Execução

Ajustado o consumo do `mapFailureMessage` no FeedController.
