### PR TITLE
Cobertura de teste do domain no feature MainBoard

### DIFF
--- a/lib/app/features/mainboard/domain/states/mainboard_store.dart
+++ b/lib/app/features/mainboard/domain/states/mainboard_store.dart
@@ -1,12 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:mobx/mobx.dart';
-import 'package:penhas/app/core/managers/modules_sevices.dart';
-import 'package:penhas/app/features/chat/domain/usecases/chat_toggle_feature.dart';
-import 'package:penhas/app/features/feed/domain/usecases/feed_toggle_feature.dart';
-import 'package:penhas/app/features/feed/domain/usecases/tweet_toggle_feature.dart';
-import 'package:penhas/app/features/help_center/domain/usecases/security_mode_action_feature.dart';
-import 'package:penhas/app/features/mainboard/domain/states/mainboard_state.dart';
-import 'package:penhas/app/features/support_center/domain/usecases/support_center_toggle_feature.dart';
+
+import '../../../../core/managers/modules_sevices.dart';
+import '../../../chat/domain/usecases/chat_toggle_feature.dart';
+import '../../../feed/domain/usecases/feed_toggle_feature.dart';
+import '../../../feed/domain/usecases/tweet_toggle_feature.dart';
+import '../../../help_center/domain/usecases/security_mode_action_feature.dart';
+import '../../../support_center/domain/usecases/support_center_toggle_feature.dart';
+import 'mainboard_state.dart';
 
 part 'mainboard_store.g.dart';
 
@@ -14,14 +15,20 @@ class MainboardStore extends _MainboardStoreBase with _$MainboardStore {
   MainboardStore({
     required IAppModulesServices modulesServices,
     required MainboardState initialPage,
-  }) : super(modulesServices, initialPage);
+    PageController? pageController,
+  }) : super(modulesServices, initialPage, pageController ?? PageController());
 }
 
 abstract class _MainboardStoreBase with Store {
-  _MainboardStoreBase(this._modulesServices, this._initialPage);
+  _MainboardStoreBase(
+    this._modulesServices,
+    this._initialPage,
+    this._pageController,
+  );
 
   final IAppModulesServices _modulesServices;
   final MainboardState _initialPage;
+  final PageController _pageController;
   late final Future setupProgress = setup();
 
   late final PageController pageController = _buildPageCtrl();
@@ -35,7 +42,7 @@ abstract class _MainboardStoreBase with Store {
 
   PageController _buildPageCtrl() {
     setupProgress.then((value) => null); // initialize when ctrl is attached
-    return PageController();
+    return _pageController;
   }
 
   @action

--- a/penhas.code-workspace
+++ b/penhas.code-workspace
@@ -18,6 +18,7 @@
 		},
 		"cSpell.words": [
 			"datasources",
+			"mainboard",
 			"mocktail",
 			"penhas",
 			"usecases"

--- a/test/app/features/mainboard/domain/states/mainboard_state_test.dart
+++ b/test/app/features/mainboard/domain/states/mainboard_state_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:penhas/app/features/mainboard/domain/states/mainboard_state.dart';
+
+void main() {
+  group(MainboardState, () {
+    test('returns Feed state when fromString is called with "feed"', () {
+      // arrange
+      const expectedState = MainboardState.feed();
+      const inputString = 'feed';
+      // act
+      final result = MainboardState.fromString(inputString);
+      // assert
+      expect(result, equals(expectedState));
+    });
+
+    test('returns Chat state when fromString is called with "chat"', () {
+      // arrange
+      const expectedState = MainboardState.chat();
+      const inputString = 'chat';
+      // act
+      final result = MainboardState.fromString(inputString);
+      // assert
+      expect(result, equals(expectedState));
+    });
+
+    test('returns Compose state when fromString is called with "compose"', () {
+      // arrange
+      const expectedState = MainboardState.compose();
+      const inputString = 'compose';
+      // act
+      final result = MainboardState.fromString(inputString);
+      // assert
+      expect(result, equals(expectedState));
+    });
+
+    test(
+        'returns SupportPoint state when fromString is called with "supportpoint"',
+        () {
+      // arrange
+      const expectedState = MainboardState.supportPoint();
+      const inputString = 'supportpoint';
+      // act
+      final result = MainboardState.fromString(inputString);
+      // assert
+      expect(result, equals(expectedState));
+    });
+
+    test('returns HelpCenter state when fromString is called with "helpcenter"',
+        () {
+      // arrange
+      const expectedState = MainboardState.helpCenter();
+      const inputString = 'helpcenter';
+      // act
+      final result = MainboardState.fromString(inputString);
+      // assert
+      expect(result, equals(expectedState));
+    });
+
+    test(
+        'returns Feed state when fromString is called with an unrecognized string',
+        () {
+      // arrange
+      const expectedState = MainboardState.feed();
+      const inputString = 'unrecognized';
+      // act
+      final result = MainboardState.fromString(inputString);
+      // assert
+      expect(result, equals(expectedState));
+    });
+
+    test('returns Feed state when fromString is called with null', () {
+      // arrange
+      const expectedState = MainboardState.feed();
+      const inputString = null;
+      // act
+      final result = MainboardState.fromString(inputString);
+      // assert
+      expect(result, equals(expectedState));
+    });
+  });
+}

--- a/test/app/features/mainboard/domain/states/mainboard_store_test.dart
+++ b/test/app/features/mainboard/domain/states/mainboard_store_test.dart
@@ -1,0 +1,79 @@
+// ignore_for_file: prefer_const_constructors
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:penhas/app/core/managers/modules_sevices.dart';
+import 'package:penhas/app/features/appstate/domain/entities/app_state_entity.dart';
+import 'package:penhas/app/features/mainboard/domain/states/mainboard_state.dart';
+import 'package:penhas/app/features/mainboard/domain/states/mainboard_store.dart';
+
+void main() {
+  group(MainboardStore, () {
+    late MainboardStore store;
+    late IAppModulesServices mockServices;
+    late PageController pageController;
+
+    setUp(() {
+      mockServices = MockIAppModulesServices();
+      pageController = MockPageController();
+      when(() => mockServices.feature(name: any(named: 'name')))
+          .thenAnswer((_) async => FakeAppStateModuleEntity());
+      when(() => mockServices.isEnabled(any())).thenAnswer((_) async => true);
+
+      store = MainboardStore(
+        modulesServices: mockServices,
+        initialPage: const MainboardState.feed(),
+        pageController: pageController,
+      );
+    });
+
+    test('initializes with the correct initial page', () {
+      // arrange
+      const expectedPage = MainboardState.feed();
+      // act
+      final result = store.selectedPage;
+      // assert
+      expect(result, equals(expectedPage));
+    });
+
+    test('setupProgress initializes with the correct pages', () async {
+      // arrange
+      const expectedPages = [
+        MainboardState.feed(),
+        MainboardState.compose(),
+        MainboardState.helpCenter(),
+        MainboardState.chat(),
+        MainboardState.supportPoint(),
+      ];
+      // act
+      await store.setupProgress;
+      final result = store.pages;
+      // assert
+      expect(result, equals(expectedPages));
+      verify(
+        () => pageController.jumpToPage(
+          expectedPages.indexOf(const MainboardState.feed()),
+        ),
+      ).called(1);
+    });
+
+    test('jumps to the correct page when changePage is called', () async {
+      // arrange
+      await store.setupProgress;
+      final expectedPage = MainboardState.chat();
+      final expectedIndex = store.pages.indexOf(expectedPage);
+      // act
+      await store.changePage(to: expectedPage);
+      // assert
+      expect(store.selectedPage, equals(expectedPage));
+      verify(() => pageController.jumpToPage(expectedIndex)).called(1);
+    });
+  });
+}
+
+class MockIAppModulesServices extends Mock implements IAppModulesServices {}
+
+class FakeAppStateModuleEntity extends Fake implements AppStateModuleEntity {}
+
+class MockPageController extends Mock implements PageController {}


### PR DESCRIPTION
## Objetivo

Escrever, ou ajustar, os testes aumentar a cobertura de teste no Domain da feature MainBoard

## Execução

1. Criado teste onde ainda não tinha cobertura de teste
2. Ajustado a classe  MainboardStore
