### PR TITLE
Fix CastError 'StreamedResponse' is not a subtype of type 'Response'

### DIFF
--- a/lib/app/core/network/api_client.dart
+++ b/lib/app/core/network/api_client.dart
@@ -189,7 +189,11 @@ extension _ApiProvider on ApiProvider {
 
     final statusCode = response.statusCode;
     if (successfulResponse.contains(statusCode)) {
-      return response as Response;
+      if (response is StreamedResponse) {
+        return Response.fromStream(response);
+      } else {
+        return response as Response;
+      }
     }
 
     // Tratamento dos códigos com erro


### PR DESCRIPTION
Conserta o erro  `_CastError (type 'StreamedResponse' is not a subtype of type 'Response' in type cast)` que estava sendo levantado no api client.