### PR TITLE
Bump mobx

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -450,7 +450,7 @@ packages:
       name: flutter_mobx
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.5"
   flutter_modular:
     dependency: "direct main"
     description:
@@ -900,7 +900,7 @@ packages:
       name: mobx
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.5"
+    version: "2.0.6"
   mobx_codegen:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,7 +39,7 @@ dependencies:
   firebase_analytics: ^9.3.0
   firebase_core: ^1.20.1
   firebase_crashlytics: ^2.8.7
-  flutter_mobx: ^2.0.2
+  flutter_mobx: ^2.0.5
   flutter_modular:
     git:
       url: https://github.com/pedrox-hs/modular.git


### PR DESCRIPTION
Corrige a mensagem "No observables detected in the build method of Observer" durante os testes unitários de widgets, mencionado na issue: https://github.com/mobxjs/mobx.dart/issues/676