### PR TITLE
Adiciona model de dados para QuizSession

### DIFF
--- a/lib/app/features/appstate/data/model/app_state_model.dart
+++ b/lib/app/features/appstate/data/model/app_state_model.dart
@@ -1,9 +1,11 @@
 import 'dart:convert';
 
 import 'package:collection/collection.dart';
-import 'package:penhas/app/features/appstate/data/model/user_profile_model.dart';
-import 'package:penhas/app/features/appstate/domain/entities/app_state_entity.dart';
-import 'package:penhas/app/features/appstate/domain/entities/user_profile_entity.dart';
+
+import '../../domain/entities/app_state_entity.dart';
+import '../../domain/entities/user_profile_entity.dart';
+import 'quiz_session_model.dart';
+import 'user_profile_model.dart';
 
 class AppStateModel extends AppStateEntity {
   const AppStateModel(
@@ -36,33 +38,7 @@ class AppStateModel extends AppStateEntity {
     if (session == null || session.isEmpty) {
       return null;
     }
-
-    final currentMessage = _parseQuizMessage(session['current_msgs']);
-    final previousMessage = _parseQuizMessage(session['prev_msgs']);
-    final isFinished = session['finished'] != null && session['finished'] == 1;
-
-    if (previousMessage != null) {
-      currentMessage?.insertAll(0, previousMessage);
-    }
-
-    final String sessionId = "${session['session_id']}";
-    return QuizSessionEntity(
-      currentMessage: currentMessage,
-      sessionId: sessionId,
-      isFinished: isFinished,
-      endScreen: session['end_screen'],
-    );
-  }
-
-  static List<QuizMessageEntity>? _parseQuizMessage(List<dynamic>? data) {
-    if (data == null || data.isEmpty) {
-      return null;
-    }
-
-    return data
-        .map((e) => e as Map<String, dynamic>)
-        .expand((e) => _buildMessage(e))
-        .toList();
+    return QuizSessionModel.fromJson(session);
   }
 
   static List<AppStateModuleEntity> _parseAppModules(List<dynamic>? data) {
@@ -86,74 +62,6 @@ class AppStateModel extends AppStateEntity {
     final String meta =
         module['meta'] == null ? '{}' : jsonEncode(module['meta']);
     return AppStateModuleEntity(code: code, meta: meta);
-  }
-
-  static List<QuizMessageEntity> _buildMessage(Map<String, dynamic> message) {
-    if (message['display_response'] != null) {
-      return _buildDisplayResponseMessage(message);
-    }
-
-    return [
-      QuizMessageEntity(
-        content: message['content'],
-        ref: message['ref'] ?? '',
-        style: message['style'],
-        action: message['action'],
-        buttonLabel: message['label'],
-        type: _mapMessageType(message),
-        options: _mapToOptions(message['options']),
-      )
-    ];
-  }
-
-  static QuizMessageType _mapMessageType(Map<String, dynamic> message) {
-    QuizMessageType type = QuizMessageType.from[message['type'] as String];
-    if (message['action'] == 'botao_tela_modo_camuflado') {
-      type = QuizMessageType.showStealthTutorial;
-    }
-    if (message['action'] == 'botao_tela_socorro') {
-      type = QuizMessageType.showHelpTutorial;
-    }
-    if (message['action'] == 'reload') {
-      type = QuizMessageType.forceReload;
-    }
-
-    return type;
-  }
-
-  static List<QuizMessageEntity> _buildDisplayResponseMessage(
-    Map<String, dynamic> message,
-  ) {
-    return [
-      QuizMessageEntity(
-        content: message['content'],
-        type: QuizMessageType.displayText,
-        style: 'normal',
-      ),
-      QuizMessageEntity(
-        content: message['display_response'],
-        type: QuizMessageType.displayTextResponse,
-        style: 'normal',
-      )
-    ];
-  }
-
-  static List<QuizMessageMultiplechoicesOptions>? _mapToOptions(
-    List<dynamic>? options,
-  ) {
-    if (options == null || options.isEmpty) {
-      return null;
-    }
-
-    return options
-        .map((e) => e as Map<String, dynamic>)
-        .map(
-          (e) => QuizMessageMultiplechoicesOptions(
-            index: e['index'],
-            display: e['display'],
-          ),
-        )
-        .toList();
   }
 
   static UserProfileEntity? _parseUserProfile(Map<String, dynamic>? jsonData) {

--- a/lib/app/features/appstate/data/model/quiz_session_model.dart
+++ b/lib/app/features/appstate/data/model/quiz_session_model.dart
@@ -1,0 +1,134 @@
+import '../../domain/entities/app_state_entity.dart';
+
+class QuizSessionModel extends QuizSessionEntity {
+  const QuizSessionModel({
+    required String sessionId,
+    List<QuizMessageEntity>? currentMessage,
+    bool isFinished = false,
+    String? endScreen,
+  }) : super(
+          currentMessage: currentMessage,
+          sessionId: sessionId,
+          isFinished: isFinished,
+          endScreen: endScreen,
+        );
+
+  factory QuizSessionModel.fromJson(Map<String, dynamic> jsonData) {
+    final currentMessage = jsonData['current_msgs'] ?? [];
+    final previousMessage = jsonData['prev_msgs'] ?? [];
+    final messages = _parseQuizMessage(previousMessage + currentMessage);
+
+    final isFinished = jsonData['finished'] == 1;
+
+    return QuizSessionModel(
+      sessionId: "${jsonData['session_id']}",
+      currentMessage: messages,
+      endScreen: jsonData['end_screen'],
+      isFinished: isFinished,
+    );
+  }
+
+  static List<QuizMessageModel>? _parseQuizMessage(List<dynamic> data) {
+    if (data.isEmpty) return null;
+
+    return data
+        .map((e) => e as Map<String, dynamic>)
+        .expand((e) => _buildMessage(e))
+        .toList();
+  }
+
+  static List<QuizMessageModel> _buildMessage(Map<String, dynamic> message) {
+    if (message['display_response'] != null) {
+      return _buildDisplayResponseMessage(message);
+    }
+
+    return [
+      QuizMessageModel.fromJson(message),
+    ];
+  }
+
+  static List<QuizMessageModel> _buildDisplayResponseMessage(
+    Map<String, dynamic> message,
+  ) {
+    return [
+      QuizMessageModel(
+        content: message['content'],
+        type: QuizMessageType.displayText,
+        style: 'normal',
+      ),
+      QuizMessageModel(
+        content: message['display_response'],
+        type: QuizMessageType.displayTextResponse,
+        style: 'normal',
+      )
+    ];
+  }
+}
+
+class QuizMessageModel extends QuizMessageEntity {
+  const QuizMessageModel({
+    required String? content,
+    required QuizMessageType type,
+    String? ref,
+    String? style,
+    String? action,
+    String? buttonLabel,
+    List<QuizMessageMultiplechoicesOptions>? options,
+  }) : super(
+          content: content,
+          type: type,
+          ref: ref ?? '',
+          style: style,
+          action: action,
+          buttonLabel: buttonLabel,
+          options: options,
+        );
+
+  factory QuizMessageModel.fromJson(Map<String, dynamic> jsonData) {
+    final QuizMessageType type = _parseMessageType(jsonData);
+    final List<MultiplechoicesOptionModel>? options =
+        _parseOptions(jsonData['options'] ?? []);
+
+    return QuizMessageModel(
+      content: jsonData['content'],
+      type: type,
+      ref: jsonData['ref'],
+      style: jsonData['style'],
+      action: jsonData['action'],
+      buttonLabel: jsonData['label'],
+      options: options,
+    );
+  }
+
+  static QuizMessageType _parseMessageType(Map<String, dynamic> message) {
+    switch (message['action']) {
+      case 'botao_tela_modo_camuflado':
+        return QuizMessageType.showStealthTutorial;
+      case 'botao_tela_socorro':
+        return QuizMessageType.showHelpTutorial;
+      case 'reload':
+        return QuizMessageType.forceReload;
+      default:
+        return QuizMessageType.values.byName(message['type'] as String);
+    }
+  }
+
+  static List<MultiplechoicesOptionModel>? _parseOptions(List<dynamic> data) {
+    if (data.isEmpty) return null;
+    return data.map((e) => MultiplechoicesOptionModel.fromJson(e)).toList();
+  }
+}
+
+class MultiplechoicesOptionModel extends QuizMessageMultiplechoicesOptions {
+  const MultiplechoicesOptionModel({
+    required String? display,
+    required String? index,
+  }) : super(display: display, index: index);
+
+  factory MultiplechoicesOptionModel.fromJson(Map<String, dynamic> jsonData) {
+    return MultiplechoicesOptionModel(
+      display: jsonData['display'],
+      index: '${jsonData['index']}',
+    );
+  }
+}

--- a/lib/app/features/appstate/domain/entities/app_state_entity.dart
+++ b/lib/app/features/appstate/domain/entities/app_state_entity.dart
@@ -4,7 +4,6 @@ import 'package:meta/meta.dart';
 import 'user_profile_entity.dart';
 
 enum QuizMessageType {
-  from,
   button,
   yesno,
   displayText,
@@ -15,31 +14,24 @@ enum QuizMessageType {
   displayTextResponse,
 }
 
-extension QuizMessageTypeExtension on QuizMessageType {
-  QuizMessageType operator [](String key) {
-    var type = QuizMessageType.displayText;
+extension QuizMessageTypeExtension on List<QuizMessageType> {
+  QuizMessageType byName(String key) {
     switch (key.toLowerCase()) {
       case 'button':
-        type = QuizMessageType.button;
-        break;
+        return QuizMessageType.button;
       case 'show_tutorial':
-        type = QuizMessageType.showStealthTutorial;
-        break;
+        return QuizMessageType.showStealthTutorial;
       case 'yesno':
-        type = QuizMessageType.yesno;
-        break;
+        return QuizMessageType.yesno;
       case 'displaytext':
-        type = QuizMessageType.displayText;
-        break;
+        return QuizMessageType.displayText;
       case 'display_response':
-        type = QuizMessageType.displayTextResponse;
-        break;
+        return QuizMessageType.displayTextResponse;
       case 'multiplechoices':
-        type = QuizMessageType.multipleChoices;
-        break;
+        return QuizMessageType.multipleChoices;
+      default:
+        return QuizMessageType.displayText;
     }
-
-    return type;
   }
 }
 

--- a/lib/app/features/quiz/presentation/quiz/quiz_user_replay_widget.dart
+++ b/lib/app/features/quiz/presentation/quiz/quiz_user_replay_widget.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
-import 'package:penhas/app/features/appstate/domain/entities/app_state_entity.dart';
 
-import 'package:penhas/app/features/quiz/presentation/quiz/quiz_button_yes_no_widget.dart';
-import 'package:penhas/app/features/quiz/presentation/quiz/quiz_multiple_choices_widget.dart';
-import 'package:penhas/app/features/quiz/presentation/quiz/quiz_show_help_tutorial_widget.dart';
-import 'package:penhas/app/features/quiz/presentation/quiz/quiz_show_stealth_tutorial_widget.dart';
-import 'package:penhas/app/features/quiz/presentation/quiz/quiz_single_button.dart';
-import 'package:penhas/app/features/quiz/presentation/quiz/quiz_typedef.dart';
+import '../../../appstate/domain/entities/app_state_entity.dart';
+import 'quiz_button_yes_no_widget.dart';
+import 'quiz_multiple_choices_widget.dart';
+import 'quiz_show_help_tutorial_widget.dart';
+import 'quiz_show_stealth_tutorial_widget.dart';
+import 'quiz_single_button.dart';
+import 'quiz_typedef.dart';
 
 class QuizUserReplayWidget extends StatelessWidget {
   const QuizUserReplayWidget({
@@ -50,7 +50,6 @@ class QuizUserReplayWidget extends StatelessWidget {
           options: message.options,
           onPressed: onActionReplay,
         );
-      case QuizMessageType.from:
       case QuizMessageType.forceReload:
       case QuizMessageType.displayText:
       case QuizMessageType.displayTextResponse:

--- a/test/app/features/appstate/data/models/app_state_model_test.dart
+++ b/test/app/features/appstate/data/models/app_state_model_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:penhas/app/features/appstate/data/model/app_state_model.dart';
+import 'package:penhas/app/features/appstate/data/model/quiz_session_model.dart';
 import 'package:penhas/app/features/appstate/data/model/user_profile_model.dart';
 import 'package:penhas/app/features/appstate/domain/entities/app_state_entity.dart';
 
@@ -23,14 +24,13 @@ void main() {
   group('AppStateModel', () {
     test('should be a subclass of AppStateEntity', () async {
       // arrange
-      const session = QuizSessionEntity(
-          currentMessage: [],
-          sessionId: '1',
-          endScreen: 'home',
-          isFinished: false,);
-      const appMode = AppStateModeEntity(
-        
+      const session = QuizSessionModel(
+        currentMessage: [],
+        sessionId: '1',
+        endScreen: 'home',
+        isFinished: false,
       );
+      const appMode = AppStateModeEntity();
       final List<AppStateModuleEntity> modes = [];
       // act
       appStateModel = AppStateModel(session, userProfile, appMode, modes);
@@ -40,19 +40,19 @@ void main() {
 
     List<QuizMessageEntity> _currentMessage() {
       return [
-        const QuizMessageEntity(
+        const QuizMessageModel(
           content:
               'Olá, eu sou a Assistente PenhaS ☺️ e vou te ajudar a conhecer o aplicativo 🤳',
           type: QuizMessageType.displayText,
           style: 'normal',
         ),
-        const QuizMessageEntity(
+        const QuizMessageModel(
           content:
               'Vou começar com algumas perguntas, para saber melhor como te ajudar',
           type: QuizMessageType.displayText,
           style: 'normal',
         ),
-        const QuizMessageEntity(
+        const QuizMessageModel(
           content: 'Atualmente, você está em um relacionamento amoroso?',
           type: QuizMessageType.yesno,
           ref: 'YN1',
@@ -62,29 +62,29 @@ void main() {
 
     List<QuizMessageEntity> _currentMessageWithPrevious() {
       return [
-        const QuizMessageEntity(
+        const QuizMessageModel(
           content:
               'Olá, eu sou a Assistente PenhaS ☺️ e vou te ajudar a conhecer o aplicativo 🤳',
           type: QuizMessageType.displayText,
           style: 'normal',
         ),
-        const QuizMessageEntity(
+        const QuizMessageModel(
           content:
               'Vou começar com algumas perguntas, para saber melhor como te ajudar',
           type: QuizMessageType.displayText,
           style: 'normal',
         ),
-        const QuizMessageEntity(
+        const QuizMessageModel(
           content: 'Atualmente, você está em um relacionamento amoroso?',
           type: QuizMessageType.displayText,
           style: 'normal',
         ),
-        const QuizMessageEntity(
+        const QuizMessageModel(
           content: 'Sim',
           type: QuizMessageType.displayTextResponse,
           style: 'normal',
         ),
-        const QuizMessageEntity(
+        const QuizMessageModel(
           content:
               'Você acredita que tem uma relação saudável com o seu parceiro ou parceira?',
           type: QuizMessageType.yesno,
@@ -95,36 +95,41 @@ void main() {
 
     List<QuizMessageEntity> _currentMessageWithMultipleChoices() {
       return [
-        const QuizMessageEntity(
-            content:
-                'Que tal nos contar um pouco como você acha que pode ajudar outras mulheres? Suas opções ficarão visíveis para as outras usuárias',
-            type: QuizMessageType.multipleChoices,
-            ref: 'MC7',
-            options: [
-              QuizMessageMultiplechoicesOptions(
-                  index: '0', display: 'Escuta acolhedora',),
-              QuizMessageMultiplechoicesOptions(
-                  index: '1', display: 'Psicologia',),
-              QuizMessageMultiplechoicesOptions(index: '2', display: 'Abrigo'),
-            ],),
+        const QuizMessageModel(
+          content:
+              'Que tal nos contar um pouco como você acha que pode ajudar outras mulheres? Suas opções ficarão visíveis para as outras usuárias',
+          type: QuizMessageType.multipleChoices,
+          ref: 'MC7',
+          options: [
+            MultiplechoicesOptionModel(
+              index: '0',
+              display: 'Escuta acolhedora',
+            ),
+            MultiplechoicesOptionModel(
+              index: '1',
+              display: 'Psicologia',
+            ),
+            MultiplechoicesOptionModel(index: '2', display: 'Abrigo'),
+          ],
+        ),
       ];
     }
 
     List<QuizMessageEntity> _currentMessageWithTutorialStealth() {
       return [
-        const QuizMessageEntity(
+        const QuizMessageModel(
           content:
               'Fulana da Silva, pelas suas respostas avalio que você está em situação de risco ⚠️',
           type: QuizMessageType.displayText,
           style: 'normal',
         ),
-        const QuizMessageEntity(
+        const QuizMessageModel(
           content:
               'Para garantir sua segurança, nenhuma outra usuária do PenhaS saberá sua identidade e você terá um perfil anônimo 👭',
           type: QuizMessageType.displayText,
           style: 'normal',
         ),
-        const QuizMessageEntity(
+        const QuizMessageModel(
           content:
               'Também recomendamos que você utilize o PenhaS com o <b>Modo Camuflado ativado</b>. Isso criará um disfarce para o app. Veja como funciona',
           type: QuizMessageType.showStealthTutorial,
@@ -137,7 +142,7 @@ void main() {
 
     List<QuizMessageEntity> _currentMessageWithSingleButton() {
       return [
-        const QuizMessageEntity(
+        const QuizMessageModel(
           content:
               'Lindo 💜 Obrigada! Assim você nos ajuda a construir um ambiente em que mais mulheres se sintam mais seguras 🤗',
           type: QuizMessageType.button,
@@ -151,7 +156,8 @@ void main() {
     List<AppStateModuleEntity> _currentModules() {
       return [
         const AppStateModuleEntity(code: 'modo_anonimo', meta: '{}'),
-        const AppStateModuleEntity(code: 'modo_seguranca', meta: '{"numero":"000"}'),
+        const AppStateModuleEntity(
+            code: 'modo_seguranca', meta: '{"numero":"000"}'),
         const AppStateModuleEntity(code: 'modo_camuflado', meta: '{}'),
       ];
     }
@@ -162,7 +168,7 @@ void main() {
       final jsonData =
           await JsonUtil.getJson(from: 'profile/about_with_quiz_session.json');
       final List<QuizMessageEntity> currentMessage = _currentMessage();
-      final QuizSessionEntity quizSession = QuizSessionEntity(
+      final QuizSessionEntity quizSession = QuizSessionModel(
         currentMessage: currentMessage,
         sessionId: '200',
         endScreen: null,
@@ -189,18 +195,17 @@ void main() {
         () async {
       // arrange
       final jsonData = await JsonUtil.getJson(
-          from: 'profile/quiz_session_response_with_previous_message.json',);
+        from: 'profile/quiz_session_response_with_previous_message.json',
+      );
       final List<QuizMessageEntity> currentMessage =
           _currentMessageWithPrevious();
-      final QuizSessionEntity quizSession = QuizSessionEntity(
+      final QuizSessionEntity quizSession = QuizSessionModel(
         currentMessage: currentMessage,
         sessionId: '247',
         endScreen: null,
         isFinished: false,
       );
-      const appMode = AppStateModeEntity(
-        
-      );
+      const appMode = AppStateModeEntity();
       final modules = _currentModules();
       final userProfile = UserProfileModel(
         nickname: 'maria',
@@ -228,18 +233,17 @@ void main() {
         () async {
       // arrange
       final jsonData = await JsonUtil.getJson(
-          from: 'profile/quiz_session_resonse_multiple_choices.json',);
+        from: 'profile/quiz_session_resonse_multiple_choices.json',
+      );
       final List<QuizMessageEntity> currentMessage =
           _currentMessageWithMultipleChoices();
-      final QuizSessionEntity quizSession = QuizSessionEntity(
+      final QuizSessionEntity quizSession = QuizSessionModel(
         currentMessage: currentMessage,
         sessionId: '255',
         endScreen: null,
         isFinished: false,
       );
-      const appMode = AppStateModeEntity(
-        
-      );
+      const appMode = AppStateModeEntity();
       final modules = _currentModules();
       final userProfile = UserProfileModel(
         nickname: 'maria',
@@ -266,10 +270,11 @@ void main() {
     test('should return a valid model with JSON with showTutorial', () async {
       // arrange
       final jsonData = await JsonUtil.getJson(
-          from: 'profile/quiz_session_response_stealth_mode.json',);
+        from: 'profile/quiz_session_response_stealth_mode.json',
+      );
       final List<QuizMessageEntity> currentMessage =
           _currentMessageWithTutorialStealth();
-      final QuizSessionEntity quizSession = QuizSessionEntity(
+      final QuizSessionEntity quizSession = QuizSessionModel(
         currentMessage: currentMessage,
         sessionId: '200',
         endScreen: null,
@@ -294,18 +299,17 @@ void main() {
     test('should return a valid model with JSON with single button', () async {
       // arrange
       final jsonData = await JsonUtil.getJson(
-          from: 'profile/quiz_session_response_button_fim.json',);
+        from: 'profile/quiz_session_response_button_fim.json',
+      );
       final List<QuizMessageEntity> currentMessage =
           _currentMessageWithSingleButton();
-      final QuizSessionEntity quizSession = QuizSessionEntity(
+      final QuizSessionEntity quizSession = QuizSessionModel(
         currentMessage: currentMessage,
         sessionId: '310',
         endScreen: 'home',
         isFinished: true,
       );
-      const appMode = AppStateModeEntity(
-        
-      );
+      const appMode = AppStateModeEntity();
       final modules = _currentModules();
       final AppStateEntity expected = AppStateModel(
         quizSession,

--- a/test/app/features/chat/data/models/chat_channel_available_model_test.dart
+++ b/test/app/features/chat/data/models/chat_channel_available_model_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:penhas/app/features/appstate/data/model/quiz_session_model.dart';
 import 'package:penhas/app/features/appstate/domain/entities/app_state_entity.dart';
 import 'package:penhas/app/features/chat/data/models/chat_assistant_model.dart';
 import 'package:penhas/app/features/chat/data/models/chat_channel_available_model.dart';
@@ -73,12 +74,13 @@ void main() {
           avatar: null,
           title: 'Assistente PenhaS',
           subtitle: 'Entenda se você está em situação de violência',
-          quizSession: QuizSessionEntity(
+          quizSession: QuizSessionModel(
             currentMessage: [
-              QuizMessageEntity(
-                  content: 'Deseja responder o questionário novamente?',
-                  type: QuizMessageType.yesno,
-                  ref: 'reset_questionnaire',)
+              QuizMessageModel(
+                content: 'Deseja responder o questionário novamente?',
+                type: QuizMessageType.yesno,
+                ref: 'reset_questionnaire',
+              ),
             ],
             sessionId: 'Ada24',
             isFinished: false,
@@ -116,12 +118,13 @@ void main() {
           avatar: null,
           title: 'Assistente PenhaS',
           subtitle: 'Entenda se você está em situação de violência',
-          quizSession: QuizSessionEntity(
+          quizSession: QuizSessionModel(
             currentMessage: [
-              QuizMessageEntity(
-                  content: 'Deseja responder o questionário novamente?',
-                  type: QuizMessageType.yesno,
-                  ref: 'reset_questionnaire',)
+              QuizMessageModel(
+                content: 'Deseja responder o questionário novamente?',
+                type: QuizMessageType.yesno,
+                ref: 'reset_questionnaire',
+              ),
             ],
             sessionId: 'Ada24',
             isFinished: false,


### PR DESCRIPTION
A sessão do quiz será utilizada também para o manual de fuga, portanto houve a necessidade de extrair o mapeamento do `QuizSessionEntity` de dentro de `AppStateModel`, necessitando também que fossem criados novos modelos de dados.