### PR TITLE
Correção crash do secure storage

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -24,6 +24,7 @@
     <application
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
+        android:allowBackup="false"
         android:label="@string/app_name">
         <activity
             android:name=".MainActivity"

--- a/lib/app/core/storage/secure_local_storage.dart
+++ b/lib/app/core/storage/secure_local_storage.dart
@@ -5,7 +5,9 @@ import 'i_local_storage.dart';
 
 class SecureLocalStorage implements ILocalStorage {
   factory SecureLocalStorage({
-    FlutterSecureStorage storage = const FlutterSecureStorage(),
+    FlutterSecureStorage storage = const FlutterSecureStorage(
+      aOptions: AndroidOptions(resetOnError: true),
+    ),
   }) =>
       SecureLocalStorage._(storage, {});
 


### PR DESCRIPTION
- Foi desabilitado o auto backup do Android;
- Ao dar erro no secure storage, reseta o mesmo para não inviabilizar o uso do app.