### PR TITLE
Relaxar algumas regras de linter para testes

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -2,9 +2,8 @@
 
 # For apps, use the default set
 include: package:flutter_lints/flutter.yaml
-# include: package:lints/recommended.yaml
 
-# Packages, that may be distributed (i.e. via pub.dev) should use the package 
+# Packages, that may be distributed (i.e. via pub.dev) should use the package
 # version, resulting in a better pub score.
 # include: package:lint/analysis_options_package.yaml
 
@@ -21,7 +20,7 @@ linter:
   rules:
     # Util classes are awesome!
     avoid_classes_with_only_static_members: false
-    
+
     # Make constructors the first thing in every class
     sort_constructors_first: true
 

--- a/test/analysis_options.yaml
+++ b/test/analysis_options.yaml
@@ -7,17 +7,8 @@ analyzer:
 
 linter:
   rules:
-    - avoid_print
-    - avoid_unnecessary_containers
-    - avoid_web_libraries_in_flutter
     - invalid_null_aware_operator: false
-    - no_logic_in_create_state
     - prefer_const_constructors: false
     - prefer_const_constructors_in_immutables: false
     - prefer_const_declarations: false
     - prefer_const_literals_to_create_immutables: false
-    - sized_box_for_whitespace: false
-    - sort_child_properties_last
-    - use_build_context_synchronously
-    - use_full_hex_values_for_flutter_colors
-    - use_key_in_widget_constructors

--- a/test/analysis_options.yaml
+++ b/test/analysis_options.yaml
@@ -1,0 +1,23 @@
+---
+include: ../analysis_options.yaml
+
+analyzer:
+  errors:
+    invalid_null_aware_operator: ignore
+
+linter:
+  rules:
+    - avoid_print
+    - avoid_unnecessary_containers
+    - avoid_web_libraries_in_flutter
+    - invalid_null_aware_operator: false
+    - no_logic_in_create_state
+    - prefer_const_constructors: false
+    - prefer_const_constructors_in_immutables: false
+    - prefer_const_declarations: false
+    - prefer_const_literals_to_create_immutables: false
+    - sized_box_for_whitespace: false
+    - sort_child_properties_last
+    - use_build_context_synchronously
+    - use_full_hex_values_for_flutter_colors
+    - use_key_in_widget_constructors


### PR DESCRIPTION
Seguindo a proposta iniciada em #10, mas com alguma diferença de abordagem, nesta PR estamos implementando um extensão do arquivo que configura as regras de linter para serem seguidas nos arquivos de testes de forma que possamos efetuar o relaxamento de algumas regras neste contexto, com a finalidade de manter um padrão de desenvolvimento de código mas não ser extremamente rígido com os testes (que normalmente fogem um pouco do padrão de código usado em produção).