### PR TITLE
Adiciona tarefas ao contrato de manual de fuga com a API

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,0 +1,17 @@
+targets:
+  $default:
+    builders:
+      json_serializable:
+        options:
+          any_map: false
+          checked: false
+          constructor: ""
+          create_factory: true
+          create_field_map: false
+          create_to_json: true
+          disallow_unrecognized_keys: false
+          explicit_to_json: false
+          field_rename: none
+          generic_argument_factories: false
+          ignore_unannotated: true
+          include_if_null: false

--- a/lib/app/core/extension/date_time.dart
+++ b/lib/app/core/extension/date_time.dart
@@ -1,0 +1,13 @@
+extension DateTimeExt on DateTime {
+  int get secondsSinceEpoch =>
+      millisecondsSinceEpoch ~/ Duration.millisecondsPerSecond;
+
+  static DateTime fromSecondsSinceEpoch(
+    int secondsSinceEpoch, {
+    bool isUtc = false,
+  }) =>
+      DateTime.fromMillisecondsSinceEpoch(
+        secondsSinceEpoch * Duration.millisecondsPerSecond,
+        isUtc: isUtc,
+      );
+}

--- a/lib/app/core/extension/json_serializer.dart
+++ b/lib/app/core/extension/json_serializer.dart
@@ -1,0 +1,41 @@
+import 'package:json_annotation/json_annotation.dart';
+
+import 'date_time.dart';
+
+abstract class FromJson {
+  static String parseAsString(dynamic obj) => '$obj';
+
+  static Iterable<String> parseAsStringList(Iterable<dynamic> obj) =>
+      obj.map<String>(parseAsString);
+}
+
+class JsonSecondsFromEpochConverter implements JsonConverter<DateTime, int> {
+  const JsonSecondsFromEpochConverter();
+
+  @override
+  DateTime fromJson(int json) => DateTimeExt.fromSecondsSinceEpoch(json);
+
+  @override
+  int toJson(DateTime object) => object.secondsSinceEpoch;
+}
+
+class JsonBoolConverter implements JsonConverter<bool, dynamic> {
+  const JsonBoolConverter();
+
+  @override
+  bool fromJson(dynamic json) => json is bool ? json : '${json ?? 0}' == '1';
+
+  @override
+  dynamic toJson(bool object) => object == false ? null : object;
+}
+
+class JsonEmptyStringToNullConverter
+    implements JsonConverter<String?, String?> {
+  const JsonEmptyStringToNullConverter();
+
+  @override
+  String? fromJson(String? json) => json?.isEmpty == true ? null : json;
+
+  @override
+  String? toJson(String? object) => object?.isEmpty == true ? null : object;
+}

--- a/lib/app/features/escape_manual/data/datasource/escape_manual_datasource.dart
+++ b/lib/app/features/escape_manual/data/datasource/escape_manual_datasource.dart
@@ -1,57 +1,7 @@
-import 'dart:convert';
-
-import 'package:dartz/dartz.dart';
-
-import '../../../../core/error/failures.dart';
-import '../../../../core/network/api_client.dart';
-import '../../../../shared/logger/log.dart';
 import '../../../appstate/data/model/quiz_session_model.dart';
-import '../../../authentication/presentation/shared/map_exception_to_failure.dart';
 import '../model/escape_manual.dart';
 
 abstract class IEscapeManualDatasource {
-  Future<Either<Failure, QuizSessionModel>> start(String sessionId);
-  Future<Either<Failure, EscapeManualModel>> fetch();
-}
-
-class EscapeManualDatasource implements IEscapeManualDatasource {
-  EscapeManualDatasource({
-    required IApiProvider apiProvider,
-  }) : _apiProvider = apiProvider;
-
-  final IApiProvider _apiProvider;
-
-  @override
-  Future<Either<Failure, QuizSessionModel>> start(String sessionId) async {
-    try {
-      final response = await _apiProvider.post(
-        path: '/me/quiz',
-        parameters: {'session_id': sessionId},
-      ).then(jsonDecode);
-
-      final quizSession = QuizSessionModel.fromJson(response['quiz_session']);
-      return right(quizSession);
-    } catch (error, stack) {
-      logError(error, stack);
-      return left(MapExceptionToFailure.map(error));
-    }
-  }
-
-  @override
-  Future<Either<Failure, EscapeManualModel>> fetch() async {
-    try {
-      final response = await _apiProvider.get(
-        path: '/me/tarefas',
-        parameters: {
-          'modificado_apos': '0',
-        },
-      ).then(jsonDecode);
-
-      final escapeManual = EscapeManualModel.fromJson(response);
-      return right(escapeManual);
-    } catch (error, stack) {
-      logError(error, stack);
-      return left(MapExceptionToFailure.map(error));
-    }
-  }
+  Future<QuizSessionModel> start(String sessionId);
+  Future<EscapeManualRemoteModel> fetch();
 }

--- a/lib/app/features/escape_manual/data/datasource/impl/escape_manual_remote_datasource.dart
+++ b/lib/app/features/escape_manual/data/datasource/impl/escape_manual_remote_datasource.dart
@@ -1,0 +1,38 @@
+import 'dart:convert';
+
+import '../../../../../core/network/api_client.dart';
+import '../../../../appstate/data/model/quiz_session_model.dart';
+import '../../model/escape_manual.dart';
+import '../escape_manual_datasource.dart';
+
+export '../escape_manual_datasource.dart' show IEscapeManualDatasource;
+
+class EscapeManualDatasource implements IEscapeManualDatasource {
+  EscapeManualDatasource({
+    required IApiProvider apiProvider,
+  }) : _apiProvider = apiProvider;
+
+  final IApiProvider _apiProvider;
+
+  @override
+  Future<QuizSessionModel> start(String sessionId) async {
+    final response = await _apiProvider.post(
+      path: '/me/quiz',
+      parameters: {'session_id': sessionId},
+    ).then(jsonDecode);
+
+    return QuizSessionModel.fromJson(response['quiz_session']);
+  }
+
+  @override
+  Future<EscapeManualRemoteModel> fetch() async {
+    final response = await _apiProvider.get(
+      path: '/me/tarefas',
+      parameters: {
+        'modificado_apos': '0',
+      },
+    ).then(jsonDecode);
+
+    return EscapeManualRemoteModel.fromJson(response);
+  }
+}

--- a/lib/app/features/escape_manual/data/model/escape_manual.dart
+++ b/lib/app/features/escape_manual/data/model/escape_manual.dart
@@ -1,46 +1,82 @@
+import 'package:equatable/equatable.dart';
+
 import '../../../appstate/data/model/quiz_session_model.dart';
-import '../../domain/entity/escape_manual.dart';
 
-class EscapeManualModel extends EscapeManualEntity {
-  const EscapeManualModel({
-    required EscapeManualAssistantModel assistant,
-  }) : super(assistant: assistant);
+class EscapeManualRemoteModel extends Equatable {
+  const EscapeManualRemoteModel({
+    required this.assistant,
+    this.tasks = const [],
+    this.removedTasks = const [],
+  });
 
-  factory EscapeManualModel.fromJson(Map<String, dynamic> json) {
-    return EscapeManualModel(
-      assistant: EscapeManualAssistantModel.fromJson(json['mf_assistant']),
-    );
-  }
+  final EscapeManualAssistantRemoteModel assistant;
+
+  final Iterable<EscapeManualTaskRemoteModel> tasks;
+
+  final Iterable<String> removedTasks;
+
+  @override
+  List<Object?> get props => [assistant, tasks.toList(), removedTasks.toList()];
 }
 
-class EscapeManualAssistantModel extends EscapeManualAssistantEntity {
-  const EscapeManualAssistantModel({
-    required String explanation,
-    required EscapeManualAssistantActionModel action,
-  }) : super(
-          explanation: explanation,
-          action: action,
-        );
+class EscapeManualAssistantRemoteModel extends Equatable {
+  const EscapeManualAssistantRemoteModel({
+    required this.title,
+    required this.subtitle,
+    required this.quizSession,
+  });
 
-  factory EscapeManualAssistantModel.fromJson(Map<String, dynamic> json) {
-    return EscapeManualAssistantModel(
-      explanation: json['subtitle'],
-      action: EscapeManualAssistantActionModel.fromJson(json),
-    );
-  }
+  final String title;
+
+  final String? subtitle;
+
+  final QuizSessionModel quizSession;
+
+  @override
+  List<Object?> get props => [title, subtitle, quizSession];
 }
 
-class EscapeManualAssistantActionModel
-    extends EscapeManualAssistantActionEntity {
-  const EscapeManualAssistantActionModel({
-    required String text,
-    required QuizSessionModel quizSession,
-  }) : super(text: text, quizSession: quizSession);
+class EscapeManualTaskRemoteModel extends Equatable {
+  const EscapeManualTaskRemoteModel({
+    required this.id,
+    required this.type,
+    required this.group,
+    this.title,
+    required this.description,
+    this.isDone = false,
+    this.isEditable = false,
+    this.userInputValue,
+    required this.updatedAt,
+  });
 
-  factory EscapeManualAssistantActionModel.fromJson(Map<String, dynamic> json) {
-    return EscapeManualAssistantActionModel(
-      text: json['title'],
-      quizSession: QuizSessionModel.fromJson(json['quiz_session']),
-    );
-  }
+  final String id;
+
+  final String type;
+
+  final String group;
+
+  final String? title;
+
+  final String description;
+
+  final String? userInputValue;
+
+  final bool isEditable;
+
+  final bool isDone;
+
+  final DateTime updatedAt;
+
+  @override
+  List<Object?> get props => [
+        id,
+        type,
+        group,
+        title,
+        description,
+        isDone,
+        isEditable,
+        userInputValue,
+        updatedAt,
+      ];
 }

--- a/lib/app/features/escape_manual/data/model/escape_manual.dart
+++ b/lib/app/features/escape_manual/data/model/escape_manual.dart
@@ -1,7 +1,12 @@
 import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
 
+import '../../../../core/extension/json_serializer.dart';
 import '../../../appstate/data/model/quiz_session_model.dart';
 
+part 'escape_manual.g.dart';
+
+@JsonSerializable(createToJson: false)
 class EscapeManualRemoteModel extends Equatable {
   const EscapeManualRemoteModel({
     required this.assistant,
@@ -9,16 +14,23 @@ class EscapeManualRemoteModel extends Equatable {
     this.removedTasks = const [],
   });
 
+  factory EscapeManualRemoteModel.fromJson(Map<String, dynamic> json) =>
+      _$EscapeManualRemoteModelFromJson(json);
+
+  @JsonKey(name: 'mf_assistant')
   final EscapeManualAssistantRemoteModel assistant;
 
+  @JsonKey(name: 'tarefas')
   final Iterable<EscapeManualTaskRemoteModel> tasks;
 
+  @JsonKey(name: 'tarefas_removidas', fromJson: FromJson.parseAsStringList)
   final Iterable<String> removedTasks;
 
   @override
   List<Object?> get props => [assistant, tasks.toList(), removedTasks.toList()];
 }
 
+@JsonSerializable(createToJson: false)
 class EscapeManualAssistantRemoteModel extends Equatable {
   const EscapeManualAssistantRemoteModel({
     required this.title,
@@ -26,16 +38,25 @@ class EscapeManualAssistantRemoteModel extends Equatable {
     required this.quizSession,
   });
 
+  factory EscapeManualAssistantRemoteModel.fromJson(
+    Map<String, dynamic> json,
+  ) =>
+      _$EscapeManualAssistantRemoteModelFromJson(json);
+
+  @JsonKey()
   final String title;
 
+  @JsonKey()
   final String? subtitle;
 
+  @JsonKey(name: 'quiz_session')
   final QuizSessionModel quizSession;
 
   @override
   List<Object?> get props => [title, subtitle, quizSession];
 }
 
+@JsonSerializable(createToJson: false)
 class EscapeManualTaskRemoteModel extends Equatable {
   const EscapeManualTaskRemoteModel({
     required this.id,
@@ -49,22 +70,38 @@ class EscapeManualTaskRemoteModel extends Equatable {
     required this.updatedAt,
   });
 
+  factory EscapeManualTaskRemoteModel.fromJson(Map<String, dynamic> json) =>
+      _$EscapeManualTaskRemoteModelFromJson(json);
+
+  @JsonKey(fromJson: FromJson.parseAsString)
   final String id;
 
+  @JsonKey(name: 'tipo')
   final String type;
 
+  @JsonKey(name: 'agrupador')
   final String group;
 
+  @JsonKey(name: 'titulo')
+  @JsonEmptyStringToNullConverter()
   final String? title;
 
+  @JsonKey(name: 'descricao')
   final String description;
 
+  @JsonKey(name: 'campo_livre')
   final String? userInputValue;
 
+  @JsonKey(name: 'eh_customizada')
+  @JsonBoolConverter()
   final bool isEditable;
 
+  @JsonKey(name: 'checkbox_feito')
+  @JsonBoolConverter()
   final bool isDone;
 
+  @JsonKey(name: 'atualizado_em')
+  @JsonSecondsFromEpochConverter()
   final DateTime updatedAt;
 
   @override

--- a/lib/app/features/escape_manual/data/model/escape_manual.g.dart
+++ b/lib/app/features/escape_manual/data/model/escape_manual.g.dart
@@ -1,0 +1,50 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'escape_manual.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+EscapeManualRemoteModel _$EscapeManualRemoteModelFromJson(
+        Map<String, dynamic> json) =>
+    EscapeManualRemoteModel(
+      assistant: EscapeManualAssistantRemoteModel.fromJson(
+          json['mf_assistant'] as Map<String, dynamic>),
+      tasks: (json['tarefas'] as List<dynamic>?)?.map((e) =>
+              EscapeManualTaskRemoteModel.fromJson(
+                  e as Map<String, dynamic>)) ??
+          const [],
+      removedTasks: json['tarefas_removidas'] == null
+          ? const []
+          : FromJson.parseAsStringList(json['tarefas_removidas'] as List),
+    );
+
+EscapeManualAssistantRemoteModel _$EscapeManualAssistantRemoteModelFromJson(
+        Map<String, dynamic> json) =>
+    EscapeManualAssistantRemoteModel(
+      title: json['title'] as String,
+      subtitle: json['subtitle'] as String?,
+      quizSession: QuizSessionModel.fromJson(
+          json['quiz_session'] as Map<String, dynamic>),
+    );
+
+EscapeManualTaskRemoteModel _$EscapeManualTaskRemoteModelFromJson(
+        Map<String, dynamic> json) =>
+    EscapeManualTaskRemoteModel(
+      id: FromJson.parseAsString(json['id']),
+      type: json['tipo'] as String,
+      group: json['agrupador'] as String,
+      title: const JsonEmptyStringToNullConverter()
+          .fromJson(json['titulo'] as String?),
+      description: json['descricao'] as String,
+      isDone: json['checkbox_feito'] == null
+          ? false
+          : const JsonBoolConverter().fromJson(json['checkbox_feito']),
+      isEditable: json['eh_customizada'] == null
+          ? false
+          : const JsonBoolConverter().fromJson(json['eh_customizada']),
+      userInputValue: json['campo_livre'] as String?,
+      updatedAt: const JsonSecondsFromEpochConverter()
+          .fromJson(json['atualizado_em'] as int),
+    );

--- a/lib/app/features/escape_manual/data/model/escape_manual_mapper.dart
+++ b/lib/app/features/escape_manual/data/model/escape_manual_mapper.dart
@@ -1,0 +1,54 @@
+import 'package:collection/collection.dart';
+
+import '../../domain/entity/escape_manual.dart';
+import 'escape_manual.dart';
+
+extension EscapeManualRemoteMapper on EscapeManualRemoteModel {
+  /// Maps a [EscapeManualRemoteModel] to a [EscapeManualEntity].
+  EscapeManualEntity get asEntity => EscapeManualEntity(
+        assistant: assistant.asEntity,
+        sections: tasks.asEntity,
+      );
+}
+
+extension EscapeManualAssistantRemoteMapper
+    on EscapeManualAssistantRemoteModel {
+  /// Maps a [EscapeManualAssistantRemoteModel] to a [EscapeManualAssistantEntity].
+  EscapeManualAssistantEntity get asEntity => EscapeManualAssistantEntity(
+        explanation: subtitle ?? '',
+        action: EscapeManualAssistantActionEntity(
+          text: title,
+          quizSession: quizSession,
+        ),
+      );
+}
+
+extension EscapeManualTasksSectionMapper
+    on Iterable<EscapeManualTaskRemoteModel> {
+  /// Maps a list of [EscapeManualTaskRemoteModel] to a list of
+  /// [EscapeManualTasksSectionEntity] grouping them by [group].
+  ///
+  /// The [group] is the same as the [title] of the section.
+  List<EscapeManualTasksSectionEntity> get asEntity =>
+      groupListsBy((el) => el.group)
+          .entries
+          .map(
+            (el) => EscapeManualTasksSectionEntity(
+              title: el.key,
+              tasks: el.value.map((el) => el.asEntity).toList(),
+            ),
+          )
+          .toList();
+}
+
+extension EscapeManualTaskRemoteMapper on EscapeManualTaskRemoteModel {
+  /// Maps a [EscapeManualTaskRemoteModel] to a [EscapeManualTaskEntity].
+  EscapeManualTaskEntity get asEntity => EscapeManualTaskEntity(
+        id: id,
+        type: type,
+        description: description,
+        isEditable: isEditable == true,
+        userInputValue: userInputValue,
+        isDone: isDone == true,
+      );
+}

--- a/lib/app/features/escape_manual/data/repository/escape_manual_repository.dart
+++ b/lib/app/features/escape_manual/data/repository/escape_manual_repository.dart
@@ -1,10 +1,18 @@
+import 'dart:async';
+
 import 'package:dartz/dartz.dart';
 
 import '../../../../core/error/failures.dart';
+import '../../../../shared/logger/log.dart';
 import '../../../appstate/domain/entities/app_state_entity.dart';
+import '../../../authentication/presentation/shared/map_exception_to_failure.dart';
 import '../../domain/entity/escape_manual.dart';
 import '../../domain/repository/escape_manual_repository.dart';
 import '../datasource/escape_manual_datasource.dart';
+import '../model/escape_manual_mapper.dart';
+
+export '../../domain/repository/escape_manual_repository.dart'
+    show IEscapeManualRepository;
 
 class EscapeManualRepository implements IEscapeManualRepository {
   EscapeManualRepository({
@@ -14,12 +22,25 @@ class EscapeManualRepository implements IEscapeManualRepository {
   final IEscapeManualDatasource _datasource;
 
   @override
-  Future<Either<Failure, QuizSessionEntity>> start(String sessionId) {
-    return _datasource.start(sessionId);
+  Future<Either<Failure, QuizSessionEntity>> start(String sessionId) async {
+    try {
+      final quizSession = await _datasource.start(sessionId);
+      return right(quizSession);
+    } catch (error, stack) {
+      logError(error, stack);
+      return left(MapExceptionToFailure.map(error));
+    }
   }
 
   @override
-  Future<Either<Failure, EscapeManualEntity>> fetch() {
-    return _datasource.fetch();
+  Future<Either<Failure, EscapeManualEntity>> fetch() async {
+    try {
+      final response = await _datasource.fetch();
+
+      return right(response.asEntity);
+    } catch (error, stack) {
+      logError(error, stack);
+      return left(MapExceptionToFailure.map(error));
+    }
   }
 }

--- a/lib/app/features/escape_manual/domain/entity/escape_manual.dart
+++ b/lib/app/features/escape_manual/domain/entity/escape_manual.dart
@@ -5,12 +5,14 @@ import '../../../appstate/domain/entities/app_state_entity.dart';
 class EscapeManualEntity extends Equatable {
   const EscapeManualEntity({
     required this.assistant,
+    this.sections = const [],
   });
 
   final EscapeManualAssistantEntity assistant;
+  final List<EscapeManualTasksSectionEntity> sections;
 
   @override
-  List<Object?> get props => [assistant];
+  List<Object?> get props => [assistant, sections];
 }
 
 class EscapeManualAssistantEntity extends Equatable {
@@ -37,4 +39,45 @@ class EscapeManualAssistantActionEntity extends Equatable {
 
   @override
   List<Object?> get props => [text, quizSession];
+}
+
+class EscapeManualTasksSectionEntity extends Equatable {
+  const EscapeManualTasksSectionEntity({
+    required this.title,
+    required this.tasks,
+  });
+
+  final String title;
+  final List<EscapeManualTaskEntity> tasks;
+
+  @override
+  List<Object?> get props => [title, tasks];
+}
+
+class EscapeManualTaskEntity extends Equatable {
+  const EscapeManualTaskEntity({
+    required this.id,
+    required this.type,
+    required this.description,
+    required this.isEditable,
+    required this.userInputValue,
+    required this.isDone,
+  });
+
+  final String id;
+  final String type;
+  final String description;
+  final bool isEditable;
+  final String? userInputValue;
+  final bool isDone;
+
+  @override
+  List<Object?> get props => [
+        id,
+        type,
+        description,
+        isEditable,
+        userInputValue,
+        isDone,
+      ];
 }

--- a/lib/app/features/escape_manual/escape_manual_module.dart
+++ b/lib/app/features/escape_manual/escape_manual_module.dart
@@ -4,7 +4,6 @@ import 'package:flutter_modular/flutter_modular.dart';
 import 'data/datasource/impl/escape_manual_remote_datasource.dart';
 import 'data/repository/escape_manual_repository.dart';
 import 'domain/get_escape_manual.dart';
-import 'domain/repository/escape_manual_repository.dart';
 import 'domain/start_escape_manual.dart';
 import 'presentation/escape_manual_controller.dart';
 import 'presentation/escape_manual_page.dart';

--- a/lib/app/features/escape_manual/escape_manual_module.dart
+++ b/lib/app/features/escape_manual/escape_manual_module.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 
-import 'data/datasource/escape_manual_datasource.dart';
+import 'data/datasource/impl/escape_manual_remote_datasource.dart';
 import 'data/repository/escape_manual_repository.dart';
 import 'domain/get_escape_manual.dart';
 import 'domain/repository/escape_manual_repository.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -825,12 +825,19 @@ packages:
     source: hosted
     version: "0.6.3"
   json_annotation:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.6.0"
+  json_serializable:
+    dependency: "direct dev"
+    description:
+      name: json_serializable
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.3.1"
   just_audio:
     dependency: transitive
     description:
@@ -1258,6 +1265,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.2"
+  source_helper:
+    dependency: transitive
+    description:
+      name: source_helper
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.2"
   source_map_stack_trace:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -88,6 +88,7 @@ dependencies:
   scroll_to_index: ^2.1.1
   flutter_secure_storage: ^6.1.0
   synchronized: ^3.0.0+3
+  json_annotation: ^4.6.0
 
 dependency_overrides:
   flutter_modular:
@@ -121,6 +122,7 @@ dev_dependencies:
   # snapshot test
   alchemist: ^0.3.3
   golden_toolkit: ^0.13.0
+  json_serializable: ^6.3.1
 
 flutter_icons:
   ios: true

--- a/test/app/features/escape_manual/data/model/escape_manual_fixtures.dart
+++ b/test/app/features/escape_manual/data/model/escape_manual_fixtures.dart
@@ -1,5 +1,55 @@
 import 'package:penhas/app/features/appstate/data/model/quiz_session_model.dart';
 import 'package:penhas/app/features/escape_manual/data/model/escape_manual.dart';
+import 'package:penhas/app/features/escape_manual/domain/entity/escape_manual.dart';
+
+final escapeManualModelFixture = EscapeManualRemoteModel(
+  assistant: const EscapeManualAssistantRemoteModel(
+    title: 'text',
+    subtitle: 'explanation',
+    quizSession: QuizSessionModel(
+      sessionId: 'sessionId',
+    ),
+  ),
+  tasks: [
+    EscapeManualTaskRemoteModel(
+      id: 'id',
+      type: 'type',
+      group: 'group',
+      title: 'title',
+      description: 'description',
+      isEditable: true,
+      userInputValue: 'userInputValue',
+      updatedAt: DateTime.now(),
+    ),
+  ],
+);
+
+const escapeManualEntityFixture = EscapeManualEntity(
+  assistant: EscapeManualAssistantEntity(
+    explanation: 'explanation',
+    action: EscapeManualAssistantActionEntity(
+      text: 'text',
+      quizSession: QuizSessionModel(
+        sessionId: 'sessionId',
+      ),
+    ),
+  ),
+  sections: [
+    EscapeManualTasksSectionEntity(
+      title: 'group',
+      tasks: [
+        EscapeManualTaskEntity(
+          id: 'id',
+          type: 'type',
+          description: 'description',
+          isDone: false,
+          isEditable: true,
+          userInputValue: 'userInputValue',
+        ),
+      ],
+    ),
+  ],
+);
 
 final escapeManualRemoteModelFixture = EscapeManualRemoteModel(
   assistant: const EscapeManualAssistantRemoteModel(

--- a/test/app/features/escape_manual/data/model/escape_manual_fixtures.dart
+++ b/test/app/features/escape_manual/data/model/escape_manual_fixtures.dart
@@ -1,0 +1,54 @@
+import 'package:penhas/app/features/appstate/data/model/quiz_session_model.dart';
+import 'package:penhas/app/features/escape_manual/data/model/escape_manual.dart';
+
+final escapeManualRemoteModelFixture = EscapeManualRemoteModel(
+  assistant: const EscapeManualAssistantRemoteModel(
+    title: 'action button',
+    subtitle: 'Explanation',
+    quizSession: QuizSessionModel(
+      sessionId: 'MF1234',
+    ),
+  ),
+  tasks: [
+    EscapeManualTaskRemoteModel(
+      id: '71',
+      type: 'checkbox',
+      group: 'Itens Básicos',
+      description:
+          'Organize uma mochila com roupas. Se achar que a mochila levantará suspeita, separe em sacolas plásticas algumas mudas de roupa. Você pode ir separando as peças de roupas no decorrer dos dias para não levantar suspeitas.',
+      updatedAt: DateTime.fromMillisecondsSinceEpoch(1689701023000),
+    ),
+    EscapeManualTaskRemoteModel(
+      id: '72',
+      type: 'checkbox',
+      group: 'Itens Básicos',
+      description: 'Ponha na mochila medicamentos básicos e de uso contínuo',
+      updatedAt: DateTime.fromMillisecondsSinceEpoch(1689701023000),
+    ),
+    EscapeManualTaskRemoteModel(
+      id: '73',
+      type: 'checkbox',
+      group: 'Passos para fuga',
+      description:
+          'Cadastre-se e/ou verifique se o seu Cadastro Único (CadÚnico) está ativo.',
+      isEditable: true,
+      updatedAt: DateTime.fromMillisecondsSinceEpoch(1689701023000),
+    ),
+    EscapeManualTaskRemoteModel(
+      id: '75',
+      type: 'checkbox',
+      group: 'Segurança pessoal',
+      description:
+          'Busque o Centro de Referência de Assistência Social (CRAS).',
+      updatedAt: DateTime.fromMillisecondsSinceEpoch(1689701025000),
+    ),
+    EscapeManualTaskRemoteModel(
+      id: '76',
+      type: 'checkbox',
+      group: 'Passos para fuga',
+      description:
+          'Leve ao CRAS toda documentação necessária, tanto sua, quanto das crianças, se houver.',
+      updatedAt: DateTime.fromMillisecondsSinceEpoch(1689701025000),
+    ),
+  ],
+);

--- a/test/app/features/escape_manual/data/repository/escape_manual_repository_test.dart
+++ b/test/app/features/escape_manual/data/repository/escape_manual_repository_test.dart
@@ -1,11 +1,13 @@
 import 'package:dartz/dartz.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:penhas/app/core/error/failures.dart';
 import 'package:penhas/app/features/appstate/data/model/quiz_session_model.dart';
 import 'package:penhas/app/features/escape_manual/data/datasource/escape_manual_datasource.dart';
 import 'package:penhas/app/features/escape_manual/data/model/escape_manual.dart';
 import 'package:penhas/app/features/escape_manual/data/repository/escape_manual_repository.dart';
-import 'package:penhas/app/features/escape_manual/domain/repository/escape_manual_repository.dart';
+
+import '../model/escape_manual_fixtures.dart';
 
 void main() {
   late IEscapeManualRepository sut;
@@ -13,7 +15,7 @@ void main() {
   late IEscapeManualDatasource mockDatasource;
 
   setUp(() {
-    mockDatasource = MockEscapeManualDatasource();
+    mockDatasource = _MockEscapeManualDatasource();
 
     sut = EscapeManualRepository(
       datasource: mockDatasource,
@@ -26,19 +28,17 @@ void main() {
         'should call datasource fetch',
         () async {
           // arrange
-          const escapeManual = EscapeManualModel(
-            assistant: EscapeManualAssistantModel(
-              explanation: 'explanation',
-              action: EscapeManualAssistantActionModel(
-                text: 'text',
-                quizSession: QuizSessionModel(
-                  sessionId: 'sessionId',
-                ),
+          const escapeManual = EscapeManualRemoteModel(
+            assistant: EscapeManualAssistantRemoteModel(
+              title: 'text',
+              subtitle: 'explanation',
+              quizSession: QuizSessionModel(
+                sessionId: 'sessionId',
               ),
             ),
           );
           when(() => mockDatasource.fetch())
-              .thenAnswer((_) async => right(escapeManual));
+              .thenAnswer((_) async => escapeManual);
 
           // act
           await sut.fetch();
@@ -52,25 +52,32 @@ void main() {
         'should return datasource fetch',
         () async {
           // arrange
-          const escapeManual = EscapeManualModel(
-            assistant: EscapeManualAssistantModel(
-              explanation: 'explanation',
-              action: EscapeManualAssistantActionModel(
-                text: 'text',
-                quizSession: QuizSessionModel(
-                  sessionId: 'sessionId',
-                ),
-              ),
-            ),
-          );
+          final escapeManualModel = escapeManualModelFixture;
+          const expectedEscapeManual = escapeManualEntityFixture;
+
           when(() => mockDatasource.fetch())
-              .thenAnswer((_) async => right(escapeManual));
+              .thenAnswer((_) async => escapeManualModel);
 
           // act
           final result = await sut.fetch();
 
           // assert
-          expect(result, right(escapeManual));
+          expect(result, right(expectedEscapeManual));
+        },
+      );
+
+      test(
+        'should return failure when datasource fetch throws',
+        () async {
+          // arrange
+          when(() => mockDatasource.fetch()).thenThrow(Exception());
+
+          // act
+          final result = await sut.fetch();
+
+          // assert
+          expect(result.isLeft(), isTrue);
+          expect(result.fold(id, id), isA<Failure>());
         },
       );
     });
@@ -84,7 +91,7 @@ void main() {
             sessionId: 'sessionId',
           );
           when(() => mockDatasource.start(any()))
-              .thenAnswer((_) async => right(quizSession));
+              .thenAnswer((_) async => quizSession);
 
           // act
           await sut.start('MF1234');
@@ -102,7 +109,7 @@ void main() {
             sessionId: 'sessionId',
           );
           when(() => mockDatasource.start(any()))
-              .thenAnswer((_) async => right(quizSession));
+              .thenAnswer((_) async => quizSession);
 
           // act
           final result = await sut.start('MF1234');
@@ -111,9 +118,24 @@ void main() {
           expect(result, right(quizSession));
         },
       );
+
+      test(
+        'should return failure when datasource start throws',
+        () async {
+          // arrange
+          when(() => mockDatasource.start(any())).thenThrow(Exception());
+
+          // act
+          final result = await sut.start('MF1234');
+
+          // assert
+          expect(result.isLeft(), isTrue);
+          expect(result.fold(id, id), isA<Failure>());
+        },
+      );
     });
   });
 }
 
-class MockEscapeManualDatasource extends Mock
+class _MockEscapeManualDatasource extends Mock
     implements IEscapeManualDatasource {}

--- a/test/assets/json/escape_manual/escape_manual_response.json
+++ b/test/assets/json/escape_manual/escape_manual_response.json
@@ -5,5 +5,62 @@
         "quiz_session": {
             "session_id": "MF1234"
         }
-    }
+    },
+    "tarefas": [
+        {
+            "agrupador": "Itens Básicos",
+            "atualizado_em": 1689701023,
+            "campo_livre": null,
+            "checkbox_feito": 0,
+            "descricao": "Organize uma mochila com roupas. Se achar que a mochila levantará suspeita, separe em sacolas plásticas algumas mudas de roupa. Você pode ir separando as peças de roupas no decorrer dos dias para não levantar suspeitas.",
+            "eh_customizada": 0,
+            "id": 71,
+            "tipo": "checkbox",
+            "titulo": ""
+        },
+        {
+            "agrupador": "Itens Básicos",
+            "atualizado_em": 1689701023,
+            "campo_livre": null,
+            "checkbox_feito": 0,
+            "descricao": "Ponha na mochila medicamentos básicos e de uso contínuo",
+            "eh_customizada": 0,
+            "id": 72,
+            "tipo": "checkbox",
+            "titulo": ""
+        },
+        {
+            "agrupador": "Passos para fuga",
+            "atualizado_em": 1689701023,
+            "campo_livre": null,
+            "checkbox_feito": 0,
+            "descricao": "Cadastre-se e/ou verifique se o seu Cadastro Único (CadÚnico) está ativo.",
+            "eh_customizada": 1,
+            "id": 73,
+            "tipo": "checkbox",
+            "titulo": ""
+        },
+        {
+            "agrupador": "Segurança pessoal",
+            "atualizado_em": 1689701025,
+            "campo_livre": null,
+            "checkbox_feito": 0,
+            "descricao": "Busque o Centro de Referência de Assistência Social (CRAS).",
+            "eh_customizada": 0,
+            "id": 75,
+            "tipo": "checkbox",
+            "titulo": ""
+        },
+        {
+            "agrupador": "Passos para fuga",
+            "atualizado_em": 1689701025,
+            "campo_livre": null,
+            "checkbox_feito": 0,
+            "descricao": "Leve ao CRAS toda documentação necessária, tanto sua, quanto das crianças, se houver.",
+            "eh_customizada": 0,
+            "id": 76,
+            "tipo": "checkbox",
+            "titulo": ""
+        }
+    ]
 }


### PR DESCRIPTION
Alterações para a camada de dados contemplar os dados das tarefas do manual de fuga, o PR incluí:
- Adiciona tarefas ao contrato de manual de fuga com a API;
- Adiciona lib de geração de boilerplate de serialização/deserialização de JSON;
- Extrai implementação do datasource da definição da interface.