### PR TITLE
Ajusta o nome das classes para fazer referência a origem dos dados

### DIFF
--- a/lib/app/features/escape_manual/data/datasource/escape_manual_datasource.dart
+++ b/lib/app/features/escape_manual/data/datasource/escape_manual_datasource.dart
@@ -1,7 +1,9 @@
 import '../../../appstate/data/model/quiz_session_model.dart';
-import '../model/escape_manual.dart';
+import '../model/escape_manual_remote.dart';
 
-abstract class IEscapeManualDatasource {
+abstract class IEscapeManualDatasource {}
+
+abstract class IEscapeManualRemoteDatasource extends IEscapeManualDatasource {
   Future<QuizSessionModel> start(String sessionId);
   Future<EscapeManualRemoteModel> fetch();
 }

--- a/lib/app/features/escape_manual/data/datasource/impl/escape_manual_remote_datasource.dart
+++ b/lib/app/features/escape_manual/data/datasource/impl/escape_manual_remote_datasource.dart
@@ -2,13 +2,13 @@ import 'dart:convert';
 
 import '../../../../../core/network/api_client.dart';
 import '../../../../appstate/data/model/quiz_session_model.dart';
-import '../../model/escape_manual.dart';
+import '../../model/escape_manual_remote.dart';
 import '../escape_manual_datasource.dart';
 
-export '../escape_manual_datasource.dart' show IEscapeManualDatasource;
+export '../escape_manual_datasource.dart' show IEscapeManualRemoteDatasource;
 
-class EscapeManualDatasource implements IEscapeManualDatasource {
-  EscapeManualDatasource({
+class EscapeManualRemoteDatasource implements IEscapeManualRemoteDatasource {
+  EscapeManualRemoteDatasource({
     required IApiProvider apiProvider,
   }) : _apiProvider = apiProvider;
 

--- a/lib/app/features/escape_manual/data/model/escape_manual_mapper.dart
+++ b/lib/app/features/escape_manual/data/model/escape_manual_mapper.dart
@@ -1,7 +1,7 @@
 import 'package:collection/collection.dart';
 
 import '../../domain/entity/escape_manual.dart';
-import 'escape_manual.dart';
+import 'escape_manual_remote.dart';
 
 extension EscapeManualRemoteMapper on EscapeManualRemoteModel {
   /// Maps a [EscapeManualRemoteModel] to a [EscapeManualEntity].

--- a/lib/app/features/escape_manual/data/model/escape_manual_remote.dart
+++ b/lib/app/features/escape_manual/data/model/escape_manual_remote.dart
@@ -4,7 +4,7 @@ import 'package:json_annotation/json_annotation.dart';
 import '../../../../core/extension/json_serializer.dart';
 import '../../../appstate/data/model/quiz_session_model.dart';
 
-part 'escape_manual.g.dart';
+part 'escape_manual_remote.g.dart';
 
 @JsonSerializable(createToJson: false)
 class EscapeManualRemoteModel extends Equatable {

--- a/lib/app/features/escape_manual/data/model/escape_manual_remote.g.dart
+++ b/lib/app/features/escape_manual/data/model/escape_manual_remote.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'escape_manual.dart';
+part of 'escape_manual_remote.dart';
 
 // **************************************************************************
 // JsonSerializableGenerator

--- a/lib/app/features/escape_manual/data/repository/escape_manual_repository.dart
+++ b/lib/app/features/escape_manual/data/repository/escape_manual_repository.dart
@@ -16,15 +16,15 @@ export '../../domain/repository/escape_manual_repository.dart'
 
 class EscapeManualRepository implements IEscapeManualRepository {
   EscapeManualRepository({
-    required IEscapeManualDatasource datasource,
-  }) : _datasource = datasource;
+    required IEscapeManualRemoteDatasource remoteDatasource,
+  }) : _remoteDatasource = remoteDatasource;
 
-  final IEscapeManualDatasource _datasource;
+  final IEscapeManualRemoteDatasource _remoteDatasource;
 
   @override
   Future<Either<Failure, QuizSessionEntity>> start(String sessionId) async {
     try {
-      final quizSession = await _datasource.start(sessionId);
+      final quizSession = await _remoteDatasource.start(sessionId);
       return right(quizSession);
     } catch (error, stack) {
       logError(error, stack);
@@ -35,7 +35,7 @@ class EscapeManualRepository implements IEscapeManualRepository {
   @override
   Future<Either<Failure, EscapeManualEntity>> fetch() async {
     try {
-      final response = await _datasource.fetch();
+      final response = await _remoteDatasource.fetch();
 
       return right(response.asEntity);
     } catch (error, stack) {

--- a/lib/app/features/escape_manual/escape_manual_module.dart
+++ b/lib/app/features/escape_manual/escape_manual_module.dart
@@ -34,11 +34,11 @@ class EscapeManualModule extends WidgetModule {
     ),
     Bind.factory<IEscapeManualRepository>(
       (i) => EscapeManualRepository(
-        datasource: i.get(),
+        remoteDatasource: i.get(),
       ),
     ),
-    Bind.factory<IEscapeManualDatasource>(
-      (i) => EscapeManualDatasource(
+    Bind.factory<IEscapeManualRemoteDatasource>(
+      (i) => EscapeManualRemoteDatasource(
         apiProvider: i.get(),
       ),
     ),

--- a/test/app/features/escape_manual/data/datasource/impl/escape_manual_remote_datasource_test.dart
+++ b/test/app/features/escape_manual/data/datasource/impl/escape_manual_remote_datasource_test.dart
@@ -3,13 +3,13 @@ import 'package:mocktail/mocktail.dart';
 import 'package:penhas/app/core/network/api_client.dart';
 import 'package:penhas/app/features/appstate/data/model/quiz_session_model.dart';
 import 'package:penhas/app/features/escape_manual/data/datasource/impl/escape_manual_remote_datasource.dart';
-import 'package:penhas/app/features/escape_manual/data/model/escape_manual.dart';
+import 'package:penhas/app/features/escape_manual/data/model/escape_manual_remote.dart';
 
-import '../../../../../utils/json_util.dart';
-import '../model/escape_manual_fixtures.dart';
+import '../../../../../../utils/json_util.dart';
+import '../../model/escape_manual_fixtures.dart';
 
 void main() {
-  late IEscapeManualDatasource sut;
+  late IEscapeManualRemoteDatasource sut;
 
   late IApiProvider mockApiProvider;
 
@@ -20,12 +20,12 @@ void main() {
   setUp(() {
     mockApiProvider = _MockApiProvider();
 
-    sut = EscapeManualDatasource(
+    sut = EscapeManualRemoteDatasource(
       apiProvider: mockApiProvider,
     );
   });
 
-  group(EscapeManualDatasource, () {
+  group(EscapeManualRemoteDatasource, () {
     group('start', () {
       test(
         'should call apiProvider post',

--- a/test/app/features/escape_manual/data/model/escape_manual_fixtures.dart
+++ b/test/app/features/escape_manual/data/model/escape_manual_fixtures.dart
@@ -1,5 +1,5 @@
 import 'package:penhas/app/features/appstate/data/model/quiz_session_model.dart';
-import 'package:penhas/app/features/escape_manual/data/model/escape_manual.dart';
+import 'package:penhas/app/features/escape_manual/data/model/escape_manual_remote.dart';
 import 'package:penhas/app/features/escape_manual/domain/entity/escape_manual.dart';
 
 final escapeManualModelFixture = EscapeManualRemoteModel(

--- a/test/app/features/escape_manual/data/repository/escape_manual_repository_test.dart
+++ b/test/app/features/escape_manual/data/repository/escape_manual_repository_test.dart
@@ -4,7 +4,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:penhas/app/core/error/failures.dart';
 import 'package:penhas/app/features/appstate/data/model/quiz_session_model.dart';
 import 'package:penhas/app/features/escape_manual/data/datasource/escape_manual_datasource.dart';
-import 'package:penhas/app/features/escape_manual/data/model/escape_manual.dart';
+import 'package:penhas/app/features/escape_manual/data/model/escape_manual_remote.dart';
 import 'package:penhas/app/features/escape_manual/data/repository/escape_manual_repository.dart';
 
 import '../model/escape_manual_fixtures.dart';
@@ -12,13 +12,13 @@ import '../model/escape_manual_fixtures.dart';
 void main() {
   late IEscapeManualRepository sut;
 
-  late IEscapeManualDatasource mockDatasource;
+  late IEscapeManualRemoteDatasource mockRemoteDatasource;
 
   setUp(() {
-    mockDatasource = _MockEscapeManualDatasource();
+    mockRemoteDatasource = _MockEscapeManualRemoteDatasource();
 
     sut = EscapeManualRepository(
-      datasource: mockDatasource,
+      remoteDatasource: mockRemoteDatasource,
     );
   });
 
@@ -37,14 +37,14 @@ void main() {
               ),
             ),
           );
-          when(() => mockDatasource.fetch())
+          when(() => mockRemoteDatasource.fetch())
               .thenAnswer((_) async => escapeManual);
 
           // act
           await sut.fetch();
 
           // assert
-          verify(() => mockDatasource.fetch()).called(1);
+          verify(() => mockRemoteDatasource.fetch()).called(1);
         },
       );
 
@@ -55,7 +55,7 @@ void main() {
           final escapeManualModel = escapeManualModelFixture;
           const expectedEscapeManual = escapeManualEntityFixture;
 
-          when(() => mockDatasource.fetch())
+          when(() => mockRemoteDatasource.fetch())
               .thenAnswer((_) async => escapeManualModel);
 
           // act
@@ -70,7 +70,7 @@ void main() {
         'should return failure when datasource fetch throws',
         () async {
           // arrange
-          when(() => mockDatasource.fetch()).thenThrow(Exception());
+          when(() => mockRemoteDatasource.fetch()).thenThrow(Exception());
 
           // act
           final result = await sut.fetch();
@@ -90,14 +90,14 @@ void main() {
           const quizSession = QuizSessionModel(
             sessionId: 'sessionId',
           );
-          when(() => mockDatasource.start(any()))
+          when(() => mockRemoteDatasource.start(any()))
               .thenAnswer((_) async => quizSession);
 
           // act
           await sut.start('MF1234');
 
           // assert
-          verify(() => mockDatasource.start('MF1234')).called(1);
+          verify(() => mockRemoteDatasource.start('MF1234')).called(1);
         },
       );
 
@@ -108,7 +108,7 @@ void main() {
           const quizSession = QuizSessionModel(
             sessionId: 'sessionId',
           );
-          when(() => mockDatasource.start(any()))
+          when(() => mockRemoteDatasource.start(any()))
               .thenAnswer((_) async => quizSession);
 
           // act
@@ -123,7 +123,7 @@ void main() {
         'should return failure when datasource start throws',
         () async {
           // arrange
-          when(() => mockDatasource.start(any())).thenThrow(Exception());
+          when(() => mockRemoteDatasource.start(any())).thenThrow(Exception());
 
           // act
           final result = await sut.start('MF1234');
@@ -137,5 +137,5 @@ void main() {
   });
 }
 
-class _MockEscapeManualDatasource extends Mock
-    implements IEscapeManualDatasource {}
+class _MockEscapeManualRemoteDatasource extends Mock
+    implements IEscapeManualRemoteDatasource {}


### PR DESCRIPTION
Adicionada a palavra `Remote` ao nome do datasource e modelo referente as implementações feitas para consumir a API, assim ficara melhor associado, diferenciando do modelo e datasource para a persistência local.