### PR TITLE
Implementação da persistência local para o manual de fuga

### DIFF
--- a/lib/app/app_module.dart
+++ b/lib/app/app_module.dart
@@ -15,7 +15,7 @@ import 'core/network/network_info.dart';
 import 'core/storage/cache_storage.dart';
 import 'core/storage/i_local_storage.dart';
 import 'core/storage/impl/hive_cache_storage.dart';
-import 'core/storage/impl/hive_persistent_storage_factory.dart';
+import 'core/storage/impl/hive_persistent_storage.dart';
 import 'core/storage/local_storage_shared_preferences.dart';
 import 'core/storage/migrator_local_storage.dart';
 import 'core/storage/persistent_storage.dart';

--- a/lib/app/app_module.dart
+++ b/lib/app/app_module.dart
@@ -15,8 +15,10 @@ import 'core/network/network_info.dart';
 import 'core/storage/cache_storage.dart';
 import 'core/storage/i_local_storage.dart';
 import 'core/storage/impl/hive_cache_storage.dart';
+import 'core/storage/impl/hive_persistent_storage_factory.dart';
 import 'core/storage/local_storage_shared_preferences.dart';
 import 'core/storage/migrator_local_storage.dart';
+import 'core/storage/persistent_storage.dart';
 import 'core/storage/secure_local_storage.dart';
 import 'features/appstate/data/datasources/app_state_data_source.dart';
 import 'features/appstate/data/repositories/app_state_repository.dart';
@@ -117,6 +119,11 @@ class AppModule extends Module {
         ),
         Bind.lazySingleton<ICacheStorage>(
           (i) => HiveCacheStorage(
+            encryptionKeyStorage: i.get(),
+          ),
+        ),
+        Bind.lazySingleton<IPersistentStorageFactory>(
+          (i) => HivePersistentStorageFactory(
             encryptionKeyStorage: i.get(),
           ),
         ),

--- a/lib/app/core/storage/collection_store.dart
+++ b/lib/app/core/storage/collection_store.dart
@@ -1,0 +1,49 @@
+import 'persistent_storage.dart';
+
+abstract class ICollectionStore<T> {
+  String get name;
+
+  Future<Iterable<T>> all();
+
+  Stream<Iterable<T>> watchAll();
+
+  Future<void> put(String key, T value);
+
+  Future<void> removeAll(Iterable<String> keys);
+}
+
+mixin CollectionStore<T> on ICollectionStore<T> {
+  IPersistentStorageFactory get storageFactory;
+
+  late final IPersistentStorage storage = storageFactory.create(name);
+
+  @override
+  Future<Iterable<T>> all() => storage.all();
+
+  @override
+  Stream<Iterable<T>> watchAll() => storage.watchAll();
+
+  @override
+  Future<void> put(String key, T value) => storage.put(key, value);
+
+  @override
+  Future<void> removeAll(Iterable<String> keys) => storage.removeAll(keys);
+}
+
+mixin SerializableCollectionStore<T> on ICollectionStore<T>
+    implements CollectionStore<T> {
+  T deserialize(String source);
+
+  String serialize(T object);
+
+  @override
+  Future<Iterable<T>> all() =>
+      storage.all<String>().then((value) => value.map(deserialize));
+
+  @override
+  Stream<Iterable<T>> watchAll() =>
+      storage.watchAll<String>().map((value) => value.map(deserialize));
+
+  @override
+  Future<void> put(String key, T value) => storage.put(key, serialize(value));
+}

--- a/lib/app/core/storage/collection_store.dart
+++ b/lib/app/core/storage/collection_store.dart
@@ -12,26 +12,11 @@ abstract class ICollectionStore<T> {
   Future<void> removeAll(Iterable<String> keys);
 }
 
-mixin CollectionStore<T> on ICollectionStore<T> {
+mixin SerializableCollectionStore<T> on ICollectionStore<T> {
   IPersistentStorageFactory get storageFactory;
 
   late final IPersistentStorage storage = storageFactory.create(name);
 
-  @override
-  Future<Iterable<T>> all() => storage.all();
-
-  @override
-  Stream<Iterable<T>> watchAll() => storage.watchAll();
-
-  @override
-  Future<void> put(String key, T value) => storage.put(key, value);
-
-  @override
-  Future<void> removeAll(Iterable<String> keys) => storage.removeAll(keys);
-}
-
-mixin SerializableCollectionStore<T> on ICollectionStore<T>
-    implements CollectionStore<T> {
   T deserialize(String source);
 
   String serialize(T object);
@@ -46,4 +31,7 @@ mixin SerializableCollectionStore<T> on ICollectionStore<T>
 
   @override
   Future<void> put(String key, T value) => storage.put(key, serialize(value));
+
+  @override
+  Future<void> removeAll(Iterable<String> keys) => storage.removeAll(keys);
 }

--- a/lib/app/core/storage/impl/hive_persistent_storage.dart
+++ b/lib/app/core/storage/impl/hive_persistent_storage.dart
@@ -5,36 +5,52 @@ import '../i_local_storage.dart';
 import '../persistent_storage.dart';
 import 'hive_storage_mixin.dart';
 
+/// Factory to create [IPersistentStorage] with Hive implementation.
 class HivePersistentStorageFactory extends IPersistentStorageFactory {
+  /// Creates a [HivePersistentStorageFactory].
+  ///
+  /// [encryptionKeyStorage] storage to retrieve the encryption key.
+  /// [hive] is optional, it's used to inject a mock for testing.
   HivePersistentStorageFactory({
     required ILocalStorage encryptionKeyStorage,
-  }) : _encryptionKeyStorage = encryptionKeyStorage;
+    HiveInterface? hive,
+  })  : _encryptionKeyStorage = encryptionKeyStorage,
+        _hive = hive ?? Hive; // coverage:ignore-line
 
   final ILocalStorage _encryptionKeyStorage;
+  final HiveInterface _hive;
 
   @override
   IPersistentStorage create(String name) => HivePersistentStorage(
         name: name,
         encryptionKeyStorage: _encryptionKeyStorage,
+        hive: _hive,
       );
 }
 
+/// [IPersistentStorage] implementation with Hive.
 class HivePersistentStorage extends IPersistentStorage with HiveStorage {
+  /// Creates a [HivePersistentStorage].
+  ///
+  /// [name] name of the box to be opened.
+  /// [encryptionKeyStorage] storage to retrieve the encryption key.
+  /// [hive] is optional, it's used to inject a mock for testing.
   HivePersistentStorage({
     required String name,
     required ILocalStorage encryptionKeyStorage,
-    Box? box,
+    HiveInterface? hive,
   })  : _name = name,
         _encryptionKeyStorage = encryptionKeyStorage,
-        _box = box;
+        _hive = hive ?? Hive; // coverage:ignore-line
 
   final String _name;
   final ILocalStorage _encryptionKeyStorage;
+  final HiveInterface _hive;
 
   Box? _box;
 
   @override
-  Future<Box> get box async => _box ??= await Hive.openSecureBox(
+  Future<Box> get box async => _box ??= await _hive.openSecureBox(
         _name,
         encryptionKeyStorage: _encryptionKeyStorage,
       );

--- a/lib/app/core/storage/impl/hive_persistent_storage_factory.dart
+++ b/lib/app/core/storage/impl/hive_persistent_storage_factory.dart
@@ -1,0 +1,57 @@
+import 'dart:async';
+
+import '../../extension/hive.dart';
+import '../i_local_storage.dart';
+import '../persistent_storage.dart';
+import 'hive_storage_mixin.dart';
+
+class HivePersistentStorageFactory extends IPersistentStorageFactory {
+  HivePersistentStorageFactory({
+    required ILocalStorage encryptionKeyStorage,
+  }) : _encryptionKeyStorage = encryptionKeyStorage;
+
+  final ILocalStorage _encryptionKeyStorage;
+
+  @override
+  IPersistentStorage create(String name) => HivePersistentStorage(
+        name: name,
+        encryptionKeyStorage: _encryptionKeyStorage,
+      );
+}
+
+class HivePersistentStorage extends IPersistentStorage with HiveStorage {
+  HivePersistentStorage({
+    required String name,
+    required ILocalStorage encryptionKeyStorage,
+    Box? box,
+  })  : _name = name,
+        _encryptionKeyStorage = encryptionKeyStorage,
+        _box = box;
+
+  final String _name;
+  final ILocalStorage _encryptionKeyStorage;
+
+  Box? _box;
+
+  @override
+  Future<Box> get box async => _box ??= await Hive.openSecureBox(
+        _name,
+        encryptionKeyStorage: _encryptionKeyStorage,
+      );
+
+  @override
+  Future<Iterable<T>> all<T>() async {
+    final box = await this.box;
+    return box.values.whereType();
+  }
+
+  @override
+  Stream<Iterable<T>> watchAll<T>() async* {
+    final box = await this.box;
+    final iterable = StreamIterator(box.watch());
+
+    do {
+      yield box.values.whereType();
+    } while (await iterable.moveNext());
+  }
+}

--- a/lib/app/core/storage/persistent_storage.dart
+++ b/lib/app/core/storage/persistent_storage.dart
@@ -1,0 +1,13 @@
+import 'key_value_storage.dart';
+
+export 'key_value_storage.dart' show IKeyValueStorageExt;
+
+abstract class IPersistentStorage extends IKeyValueStorage {
+  Future<Iterable<T>> all<T>();
+
+  Stream<Iterable<T>> watchAll<T>();
+}
+
+abstract class IPersistentStorageFactory {
+  IPersistentStorage create(String name);
+}

--- a/lib/app/features/escape_manual/data/datastore/escape_manual_persistent_storage.dart
+++ b/lib/app/features/escape_manual/data/datastore/escape_manual_persistent_storage.dart
@@ -6,7 +6,7 @@ import '../model/escape_manual_local.dart';
 
 class EscapeManualTasksStore
     extends ICollectionStore<EscapeManualTaskLocalModel>
-    with CollectionStore, SerializableCollectionStore {
+    with SerializableCollectionStore {
   EscapeManualTasksStore({
     required this.storageFactory,
   });

--- a/lib/app/features/escape_manual/data/datastore/escape_manual_persistent_storage.dart
+++ b/lib/app/features/escape_manual/data/datastore/escape_manual_persistent_storage.dart
@@ -1,0 +1,27 @@
+import 'dart:convert';
+
+import '../../../../core/storage/collection_store.dart';
+import '../../../../core/storage/persistent_storage.dart';
+import '../model/escape_manual_local.dart';
+
+class EscapeManualTasksStore
+    extends ICollectionStore<EscapeManualTaskLocalModel>
+    with CollectionStore, SerializableCollectionStore {
+  EscapeManualTasksStore({
+    required this.storageFactory,
+  });
+
+  @override
+  final name = 'escape_manual_tasks';
+
+  @override
+  final IPersistentStorageFactory storageFactory;
+
+  @override
+  EscapeManualTaskLocalModel deserialize(String source) =>
+      EscapeManualTaskLocalModel.fromJson(jsonDecode(source));
+
+  @override
+  String serialize(EscapeManualTaskLocalModel object) =>
+      jsonEncode(object.toJson());
+}

--- a/lib/app/features/escape_manual/data/model/escape_manual_local.dart
+++ b/lib/app/features/escape_manual/data/model/escape_manual_local.dart
@@ -1,0 +1,64 @@
+import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+import '../../../../core/extension/json_serializer.dart';
+import '../../domain/entity/escape_manual.dart';
+
+part 'escape_manual_local.g.dart';
+
+@JsonSerializable()
+class EscapeManualTaskLocalModel extends Equatable {
+  const EscapeManualTaskLocalModel({
+    required this.id,
+    this.isDone = false,
+    this.isRemoved = false,
+    this.updatedAt,
+  });
+
+  factory EscapeManualTaskLocalModel.fromEntity(
+    EscapeManualTaskEntity entity,
+  ) =>
+      EscapeManualTaskLocalModel(
+        id: entity.id,
+        isDone: entity.isDone,
+      );
+
+  factory EscapeManualTaskLocalModel.fromJson(Map<String, dynamic> map) =>
+      _$EscapeManualTaskLocalModelFromJson(map);
+
+  static Iterable<EscapeManualTaskLocalModel> fromJsonList(
+    List<dynamic> map,
+  ) =>
+      map.map<EscapeManualTaskLocalModel>(
+        (task) => EscapeManualTaskLocalModel.fromJson(task),
+      );
+
+  @JsonKey(fromJson: FromJson.parseAsString)
+  final String id;
+
+  @JsonKey()
+  final bool isDone;
+
+  @JsonKey()
+  final bool isRemoved;
+
+  @JsonKey()
+  final DateTime? updatedAt;
+
+  @override
+  List<Object?> get props => [id, isDone, isRemoved, updatedAt];
+
+  Map<String, dynamic> toJson() => _$EscapeManualTaskLocalModelToJson(this);
+
+  EscapeManualTaskLocalModel copyWith({
+    bool? isDone,
+    bool? isRemoved,
+    DateTime? updatedAt,
+  }) =>
+      EscapeManualTaskLocalModel(
+        id: id,
+        isDone: isDone ?? this.isDone,
+        isRemoved: isRemoved ?? this.isRemoved,
+        updatedAt: updatedAt ?? this.updatedAt,
+      );
+}

--- a/lib/app/features/escape_manual/data/model/escape_manual_local.g.dart
+++ b/lib/app/features/escape_manual/data/model/escape_manual_local.g.dart
@@ -1,0 +1,36 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'escape_manual_local.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+EscapeManualTaskLocalModel _$EscapeManualTaskLocalModelFromJson(
+        Map<String, dynamic> json) =>
+    EscapeManualTaskLocalModel(
+      id: FromJson.parseAsString(json['id']),
+      isDone: json['isDone'] as bool? ?? false,
+      isRemoved: json['isRemoved'] as bool? ?? false,
+      updatedAt: json['updatedAt'] == null
+          ? null
+          : DateTime.parse(json['updatedAt'] as String),
+    );
+
+Map<String, dynamic> _$EscapeManualTaskLocalModelToJson(
+    EscapeManualTaskLocalModel instance) {
+  final val = <String, dynamic>{
+    'id': instance.id,
+    'isDone': instance.isDone,
+    'isRemoved': instance.isRemoved,
+  };
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('updatedAt', instance.updatedAt?.toIso8601String());
+  return val;
+}

--- a/test/app/core/storage/impl/hive_persistent_storage_test.dart
+++ b/test/app/core/storage/impl/hive_persistent_storage_test.dart
@@ -1,0 +1,166 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:penhas/app/core/storage/i_local_storage.dart';
+import 'package:penhas/app/core/storage/impl/hive_persistent_storage.dart';
+import 'package:penhas/app/core/storage/persistent_storage.dart';
+
+void main() {
+  group(HivePersistentStorage, () {
+    late IPersistentStorage sut;
+    late IPersistentStorageFactory factory;
+
+    late ILocalStorage mockLocalStorage;
+    late Box mockBox;
+    late HiveInterface mockHive;
+
+    setUp(() {
+      mockLocalStorage = _MockLocalStorage();
+      mockBox = _MockBox();
+      mockHive = _MockHive();
+
+      factory = HivePersistentStorageFactory(
+        encryptionKeyStorage: mockLocalStorage,
+        hive: mockHive,
+      );
+
+      when(() => mockLocalStorage.get(any())).thenAnswer(
+        (_) async => 'Hki-NPifsJbbCGou0I9Z8VNyo3RKlFwP_LHnWBAu1NY=',
+      );
+
+      when(
+        () => mockHive.openBox(
+          any(),
+          path: any(named: 'path'),
+          encryptionCipher: any(named: 'encryptionCipher'),
+        ),
+      ).thenAnswer((_) async => mockBox);
+
+      sut = factory.create('test');
+    });
+
+    test(
+      'all should return values',
+      () async {
+        // arrange
+        when(() => mockBox.values).thenReturn(['test']);
+
+        // act
+        final result = await sut.all<String>();
+
+        // assert
+        expect(result, ['test']);
+      },
+    );
+
+    test(
+      'watchAll should return values',
+      () async {
+        // arrange
+        final events = [
+          ['zero'],
+          ['zero', 'one'],
+        ];
+        when(() => mockBox.watch()).thenAnswer(
+          (_) => Stream.fromIterable([
+            BoxEvent('0', 'zero', false),
+            BoxEvent('1', 'one', false),
+          ]),
+        );
+        when(() => mockBox.values).thenAnswer((_) => events.removeAt(0));
+
+        // act / assert
+        expectLater(
+          sut.watchAll<String>(),
+          emitsInOrder([
+            ['zero'],
+            ['zero', 'one'],
+          ]),
+        );
+      },
+    );
+
+    test(
+      'get should call box.get',
+      () async {
+        // arrange
+        final key = 'persistent key';
+        final savedValue = 'saved value';
+        when(() => mockBox.get(any())).thenAnswer((_) async => savedValue);
+
+        // act
+        final actual = await sut.getString(key);
+
+        // assert
+        verify(() => mockBox.get(key)).called(1);
+        expect(actual, equals(savedValue));
+      },
+    );
+
+    test(
+      'put should call box.put',
+      () async {
+        // arrange
+        final key = 'new persistent key';
+        final newValue = 'value to save';
+        when(() => mockBox.put(any(), any())).thenAnswer((_) => Future.value());
+
+        // act
+        await sut.putString(key, newValue);
+
+        // assert
+        verify(() => mockBox.put(key, newValue)).called(1);
+      },
+    );
+
+    test(
+      'remove should call box.delete',
+      () async {
+        // arrange
+        final key = 'key to remove';
+        when(() => mockBox.delete(any())).thenAnswer((_) => Future.value());
+
+        // act
+        await sut.remove(key);
+
+        // assert
+        verify(() => mockBox.delete(key)).called(1);
+      },
+    );
+
+    test(
+      'removeAll should call box.deleteAll',
+      () async {
+        // arrange
+        final keys = ['first key', 'second key', 'third key'];
+        when(() => mockBox.deleteAll(any())).thenAnswer((_) => Future.value());
+
+        // act
+        await sut.removeAll(keys);
+
+        // assert
+        verify(() => mockBox.deleteAll(keys)).called(1);
+      },
+    );
+
+    test(
+      'clear should call box.clear',
+      () async {
+        // arrange
+        when(() => mockBox.clear()).thenAnswer((_) => Future.value(0));
+
+        // act
+        await sut.clear();
+
+        // assert
+        verify(() => mockBox.clear()).called(1);
+      },
+    );
+  });
+}
+
+class _MockLocalStorage extends Mock implements ILocalStorage {}
+
+class _MockBox extends Mock implements Box {}
+
+class _MockHive extends Mock implements HiveInterface {}

--- a/test/app/features/escape_manual/data/datastore/escape_manual_persistent_storage_test.dart
+++ b/test/app/features/escape_manual/data/datastore/escape_manual_persistent_storage_test.dart
@@ -1,0 +1,162 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:penhas/app/core/storage/collection_store.dart';
+import 'package:penhas/app/core/storage/persistent_storage.dart';
+import 'package:penhas/app/features/escape_manual/data/datastore/escape_manual_persistent_storage.dart';
+import 'package:penhas/app/features/escape_manual/data/model/escape_manual_local.dart';
+
+void main() {
+  group(EscapeManualTasksStore, () {
+    late ICollectionStore<EscapeManualTaskLocalModel> sut;
+
+    late IPersistentStorageFactory mockStorageFactory;
+    late IPersistentStorage mockStorage;
+
+    setUp(() {
+      mockStorageFactory = _MockPersistentStorageFactory();
+      mockStorage = _MockPersistentStorage();
+
+      sut = EscapeManualTasksStore(storageFactory: mockStorageFactory);
+
+      when(() => mockStorageFactory.create(any())).thenReturn(mockStorage);
+    });
+
+    test(
+      'should call factory with correct name',
+      () async {
+        // arrange
+        when(() => mockStorage.all<String>()).thenAnswer((_) async => []);
+
+        // act
+        await sut.all();
+
+        // assert
+        verify(() => mockStorageFactory.create('escape_manual_tasks'))
+            .called(1);
+      },
+    );
+
+    test(
+      'all should return deserialized values',
+      () async {
+        // arrange
+        when(() => mockStorage.all<String>()).thenAnswer(
+          (_) async => [
+            '{"id":"id 0","isDone":false,"isRemoved":true,"updatedAt":"2023-11-06T18:29:33.000"}',
+            '{"id":"id 1","isDone":true,"isRemoved":false,"updatedAt":"2023-11-06T18:34:24.000"}',
+          ],
+        );
+
+        // act
+        final result = await sut.all();
+
+        // assert
+        expect(
+          result,
+          [
+            EscapeManualTaskLocalModel(
+              id: 'id 0',
+              isDone: false,
+              isRemoved: true,
+              updatedAt: DateTime(2023, 11, 06, 18, 29, 33),
+            ),
+            EscapeManualTaskLocalModel(
+              id: 'id 1',
+              isDone: true,
+              isRemoved: false,
+              updatedAt: DateTime(2023, 11, 06, 18, 34, 24),
+            ),
+          ],
+        );
+        verify(() => mockStorage.all<String>()).called(1);
+      },
+    );
+
+    test(
+      'watchAll emits deserialized values',
+      () async {
+        // arrange
+        when(() => mockStorage.watchAll<String>()).thenAnswer(
+          (_) => Stream.fromIterable([
+            [
+              '{"id":"id 0","isDone":false,"isRemoved":true,"updatedAt":"2023-11-06T18:47:08.000"}',
+              '{"id":"id 1","isDone":true,"isRemoved":false,"updatedAt":"2023-11-06T18:48:10.000"}',
+            ],
+          ]),
+        );
+
+        // act / assert
+        expectLater(
+          sut.watchAll(),
+          emits([
+            EscapeManualTaskLocalModel(
+              id: 'id 0',
+              isDone: false,
+              isRemoved: true,
+              updatedAt: DateTime(2023, 11, 06, 18, 47, 08),
+            ),
+            EscapeManualTaskLocalModel(
+              id: 'id 1',
+              isDone: true,
+              isRemoved: false,
+              updatedAt: DateTime(2023, 11, 06, 18, 48, 10),
+            ),
+          ]),
+        );
+        verify(() => mockStorage.watchAll<String>()).called(1);
+      },
+    );
+
+    test(
+      'put should store serialized value',
+      () async {
+        // arrange
+        final taskId = 'some id key';
+        when(() => mockStorage.put(any(), any<String>()))
+            .thenAnswer((_) => Future.value());
+
+        // act
+        await sut.put(
+          taskId,
+          EscapeManualTaskLocalModel(
+            id: taskId,
+            isDone: false,
+            isRemoved: false,
+            updatedAt: DateTime(2023, 11, 06, 18, 29, 33),
+          ),
+        );
+
+        // assert
+        final verifier =
+            verify(() => mockStorage.put(taskId, captureAny<String>()));
+        verifier.called(1);
+        expect(
+          verifier.captured.single,
+          '{"id":"some id key","isDone":false,"isRemoved":false,"updatedAt":"2023-11-06T18:29:33.000"}',
+        );
+      },
+    );
+
+    test(
+      'removeAll should call storage.removeAll',
+      () async {
+        // arrange
+        final keys = ['first key', 'second key', 'third key'];
+        when(() => mockStorage.removeAll(any())).thenAnswer(
+          (_) => Future.value(),
+        );
+
+        // act
+        await sut.removeAll(keys);
+
+        // assert
+        verify(() => mockStorage.removeAll(keys)).called(1);
+      },
+    );
+  });
+}
+
+class _MockPersistentStorageFactory extends Mock
+    implements IPersistentStorageFactory {}
+
+class _MockPersistentStorage extends Mock implements IPersistentStorage {}


### PR DESCRIPTION
- adiciona abstração `ICollectionStore` e mixin `SerializableCollectionStore` onde lida com dados serializados como string
- implementação da persistencia permanente utilizando o `Hive`
- implementa `EscapeManualTasksStore` para lidar com o tipo que será utilizado para persistir as tarefas localmente
- adiciona os modelos de dados locais