### PR TITLE
Torna reativo o carregamento do manual de fuga

### DIFF
--- a/lib/app/core/extension/mobx.dart
+++ b/lib/app/core/extension/mobx.dart
@@ -14,3 +14,17 @@ extension ObservableFutureExt on ObservableFuture? {
     }
   }
 }
+
+extension ObservableStreamExt on ObservableStream? {
+  PageProgressState get state {
+    switch (this?.status) {
+      case StreamStatus.waiting:
+        return PageProgressState.loading;
+      case StreamStatus.active:
+      case StreamStatus.done:
+        return PageProgressState.loaded;
+      default:
+        return PageProgressState.initial;
+    }
+  }
+}

--- a/lib/app/features/escape_manual/data/repository/escape_manual_repository.dart
+++ b/lib/app/features/escape_manual/data/repository/escape_manual_repository.dart
@@ -33,14 +33,14 @@ class EscapeManualRepository implements IEscapeManualRepository {
   }
 
   @override
-  Future<Either<Failure, EscapeManualEntity>> fetch() async {
+  Stream<EscapeManualEntity> fetch() async* {
     try {
       final response = await _remoteDatasource.fetch();
 
-      return right(response.asEntity);
+      yield response.asEntity;
     } catch (error, stack) {
       logError(error, stack);
-      return left(MapExceptionToFailure.map(error));
+      throw MapExceptionToFailure.map(error);
     }
   }
 }

--- a/lib/app/features/escape_manual/domain/get_escape_manual.dart
+++ b/lib/app/features/escape_manual/domain/get_escape_manual.dart
@@ -1,6 +1,3 @@
-import 'package:dartz/dartz.dart';
-
-import '../../../core/error/failures.dart';
 import 'entity/escape_manual.dart';
 import 'repository/escape_manual_repository.dart';
 
@@ -11,5 +8,5 @@ class GetEscapeManualUseCase {
 
   final IEscapeManualRepository _repository;
 
-  Future<Either<Failure, EscapeManualEntity>> call() => _repository.fetch();
+  Stream<EscapeManualEntity> call() => _repository.fetch();
 }

--- a/lib/app/features/escape_manual/domain/repository/escape_manual_repository.dart
+++ b/lib/app/features/escape_manual/domain/repository/escape_manual_repository.dart
@@ -6,5 +6,5 @@ import '../entity/escape_manual.dart';
 
 abstract class IEscapeManualRepository {
   Future<Either<Failure, QuizSessionEntity>> start(String sessionId);
-  Future<Either<Failure, EscapeManualEntity>> fetch();
+  Stream<EscapeManualEntity> fetch();
 }

--- a/lib/app/features/escape_manual/presentation/escape_manual_controller.dart
+++ b/lib/app/features/escape_manual/presentation/escape_manual_controller.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:dartz/dartz.dart';
 import 'package:flutter_modular/flutter_modular.dart';
+import 'package:meta/meta.dart';
 import 'package:mobx/mobx.dart';
 
 import '../../../core/error/failures.dart';
@@ -43,7 +44,8 @@ abstract class _EscapeManualControllerBase with Store, MapFailureMessage {
   @observable
   ObservableFuture? _pageProgress;
 
-  StreamSubscription? _subscription;
+  @visibleForTesting
+  StreamSubscription? subscription;
 
   ObservableStream<EscapeManualEntity>? _loadProgress;
   late ObservableFuture<Either<Failure, QuizSessionEntity>> _startProgress;
@@ -53,7 +55,7 @@ abstract class _EscapeManualControllerBase with Store, MapFailureMessage {
     if (progressState == PageProgressState.loading ||
         _loadProgress.state == PageProgressState.loading) return;
 
-    _subscription?.cancel();
+    subscription?.cancel();
 
     _loadProgress = ObservableStream(
       _getEscapeManual(),
@@ -62,7 +64,7 @@ abstract class _EscapeManualControllerBase with Store, MapFailureMessage {
 
     _pageProgress = _loadProgress?.first;
 
-    _subscription = _loadProgress?.listen(
+    subscription = _loadProgress?.listen(
       (el) => state = _handleLoadSuccess(el),
       onError: (e) => state = _handleLoadFailure(e),
       cancelOnError: true,
@@ -86,9 +88,9 @@ abstract class _EscapeManualControllerBase with Store, MapFailureMessage {
   }
 
   Future<void> dispose() async {
-    await _subscription?.cancel();
+    await subscription?.cancel();
     _loadProgress?.close();
-    _subscription = null;
+    subscription = null;
   }
 
   EscapeManualState _handleLoadFailure(Failure failure) {

--- a/lib/app/features/escape_manual/presentation/escape_manual_page.dart
+++ b/lib/app/features/escape_manual/presentation/escape_manual_page.dart
@@ -40,6 +40,7 @@ class _EscapeManualPageState
   @override
   void dispose() {
     _disposer?.call();
+    controller.dispose();
     super.dispose();
   }
 

--- a/test/app/features/escape_manual/data/repository/escape_manual_repository_test.dart
+++ b/test/app/features/escape_manual/data/repository/escape_manual_repository_test.dart
@@ -41,7 +41,7 @@ void main() {
               .thenAnswer((_) async => escapeManual);
 
           // act
-          await sut.fetch();
+          await sut.fetch().drain();
 
           // assert
           verify(() => mockRemoteDatasource.fetch()).called(1);
@@ -58,11 +58,11 @@ void main() {
           when(() => mockRemoteDatasource.fetch())
               .thenAnswer((_) async => escapeManualModel);
 
-          // act
-          final result = await sut.fetch();
-
-          // assert
-          expect(result, right(expectedEscapeManual));
+          // act / assert
+          expectLater(
+            sut.fetch(),
+            emits(expectedEscapeManual),
+          );
         },
       );
 
@@ -72,12 +72,11 @@ void main() {
           // arrange
           when(() => mockRemoteDatasource.fetch()).thenThrow(Exception());
 
-          // act
-          final result = await sut.fetch();
-
-          // assert
-          expect(result.isLeft(), isTrue);
-          expect(result.fold(id, id), isA<Failure>());
+          // act / assert
+          expectLater(
+            sut.fetch(),
+            emitsError(isA<ServerFailure>()),
+          );
         },
       );
     });

--- a/test/app/features/escape_manual/domain/get_escape_manual_test.dart
+++ b/test/app/features/escape_manual/domain/get_escape_manual_test.dart
@@ -1,9 +1,7 @@
 import 'dart:async';
 
-import 'package:dartz/dartz.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:penhas/app/core/error/failures.dart';
 import 'package:penhas/app/features/appstate/domain/entities/app_state_entity.dart';
 import 'package:penhas/app/features/escape_manual/domain/entity/escape_manual.dart';
 import 'package:penhas/app/features/escape_manual/domain/get_escape_manual.dart';
@@ -27,9 +25,9 @@ void main() {
       'should call repository fetch',
       () async {
         // arrange
-        final completer = Completer<Either<Failure, EscapeManualEntity>>();
+        final completer = Completer<EscapeManualEntity>();
         when(() => mockEscapeManualRepository.fetch())
-            .thenAnswer((_) async => completer.future);
+            .thenAnswer((_) => Stream.fromFuture(completer.future));
 
         // act
         sut();
@@ -59,13 +57,13 @@ void main() {
         );
 
         when(() => mockEscapeManualRepository.fetch())
-            .thenAnswer((_) async => right(escapeManual));
+            .thenAnswer((_) => Stream.value(escapeManual));
 
-        // act
-        final result = await sut();
-
-        // assert
-        expect(result, right(escapeManual));
+        // act / assert
+        expectLater(
+          sut(),
+          emits(escapeManual),
+        );
       },
     );
   });

--- a/test/app/features/escape_manual/presentation/escape_manual_controller_test.dart
+++ b/test/app/features/escape_manual/presentation/escape_manual_controller_test.dart
@@ -20,15 +20,15 @@ void main() {
   late GetEscapeManualUseCase mockGetEscapeManual;
   late StartEscapeManualUseCase mockStartEscapeManual;
 
-  late Completer<Either<Failure, EscapeManualEntity>> getEscapeManualCompleter;
+  late Completer<EscapeManualEntity> getEscapeManualCompleter;
 
   setUp(() {
-    mockGetEscapeManual = GetEscapeManualUseCaseMock();
-    mockStartEscapeManual = StartEscapeManualUseCaseMock();
+    mockGetEscapeManual = _MockGetEscapeManualUseCase();
+    mockStartEscapeManual = _MockStartEscapeManualUseCase();
     getEscapeManualCompleter = Completer();
 
     when(() => mockGetEscapeManual())
-        .thenAnswer((_) async => getEscapeManualCompleter.future);
+        .thenAnswer((_) => Stream.fromFuture(getEscapeManualCompleter.future));
 
     sut = EscapeManualController(
       getEscapeManual: mockGetEscapeManual,
@@ -100,7 +100,7 @@ void main() {
           );
 
           // act
-          getEscapeManualCompleter.complete(right(escapeManual));
+          getEscapeManualCompleter.complete(escapeManual);
           await sut.load();
 
           // assert
@@ -128,7 +128,7 @@ void main() {
           );
 
           // act
-          getEscapeManualCompleter.complete(right(escapeManual));
+          getEscapeManualCompleter.complete(escapeManual);
           await sut.load();
 
           // assert
@@ -144,7 +144,7 @@ void main() {
         () async {
           // arrange
           final failure = ServerFailure();
-          getEscapeManualCompleter.complete(left(failure));
+          getEscapeManualCompleter.completeError(failure);
 
           // act
           await sut.load();
@@ -181,7 +181,7 @@ void main() {
 
       setUp(() {
         startEscapeManualCompleter = Completer();
-        Modular.navigatorDelegate = mockNavigator = MockModularNavigate();
+        Modular.navigatorDelegate = mockNavigator = _MockModularNavigate();
 
         when(() => mockStartEscapeManual(any()))
             .thenAnswer((_) async => startEscapeManualCompleter.future);
@@ -256,7 +256,7 @@ void main() {
         'should emit showSnackbar reaction when failed',
         () async {
           // arrange
-          final onReactionMock = MockOnEscapeManualReaction();
+          final onReactionMock = _MockOnEscapeManualReaction();
           final failure = ServerFailure();
           startEscapeManualCompleter.complete(left(failure));
           sut.onReaction(onReactionMock);
@@ -278,17 +278,17 @@ void main() {
   });
 }
 
-class GetEscapeManualUseCaseMock extends Mock
+class _MockGetEscapeManualUseCase extends Mock
     implements GetEscapeManualUseCase {}
 
-class StartEscapeManualUseCaseMock extends Mock
+class _MockStartEscapeManualUseCase extends Mock
     implements StartEscapeManualUseCase {}
 
-class MockModularNavigate extends Mock implements IModularNavigator {}
+class _MockModularNavigate extends Mock implements IModularNavigator {}
 
-abstract class IOnEscapeManualReaction {
+abstract class _IOnEscapeManualReaction {
   void call(EscapeManualReaction? reaction);
 }
 
-class MockOnEscapeManualReaction extends Mock
-    implements IOnEscapeManualReaction {}
+class _MockOnEscapeManualReaction extends Mock
+    implements _IOnEscapeManualReaction {}

--- a/test/app/features/escape_manual/presentation/escape_manual_controller_test.dart
+++ b/test/app/features/escape_manual/presentation/escape_manual_controller_test.dart
@@ -45,6 +45,17 @@ void main() {
       },
     );
 
+    test('dispose should cancel subscription', () async {
+      // arrange
+      await sut.load();
+
+      // act
+      await sut.dispose();
+
+      // assert
+      expect(sut.subscription, null);
+    });
+
     group('load', () {
       test(
         'should call getEscapeManual',

--- a/test/app/features/escape_manual/presentation/escape_manual_page_test.dart
+++ b/test/app/features/escape_manual/presentation/escape_manual_page_test.dart
@@ -41,6 +41,8 @@ void main() {
         .thenReturn(PageProgressState.initial);
     when(() => mockController.onReaction(any()))
         .thenAnswer((invocation) => _MockReactionDisposer());
+
+    when(() => mockController.dispose()).thenAnswer((_) async {});
   });
 
   tearDownAll(() {


### PR DESCRIPTION
Utiliza `Stream` em vez de `Future` para permitir que a tela responda às alterações que ocorrem na fonte dos dados de maneira reativa.