### PR TITLE
Adiciona uso do campo 'consultado_em' para o controle do cache

### DIFF
--- a/lib/app/core/extension/date_time.dart
+++ b/lib/app/core/extension/date_time.dart
@@ -2,8 +2,6 @@ extension DateTimeExt on DateTime {
   int get secondsSinceEpoch =>
       millisecondsSinceEpoch ~/ Duration.millisecondsPerSecond;
 
-  static DateTime get epoch => DateTime.utc(1970);
-
   static DateTime fromSecondsSinceEpoch(
     int secondsSinceEpoch, {
     bool isUtc = false,

--- a/lib/app/features/escape_manual/data/datasource/impl/escape_manual_remote_datasource.dart
+++ b/lib/app/features/escape_manual/data/datasource/impl/escape_manual_remote_datasource.dart
@@ -34,13 +34,13 @@ class EscapeManualRemoteDatasource implements IEscapeManualRemoteDatasource {
   @override
   Future<EscapeManualRemoteModel> fetch() async {
     final cached = await _cacheStorage.retrieve();
-    final lastChangeAt = cached?.lastModifiedAt.secondsSinceEpoch ?? -1;
+    final lastChangeAt = cached?.lastModifiedAt.secondsSinceEpoch ?? 0;
 
     try {
       final response = await _apiProvider.get(
         path: '/me/tarefas',
         parameters: {
-          'modificado_apos': '${lastChangeAt + 1}',
+          'modificado_apos': '$lastChangeAt',
         },
       ).then(jsonDecode);
 
@@ -77,6 +77,7 @@ class EscapeManualRemoteDatasource implements IEscapeManualRemoteDatasource {
         .whereType<EscapeManualTaskRemoteModel>();
 
     return cached.copyWith(
+      lastModifiedAt: newer.lastModifiedAt,
       assistant: newer.assistant,
       tasks: updatedTasks + changedTasks.values,
     );

--- a/lib/app/features/escape_manual/data/model/escape_manual_remote.dart
+++ b/lib/app/features/escape_manual/data/model/escape_manual_remote.dart
@@ -1,7 +1,6 @@
 import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
-import '../../../../core/extension/date_time.dart';
 import '../../../../core/extension/json_serializer.dart';
 import '../../../appstate/data/model/quiz_session_model.dart';
 
@@ -9,7 +8,8 @@ part 'escape_manual_remote.g.dart';
 
 @JsonSerializable()
 class EscapeManualRemoteModel extends Equatable {
-  EscapeManualRemoteModel({
+  const EscapeManualRemoteModel({
+    required this.lastModifiedAt,
     required this.assistant,
     this.tasks = const [],
     this.removedTasks = const [],
@@ -27,21 +27,23 @@ class EscapeManualRemoteModel extends Equatable {
   @JsonKey(name: 'tarefas_removidas', fromJson: FromJson.parseAsStringList)
   final Iterable<String> removedTasks;
 
-  late final DateTime lastModifiedAt = tasks.fold<DateTime>(
-    DateTimeExt.epoch,
-    (acc, cur) => acc > cur.updatedAt ? acc : cur.updatedAt,
-  );
+  @JsonKey(name: 'consultado_em')
+  @JsonSecondsFromEpochConverter()
+  final DateTime lastModifiedAt;
 
   @override
-  List<Object?> get props => [assistant, tasks.toList(), removedTasks.toList()];
+  List<Object?> get props =>
+      [lastModifiedAt, assistant, tasks.toList(), removedTasks.toList()];
 
   Map<String, dynamic> toJson() => _$EscapeManualRemoteModelToJson(this);
 
   EscapeManualRemoteModel copyWith({
+    DateTime? lastModifiedAt,
     EscapeManualAssistantRemoteModel? assistant,
     Iterable<EscapeManualTaskRemoteModel>? tasks,
   }) =>
       EscapeManualRemoteModel(
+        lastModifiedAt: lastModifiedAt ?? this.lastModifiedAt,
         assistant: assistant ?? this.assistant,
         tasks: tasks ?? this.tasks,
       );

--- a/lib/app/features/escape_manual/data/model/escape_manual_remote.g.dart
+++ b/lib/app/features/escape_manual/data/model/escape_manual_remote.g.dart
@@ -9,6 +9,8 @@ part of 'escape_manual_remote.dart';
 EscapeManualRemoteModel _$EscapeManualRemoteModelFromJson(
         Map<String, dynamic> json) =>
     EscapeManualRemoteModel(
+      lastModifiedAt: const JsonSecondsFromEpochConverter()
+          .fromJson(json['consultado_em'] as int),
       assistant: EscapeManualAssistantRemoteModel.fromJson(
           json['mf_assistant'] as Map<String, dynamic>),
       tasks: (json['tarefas'] as List<dynamic>?)?.map((e) =>
@@ -21,12 +23,23 @@ EscapeManualRemoteModel _$EscapeManualRemoteModelFromJson(
     );
 
 Map<String, dynamic> _$EscapeManualRemoteModelToJson(
-        EscapeManualRemoteModel instance) =>
-    <String, dynamic>{
-      'mf_assistant': instance.assistant,
-      'tarefas': instance.tasks.toList(),
-      'tarefas_removidas': instance.removedTasks.toList(),
-    };
+    EscapeManualRemoteModel instance) {
+  final val = <String, dynamic>{
+    'mf_assistant': instance.assistant,
+    'tarefas': instance.tasks.toList(),
+    'tarefas_removidas': instance.removedTasks.toList(),
+  };
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('consultado_em',
+      const JsonSecondsFromEpochConverter().toJson(instance.lastModifiedAt));
+  return val;
+}
 
 EscapeManualAssistantRemoteModel _$EscapeManualAssistantRemoteModelFromJson(
         Map<String, dynamic> json) =>

--- a/test/app/features/escape_manual/data/datasource/impl/escape_manual_remote_datasource_test.dart
+++ b/test/app/features/escape_manual/data/datasource/impl/escape_manual_remote_datasource_test.dart
@@ -226,7 +226,7 @@ void main() {
             );
             final cachedData =
                 EscapeManualRemoteModel.fromJson(jsonDecode(response));
-            const expectedLastModifiedAt = 1689701026;
+            const expectedLastModifiedAt = 1699916213;
 
             when(() => mockCacheStorage.retrieve())
                 .thenAnswer((_) async => cachedData);

--- a/test/app/features/escape_manual/data/model/escape_manual_fixtures.dart
+++ b/test/app/features/escape_manual/data/model/escape_manual_fixtures.dart
@@ -15,6 +15,7 @@ final escapeManualLocalModelsFixture = [
 ];
 
 final escapeManualModelFixture = EscapeManualRemoteModel(
+  lastModifiedAt: DateTime.fromMillisecondsSinceEpoch(1699916213000),
   assistant: const EscapeManualAssistantRemoteModel(
     title: 'text',
     subtitle: 'explanation',
@@ -138,6 +139,7 @@ final updatedEscapeManualEntityFixture = EscapeManualEntity(
 );
 
 final escapeManualRemoteModelFixture = EscapeManualRemoteModel(
+  lastModifiedAt: DateTime.fromMillisecondsSinceEpoch(1699916213000),
   assistant: const EscapeManualAssistantRemoteModel(
     title: 'action button',
     subtitle: 'Explanation',
@@ -189,6 +191,7 @@ final escapeManualRemoteModelFixture = EscapeManualRemoteModel(
 );
 
 final updatedEscapeManualRemoteModelFixture = EscapeManualRemoteModel(
+  lastModifiedAt: DateTime.fromMillisecondsSinceEpoch(1699916697000),
   assistant: const EscapeManualAssistantRemoteModel(
     title: 'new action button',
     subtitle: 'New explanation',

--- a/test/app/features/escape_manual/data/repository/escape_manual_repository_test.dart
+++ b/test/app/features/escape_manual/data/repository/escape_manual_repository_test.dart
@@ -40,6 +40,7 @@ void main() {
         () async {
           // arrange
           final escapeManual = EscapeManualRemoteModel(
+            lastModifiedAt: DateTime.now(),
             assistant: EscapeManualAssistantRemoteModel(
               title: 'text',
               subtitle: 'explanation',

--- a/test/assets/json/escape_manual/escape_manual_latest_response.json
+++ b/test/assets/json/escape_manual/escape_manual_latest_response.json
@@ -1,4 +1,5 @@
 {
+    "consultado_em": 1699916697,
     "mf_assistant": {
         "subtitle": "New explanation",
         "title": "new action button",

--- a/test/assets/json/escape_manual/escape_manual_response.json
+++ b/test/assets/json/escape_manual/escape_manual_response.json
@@ -1,4 +1,5 @@
 {
+    "consultado_em": 1699916213,
     "mf_assistant": {
         "subtitle": "Explanation",
         "title": "action button",


### PR DESCRIPTION
Antes o controle do cache era feito utilizando a maior data vinda da lista de tarefas modificadas, porém quando não haviam tarefas modificadas ou somente removidas, esse valor não existia, fazendo com que a requisição fosse feita sempre com o mesmo valor `modificado_apos` para ser feita a comparação. Esse PR utiliza o novo campo  `consultado_em` para fazer esse controle.