### PR TITLE
Camada de dominio e dados para a edição de contatos de confiança

### DIFF
--- a/lib/app/features/escape_manual/data/model/contact.dart
+++ b/lib/app/features/escape_manual/data/model/contact.dart
@@ -1,0 +1,30 @@
+import '../../domain/entity/contact.dart';
+
+export '../../domain/entity/contact.dart';
+
+class ContactModel extends ContactEntity {
+  const ContactModel({
+    required int id,
+    required String name,
+    required String phone,
+  }) : super(
+          id: id,
+          name: name,
+          phone: phone,
+        );
+
+  factory ContactModel.fromJson(Map<String, dynamic> json) => ContactModel(
+        id: json['id'] as int,
+        name: json['name'] as String,
+        phone: json['phone'] as String,
+      );
+
+  static List<ContactEntity> fromJsonList(List<dynamic> json) =>
+      json.map<ContactEntity>((e) => ContactModel.fromJson(e)).toList();
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'phone': phone,
+      };
+}

--- a/lib/app/features/escape_manual/data/model/escape_manual_local.dart
+++ b/lib/app/features/escape_manual/data/model/escape_manual_local.dart
@@ -3,6 +3,12 @@ import 'package:json_annotation/json_annotation.dart';
 
 import '../../../../core/extension/json_serializer.dart';
 import '../../domain/entity/escape_manual.dart';
+import 'escape_manual_mapper.dart'
+    show readUserInputValue, userInputValueFromJson;
+import 'escape_manual_task_type.dart';
+
+export 'contact.dart';
+export 'escape_manual_task_type.dart';
 
 part 'escape_manual_local.g.dart';
 
@@ -10,31 +16,35 @@ part 'escape_manual_local.g.dart';
 class EscapeManualTaskLocalModel extends Equatable {
   const EscapeManualTaskLocalModel({
     required this.id,
+    this.type = EscapeManualTaskType.normal,
+    this.value,
     this.isDone = false,
     this.isRemoved = false,
     this.updatedAt,
-  });
-
-  factory EscapeManualTaskLocalModel.fromEntity(
-    EscapeManualTaskEntity entity,
-  ) =>
-      EscapeManualTaskLocalModel(
-        id: entity.id,
-        isDone: entity.isDone,
-      );
+  })  : assert(type != EscapeManualTaskType.unknown),
+        assert(
+          type != EscapeManualTaskType.contacts ||
+              value is List<ContactEntity>?,
+          'Item $id with invalid value: $value', // coverage:ignore-line
+        );
 
   factory EscapeManualTaskLocalModel.fromJson(Map<String, dynamic> map) =>
       _$EscapeManualTaskLocalModelFromJson(map);
 
-  static Iterable<EscapeManualTaskLocalModel> fromJsonList(
-    List<dynamic> map,
-  ) =>
-      map.map<EscapeManualTaskLocalModel>(
-        (task) => EscapeManualTaskLocalModel.fromJson(task),
-      );
-
   @JsonKey(fromJson: FromJson.parseAsString)
   final String id;
+
+  @JsonKey(
+    defaultValue: EscapeManualTaskType.normal,
+    unknownEnumValue: EscapeManualTaskType.unknown,
+  )
+  final EscapeManualTaskType type;
+
+  @JsonKey(
+    readValue: readUserInputValue,
+    fromJson: userInputValueFromJson,
+  )
+  final dynamic value;
 
   @JsonKey()
   final bool isDone;
@@ -46,7 +56,7 @@ class EscapeManualTaskLocalModel extends Equatable {
   final DateTime? updatedAt;
 
   @override
-  List<Object?> get props => [id, isDone, isRemoved, updatedAt];
+  List<Object?> get props => [id, type, value, isDone, isRemoved, updatedAt];
 
   Map<String, dynamic> toJson() => _$EscapeManualTaskLocalModelToJson(this);
 
@@ -57,6 +67,8 @@ class EscapeManualTaskLocalModel extends Equatable {
   }) =>
       EscapeManualTaskLocalModel(
         id: id,
+        type: type,
+        value: value,
         isDone: isDone ?? this.isDone,
         isRemoved: isRemoved ?? this.isRemoved,
         updatedAt: updatedAt ?? this.updatedAt,

--- a/lib/app/features/escape_manual/data/model/escape_manual_local.g.dart
+++ b/lib/app/features/escape_manual/data/model/escape_manual_local.g.dart
@@ -10,6 +10,11 @@ EscapeManualTaskLocalModel _$EscapeManualTaskLocalModelFromJson(
         Map<String, dynamic> json) =>
     EscapeManualTaskLocalModel(
       id: FromJson.parseAsString(json['id']),
+      type: $enumDecodeNullable(_$EscapeManualTaskTypeEnumMap, json['type'],
+              unknownValue: EscapeManualTaskType.unknown) ??
+          EscapeManualTaskType.normal,
+      value: userInputValueFromJson(
+          readUserInputValue(json, 'value') as Map<String, dynamic>),
       isDone: json['isDone'] as bool? ?? false,
       isRemoved: json['isRemoved'] as bool? ?? false,
       updatedAt: json['updatedAt'] == null
@@ -21,8 +26,7 @@ Map<String, dynamic> _$EscapeManualTaskLocalModelToJson(
     EscapeManualTaskLocalModel instance) {
   final val = <String, dynamic>{
     'id': instance.id,
-    'isDone': instance.isDone,
-    'isRemoved': instance.isRemoved,
+    'type': _$EscapeManualTaskTypeEnumMap[instance.type]!,
   };
 
   void writeNotNull(String key, dynamic value) {
@@ -31,6 +35,15 @@ Map<String, dynamic> _$EscapeManualTaskLocalModelToJson(
     }
   }
 
+  writeNotNull('value', instance.value);
+  val['isDone'] = instance.isDone;
+  val['isRemoved'] = instance.isRemoved;
   writeNotNull('updatedAt', instance.updatedAt?.toIso8601String());
   return val;
 }
+
+const _$EscapeManualTaskTypeEnumMap = {
+  EscapeManualTaskType.normal: 'checkbox',
+  EscapeManualTaskType.contacts: 'checkbox_contato',
+  EscapeManualTaskType.unknown: 'unknown',
+};

--- a/lib/app/features/escape_manual/data/model/escape_manual_remote.dart
+++ b/lib/app/features/escape_manual/data/model/escape_manual_remote.dart
@@ -3,6 +3,13 @@ import 'package:json_annotation/json_annotation.dart';
 
 import '../../../../core/extension/json_serializer.dart';
 import '../../../appstate/data/model/quiz_session_model.dart';
+import 'contact.dart';
+import 'escape_manual_mapper.dart'
+    show readUserInputValue, userInputValueFromJson;
+import 'escape_manual_task_type.dart';
+
+export 'contact.dart';
+export 'escape_manual_task_type.dart';
 
 part 'escape_manual_remote.g.dart';
 
@@ -89,7 +96,13 @@ class EscapeManualTaskRemoteModel extends Equatable {
     this.isDone = false,
     this.userInputValue,
     required this.updatedAt,
-  });
+  })  : assert(type != EscapeManualTaskType.unknown),
+        assert(
+          type == EscapeManualTaskType.contacts
+              ? userInputValue is List<ContactEntity>?
+              : true,
+          'Invalid userInputValue: $userInputValue', // coverage:ignore-line
+        );
 
   factory EscapeManualTaskRemoteModel.fromJson(Map<String, dynamic> json) =>
       _$EscapeManualTaskRemoteModelFromJson(json);
@@ -98,7 +111,7 @@ class EscapeManualTaskRemoteModel extends Equatable {
   final String id;
 
   @JsonKey(name: 'tipo')
-  final String type;
+  final EscapeManualTaskType type;
 
   @JsonKey(name: 'agrupador')
   final String group;
@@ -110,7 +123,11 @@ class EscapeManualTaskRemoteModel extends Equatable {
   @JsonKey(name: 'descricao')
   final String description;
 
-  @JsonKey(name: 'campo_livre')
+  @JsonKey(
+    name: 'campo_livre',
+    readValue: readUserInputValue,
+    fromJson: userInputValueFromJson,
+  )
   final dynamic userInputValue;
 
   @JsonKey(name: 'checkbox_feito')

--- a/lib/app/features/escape_manual/data/model/escape_manual_remote.g.dart
+++ b/lib/app/features/escape_manual/data/model/escape_manual_remote.g.dart
@@ -71,7 +71,7 @@ EscapeManualTaskRemoteModel _$EscapeManualTaskRemoteModelFromJson(
         Map<String, dynamic> json) =>
     EscapeManualTaskRemoteModel(
       id: FromJson.parseAsString(json['id']),
-      type: json['tipo'] as String,
+      type: $enumDecode(_$EscapeManualTaskTypeEnumMap, json['tipo']),
       group: json['agrupador'] as String,
       title: const JsonEmptyStringToNullConverter()
           .fromJson(json['titulo'] as String?),
@@ -79,7 +79,8 @@ EscapeManualTaskRemoteModel _$EscapeManualTaskRemoteModelFromJson(
       isDone: json['checkbox_feito'] == null
           ? false
           : const JsonBoolConverter().fromJson(json['checkbox_feito']),
-      userInputValue: json['campo_livre'],
+      userInputValue: userInputValueFromJson(
+          readUserInputValue(json, 'campo_livre') as Map<String, dynamic>),
       updatedAt: const JsonSecondsFromEpochConverter()
           .fromJson(json['atualizado_em'] as int),
     );
@@ -88,7 +89,7 @@ Map<String, dynamic> _$EscapeManualTaskRemoteModelToJson(
     EscapeManualTaskRemoteModel instance) {
   final val = <String, dynamic>{
     'id': instance.id,
-    'tipo': instance.type,
+    'tipo': _$EscapeManualTaskTypeEnumMap[instance.type]!,
     'agrupador': instance.group,
   };
 
@@ -108,3 +109,9 @@ Map<String, dynamic> _$EscapeManualTaskRemoteModelToJson(
       const JsonSecondsFromEpochConverter().toJson(instance.updatedAt));
   return val;
 }
+
+const _$EscapeManualTaskTypeEnumMap = {
+  EscapeManualTaskType.normal: 'checkbox',
+  EscapeManualTaskType.contacts: 'checkbox_contato',
+  EscapeManualTaskType.unknown: 'unknown',
+};

--- a/lib/app/features/escape_manual/data/model/escape_manual_task_type.dart
+++ b/lib/app/features/escape_manual/data/model/escape_manual_task_type.dart
@@ -1,0 +1,12 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+const escapeManualTaskTypeNormal = 'checkbox';
+const escapeManualTaskTypeContacts = 'checkbox_contato';
+
+enum EscapeManualTaskType {
+  @JsonValue(escapeManualTaskTypeNormal)
+  normal,
+  @JsonValue(escapeManualTaskTypeContacts)
+  contacts,
+  unknown
+}

--- a/lib/app/features/escape_manual/data/repository/escape_manual_repository.dart
+++ b/lib/app/features/escape_manual/data/repository/escape_manual_repository.dart
@@ -72,9 +72,7 @@ class EscapeManualRepository implements IEscapeManualRepository {
   @override
   VoidResult updateTask(EscapeManualTaskEntity task) async {
     try {
-      final result = await _localDatasource.saveTask(
-        EscapeManualTaskLocalModel.fromEntity(task),
-      );
+      final result = await _localDatasource.saveTask(task.asLocalModel);
       return right(result);
     } catch (error, stack) {
       logError(error, stack);
@@ -86,9 +84,7 @@ class EscapeManualRepository implements IEscapeManualRepository {
   @override
   VoidResult removeTask(EscapeManualTaskEntity task) async {
     try {
-      final result = await _localDatasource.removeTask(
-        EscapeManualTaskLocalModel.fromEntity(task),
-      );
+      final result = await _localDatasource.removeTask(task.asLocalModel);
       return right(result);
     } catch (error, stack) {
       logError(error, stack);
@@ -120,6 +116,7 @@ class EscapeManualRepository implements IEscapeManualRepository {
 
       return remoteTask.copyWith(
         isDone: localTask.isDone,
+        userInputValue: localTask.value,
       );
     });
 

--- a/lib/app/features/escape_manual/domain/entity/contact.dart
+++ b/lib/app/features/escape_manual/domain/entity/contact.dart
@@ -1,0 +1,16 @@
+import 'package:equatable/equatable.dart';
+
+class ContactEntity extends Equatable {
+  const ContactEntity({
+    required this.id,
+    required this.name,
+    required this.phone,
+  });
+
+  final int id;
+  final String name;
+  final String phone;
+
+  @override
+  List<Object?> get props => [id, name, phone];
+}

--- a/lib/app/features/escape_manual/domain/entity/escape_manual.dart
+++ b/lib/app/features/escape_manual/domain/entity/escape_manual.dart
@@ -1,6 +1,9 @@
 import 'package:equatable/equatable.dart';
 
 import '../../../appstate/domain/entities/app_state_entity.dart';
+import 'escape_manual_task.dart';
+
+export 'escape_manual_task.dart';
 
 class EscapeManualEntity extends Equatable {
   const EscapeManualEntity({
@@ -67,41 +70,5 @@ class EscapeManualTasksSectionEntity extends Equatable {
       EscapeManualTasksSectionEntity(
         title: title,
         tasks: tasks,
-      );
-}
-
-class EscapeManualTaskEntity extends Equatable {
-  const EscapeManualTaskEntity({
-    required this.id,
-    required this.type,
-    required this.description,
-    required this.userInputValue,
-    required this.isDone,
-  });
-
-  final String id;
-  final String type;
-  final String description;
-  final String? userInputValue;
-  final bool isDone;
-
-  @override
-  List<Object?> get props => [
-        id,
-        type,
-        description,
-        userInputValue,
-        isDone,
-      ];
-
-  EscapeManualTaskEntity copyWith({
-    required bool isDone,
-  }) =>
-      EscapeManualTaskEntity(
-        id: id,
-        type: type,
-        description: description,
-        userInputValue: userInputValue,
-        isDone: isDone,
       );
 }

--- a/lib/app/features/escape_manual/domain/entity/escape_manual_task.dart
+++ b/lib/app/features/escape_manual/domain/entity/escape_manual_task.dart
@@ -1,0 +1,105 @@
+import 'package:equatable/equatable.dart';
+
+import 'contact.dart';
+
+export 'contact.dart';
+
+abstract class EscapeManualTaskEntity extends Equatable {
+  const EscapeManualTaskEntity({
+    required this.id,
+    required this.description,
+    required this.isDone,
+  });
+
+  final String id;
+  final String description;
+  final bool isDone;
+
+  @override
+  List<Object?> get props => [
+        id,
+        description,
+        isDone,
+      ];
+
+  EscapeManualTaskEntity copyWith({
+    required bool isDone,
+  });
+}
+
+abstract class EscapeManualEditableTaskEntity<T extends Object>
+    extends EscapeManualTaskEntity {
+  const EscapeManualEditableTaskEntity({
+    required String id,
+    required String description,
+    required this.value,
+    required bool isDone,
+  }) : super(
+          id: id,
+          description: description,
+          isDone: isDone,
+        );
+
+  final T? value;
+
+  @override
+  List<Object?> get props => [
+        ...super.props,
+        value,
+      ];
+
+  @override
+  EscapeManualTaskEntity copyWith({
+    required bool isDone,
+    T? value,
+  });
+}
+
+class EscapeManualDefaultTaskEntity extends EscapeManualTaskEntity {
+  const EscapeManualDefaultTaskEntity({
+    required String id,
+    required String description,
+    bool isDone = false,
+  }) : super(
+          id: id,
+          description: description,
+          isDone: isDone,
+        );
+
+  @override
+  EscapeManualTaskEntity copyWith({
+    required bool isDone,
+  }) =>
+      EscapeManualDefaultTaskEntity(
+        id: id,
+        description: description,
+        isDone: isDone,
+      );
+}
+
+class EscapeManualContactsTaskEntity
+    extends EscapeManualEditableTaskEntity<List<ContactEntity>> {
+  const EscapeManualContactsTaskEntity({
+    required String id,
+    required String description,
+    List<ContactEntity>? value,
+    bool isDone = false,
+  }) : super(
+          id: id,
+          description: description,
+          value: value,
+          isDone: isDone,
+        );
+
+  @override
+  EscapeManualContactsTaskEntity copyWith({
+    required bool isDone,
+    List<ContactEntity>? value,
+  }) =>
+      EscapeManualContactsTaskEntity(
+        id: id,
+        description: description,
+        value: value ?? this.value,
+        isDone: isDone,
+      );
+}

--- a/lib/app/features/escape_manual/domain/escape_manual_toggle.dart
+++ b/lib/app/features/escape_manual/domain/escape_manual_toggle.dart
@@ -1,4 +1,4 @@
-import '../../../../core/managers/modules_sevices.dart';
+import '../../../core/managers/modules_sevices.dart';
 
 class EscapeManualToggleFeature {
   EscapeManualToggleFeature({

--- a/lib/app/features/escape_manual/domain/escape_manual_toggle.dart
+++ b/lib/app/features/escape_manual/domain/escape_manual_toggle.dart
@@ -1,20 +1,39 @@
+import 'dart:convert';
+
 import '../../../core/managers/modules_sevices.dart';
+import '../../../shared/logger/log.dart';
+
+const _defaultMaxTrustedContacts = 3;
 
 class EscapeManualToggleFeature {
   EscapeManualToggleFeature({
     required IAppModulesServices modulesServices,
   }) : _modulesServices = modulesServices;
 
-  final IAppModulesServices _modulesServices;
   static const String featureCode = 'mf';
 
+  final IAppModulesServices _modulesServices;
+
   Future<bool> get isEnabled => _isEnabled();
+
+  Future<int> get maxTrustedContacts => _maxTrustedContacts();
 
   Future<bool> _isEnabled() async {
     try {
       return await _modulesServices.isEnabled(featureCode);
     } catch (_) {
       return false;
+    }
+  }
+
+  Future<int> _maxTrustedContacts() async {
+    try {
+      final module = await _modulesServices.feature(name: featureCode);
+      final meta = jsonDecode(module!.meta) as Map<String, dynamic>;
+      return int.parse("${meta['max_checkbox_contato']}");
+    } catch (error, stackTrace) {
+      logError(error, stackTrace);
+      return _defaultMaxTrustedContacts;
     }
   }
 }

--- a/lib/app/features/feed/domain/usecases/compose_tweet_fab_toggle.dart
+++ b/lib/app/features/feed/domain/usecases/compose_tweet_fab_toggle.dart
@@ -1,4 +1,4 @@
-import 'escape_manual_toggle.dart';
+import '../../../escape_manual/domain/escape_manual_toggle.dart';
 import 'tweet_toggle_feature.dart';
 
 class ComposeTweetFabToggleFeature {

--- a/lib/app/features/feed/presentation/feed_module.dart
+++ b/lib/app/features/feed/presentation/feed_module.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 
+import '../../escape_manual/domain/escape_manual_toggle.dart';
 import '../domain/usecases/compose_tweet_fab_toggle.dart';
-import '../domain/usecases/escape_manual_toggle.dart';
 import '../domain/usecases/tweet_toggle_feature.dart';
 import 'feed_controller.dart';
 import 'feed_page.dart';

--- a/lib/app/features/mainboard/domain/states/mainboard_store.dart
+++ b/lib/app/features/mainboard/domain/states/mainboard_store.dart
@@ -3,7 +3,7 @@ import 'package:mobx/mobx.dart';
 
 import '../../../../core/managers/modules_sevices.dart';
 import '../../../chat/domain/usecases/chat_toggle_feature.dart';
-import '../../../feed/domain/usecases/escape_manual_toggle.dart';
+import '../../../escape_manual/domain/escape_manual_toggle.dart';
 import '../../../feed/domain/usecases/feed_toggle_feature.dart';
 import '../../../feed/domain/usecases/tweet_toggle_feature.dart';
 import '../../../help_center/domain/usecases/security_mode_action_feature.dart';

--- a/test/app/features/escape_manual/data/datasource/impl/escape_manual_local_datasource_test.dart
+++ b/test/app/features/escape_manual/data/datasource/impl/escape_manual_local_datasource_test.dart
@@ -24,7 +24,10 @@ void main() {
       // arrange
       final tasks = [
         EscapeManualTaskLocalModel(id: '1'),
-        EscapeManualTaskLocalModel(id: '2'),
+        EscapeManualTaskLocalModel(
+          id: '2',
+          type: EscapeManualTaskType.contacts,
+        ),
       ];
       when(() => mockStore.watchAll()).thenAnswer(
         (_) => Stream.fromIterable([tasks]),
@@ -39,6 +42,7 @@ void main() {
       // arrange
       final task = EscapeManualTaskLocalModel(
         id: 'id',
+        type: EscapeManualTaskType.contacts,
         updatedAt: DateTime.now(),
         isDone: Random().nextBool(),
         isRemoved: Random().nextBool(),
@@ -77,13 +81,17 @@ void main() {
         ),
         EscapeManualTaskLocalModel(
           id: '1',
+          type: EscapeManualTaskType.contacts,
           updatedAt: DateTime(2023, 11, 13, 13, 57, 59),
         ),
         EscapeManualTaskLocalModel(
           id: '2',
           updatedAt: DateTime(2023, 11, 13, 13, 58, 0),
         ),
-        EscapeManualTaskLocalModel(id: '3'),
+        EscapeManualTaskLocalModel(
+          id: '3',
+          type: EscapeManualTaskType.contacts,
+        ),
         EscapeManualTaskLocalModel(id: '4'),
       ];
 

--- a/test/app/features/escape_manual/data/datastore/escape_manual_persistent_store_test.dart
+++ b/test/app/features/escape_manual/data/datastore/escape_manual_persistent_store_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:penhas/app/core/storage/collection_store.dart';
@@ -42,8 +44,8 @@ void main() {
         // arrange
         when(() => mockStorage.all<String>()).thenAnswer(
           (_) async => [
-            '{"id":"id 0","isDone":false,"isRemoved":true,"updatedAt":"2023-11-06T18:29:33.000"}',
-            '{"id":"id 1","isDone":true,"isRemoved":false,"updatedAt":"2023-11-06T18:34:24.000"}',
+            '{"id":"id 0","type":"checkbox","isDone":false,"isRemoved":true,"updatedAt":"2023-11-06T18:29:33.000"}',
+            '{"id":"id 1","type":"checkbox_contato","isDone":true,"isRemoved":false,"updatedAt":"2023-11-06T18:34:24.000"}',
           ],
         );
 
@@ -62,6 +64,7 @@ void main() {
             ),
             EscapeManualTaskLocalModel(
               id: 'id 1',
+              type: EscapeManualTaskType.contacts,
               isDone: true,
               isRemoved: false,
               updatedAt: DateTime(2023, 11, 06, 18, 34, 24),
@@ -79,8 +82,8 @@ void main() {
         when(() => mockStorage.watchAll<String>()).thenAnswer(
           (_) => Stream.fromIterable([
             [
-              '{"id":"id 0","isDone":false,"isRemoved":true,"updatedAt":"2023-11-06T18:47:08.000"}',
-              '{"id":"id 1","isDone":true,"isRemoved":false,"updatedAt":"2023-11-06T18:48:10.000"}',
+              '{"id":"id 0","type":"checkbox_contato","isDone":false,"isRemoved":true,"updatedAt":"2023-11-06T18:47:08.000"}',
+              '{"id":"id 1","type":"checkbox","isDone":true,"isRemoved":false,"updatedAt":"2023-11-06T18:48:10.000"}',
             ],
           ]),
         );
@@ -91,6 +94,7 @@ void main() {
           emits([
             EscapeManualTaskLocalModel(
               id: 'id 0',
+              type: EscapeManualTaskType.contacts,
               isDone: false,
               isRemoved: true,
               updatedAt: DateTime(2023, 11, 06, 18, 47, 08),
@@ -114,6 +118,13 @@ void main() {
         final taskId = 'some id key';
         when(() => mockStorage.put(any(), any<String>()))
             .thenAnswer((_) => Future.value());
+        final expected = {
+          "id": "some id key",
+          "type": "checkbox",
+          "isDone": false,
+          "isRemoved": false,
+          "updatedAt": "2023-11-06T18:29:33.000",
+        };
 
         // act
         await sut.put(
@@ -130,10 +141,7 @@ void main() {
         final verifier =
             verify(() => mockStorage.put(taskId, captureAny<String>()));
         verifier.called(1);
-        expect(
-          verifier.captured.single,
-          '{"id":"some id key","isDone":false,"isRemoved":false,"updatedAt":"2023-11-06T18:29:33.000"}',
-        );
+        expect(jsonDecode(verifier.captured.single), expected);
       },
     );
 

--- a/test/app/features/escape_manual/data/model/escape_manual_fixtures.dart
+++ b/test/app/features/escape_manual/data/model/escape_manual_fixtures.dart
@@ -9,7 +9,20 @@ final escapeManualLocalModelsFixture = [
     isDone: true,
   ),
   EscapeManualTaskLocalModel(
+    id: '2',
+    type: EscapeManualTaskType.contacts,
+    value: [
+      ContactModel(
+        id: 1,
+        name: 'Contact name',
+        phone: '(00) 00000-0000',
+      ),
+    ],
+  ),
+  EscapeManualTaskLocalModel(
     id: '3',
+    type: EscapeManualTaskType.contacts,
+    value: <ContactModel>[],
     isRemoved: true,
   ),
 ];
@@ -26,7 +39,7 @@ final escapeManualModelFixture = EscapeManualRemoteModel(
   tasks: [
     EscapeManualTaskRemoteModel(
       id: '1',
-      type: 'checkbox',
+      type: EscapeManualTaskType.normal,
       group: 'group',
       title: 'title',
       description: 'description',
@@ -36,7 +49,7 @@ final escapeManualModelFixture = EscapeManualRemoteModel(
     ),
     EscapeManualTaskRemoteModel(
       id: '2',
-      type: 'checkbox_contact',
+      type: EscapeManualTaskType.contacts,
       group: 'group 2',
       title: 'title',
       description: 'description',
@@ -45,11 +58,18 @@ final escapeManualModelFixture = EscapeManualRemoteModel(
     ),
     EscapeManualTaskRemoteModel(
       id: '3',
-      type: 'checkbox',
+      type: EscapeManualTaskType.contacts,
       group: 'group',
       title: 'title',
       description: 'description',
-      userInputValue: null,
+      isDone: true,
+      userInputValue: [
+        ContactModel(
+          id: 1,
+          name: 'Other contact name',
+          phone: '(11) 99999-9999',
+        ),
+      ],
       updatedAt: DateTime.now(),
     ),
   ],
@@ -69,31 +89,33 @@ final escapeManualEntityFixture = EscapeManualEntity(
     EscapeManualTasksSectionEntity(
       title: 'group',
       tasks: [
-        EscapeManualTaskEntity(
+        EscapeManualDefaultTaskEntity(
           id: '1',
-          type: 'checkbox',
           description: 'description',
           isDone: false,
-          userInputValue: null,
         ),
-        EscapeManualTaskEntity(
+        EscapeManualContactsTaskEntity(
           id: '3',
-          type: 'checkbox',
           description: 'description',
-          userInputValue: null,
-          isDone: false,
+          isDone: true,
+          value: <ContactEntity>[
+            ContactModel(
+              id: 1,
+              name: 'Other contact name',
+              phone: '(11) 99999-9999',
+            ),
+          ],
         ),
       ],
     ),
     EscapeManualTasksSectionEntity(
       title: 'group 2',
       tasks: [
-        EscapeManualTaskEntity(
+        EscapeManualContactsTaskEntity(
           id: '2',
-          type: 'checkbox_contact',
           description: 'description',
           isDone: true,
-          userInputValue: null,
+          value: null,
         ),
       ],
     ),
@@ -114,24 +136,27 @@ final updatedEscapeManualEntityFixture = EscapeManualEntity(
     EscapeManualTasksSectionEntity(
       title: 'group',
       tasks: [
-        EscapeManualTaskEntity(
+        EscapeManualDefaultTaskEntity(
           id: '1',
-          type: 'checkbox',
           description: 'description',
           isDone: true,
-          userInputValue: null,
         ),
       ],
     ),
     EscapeManualTasksSectionEntity(
       title: 'group 2',
       tasks: [
-        EscapeManualTaskEntity(
+        EscapeManualContactsTaskEntity(
           id: '2',
-          type: 'checkbox_contact',
           description: 'description',
-          isDone: true,
-          userInputValue: null,
+          isDone: false,
+          value: <ContactEntity>[
+            ContactModel(
+              id: 1,
+              name: 'Contact name',
+              phone: '(00) 00000-0000',
+            ),
+          ],
         ),
       ],
     ),
@@ -150,7 +175,7 @@ final escapeManualRemoteModelFixture = EscapeManualRemoteModel(
   tasks: [
     EscapeManualTaskRemoteModel(
       id: '71',
-      type: 'checkbox',
+      type: EscapeManualTaskType.normal,
       group: 'Itens Básicos',
       description:
           'Organize uma mochila com roupas. Se achar que a mochila levantará suspeita, separe em sacolas plásticas algumas mudas de roupa. Você pode ir separando as peças de roupas no decorrer dos dias para não levantar suspeitas.',
@@ -158,14 +183,14 @@ final escapeManualRemoteModelFixture = EscapeManualRemoteModel(
     ),
     EscapeManualTaskRemoteModel(
       id: '72',
-      type: 'checkbox',
+      type: EscapeManualTaskType.normal,
       group: 'Itens Básicos',
       description: 'Ponha na mochila medicamentos básicos e de uso contínuo',
       updatedAt: DateTime.fromMillisecondsSinceEpoch(1689701023000),
     ),
     EscapeManualTaskRemoteModel(
       id: '73',
-      type: 'checkbox',
+      type: EscapeManualTaskType.normal,
       group: 'Passos para fuga',
       description:
           'Cadastre-se e/ou verifique se o seu Cadastro Único (CadÚnico) está ativo.',
@@ -173,19 +198,19 @@ final escapeManualRemoteModelFixture = EscapeManualRemoteModel(
     ),
     EscapeManualTaskRemoteModel(
       id: '75',
-      type: 'checkbox',
+      type: EscapeManualTaskType.normal,
       group: 'Segurança pessoal',
       description:
           'Busque o Centro de Referência de Assistência Social (CRAS).',
       updatedAt: DateTime.fromMillisecondsSinceEpoch(1689701025000),
     ),
     EscapeManualTaskRemoteModel(
-      id: '76',
-      type: 'checkbox',
-      group: 'Passos para fuga',
-      description:
-          'Leve ao CRAS toda documentação necessária, tanto sua, quanto das crianças, se houver.',
+      id: '101',
+      type: EscapeManualTaskType.contacts,
+      group: 'Contatos',
+      description: 'Informe os contatos de pessoas de confiança.',
       updatedAt: DateTime.fromMillisecondsSinceEpoch(1689701025000),
+      userInputValue: null,
     ),
   ],
 );
@@ -202,7 +227,7 @@ final updatedEscapeManualRemoteModelFixture = EscapeManualRemoteModel(
   tasks: [
     EscapeManualTaskRemoteModel(
       id: '72',
-      type: 'checkbox',
+      type: EscapeManualTaskType.normal,
       group: 'Itens Básicos',
       description: 'Ponha na mochila medicamentos básicos e de uso contínuo',
       isDone: true,
@@ -210,24 +235,38 @@ final updatedEscapeManualRemoteModelFixture = EscapeManualRemoteModel(
     ),
     EscapeManualTaskRemoteModel(
       id: '73',
-      type: 'checkbox',
+      type: EscapeManualTaskType.normal,
       group: 'Passos para fuga',
       description:
           'Cadastre-se e/ou verifique se o seu Cadastro Único (CadÚnico) está ativo.',
       updatedAt: DateTime.fromMillisecondsSinceEpoch(1696116772000),
-      userInputValue: 'campo livre',
+      userInputValue: null,
     ),
     EscapeManualTaskRemoteModel(
       id: '75',
-      type: 'checkbox',
+      type: EscapeManualTaskType.normal,
       group: 'Segurança pessoal',
       description:
           'Busque o Centro de Referência de Assistência Social (CRAS).',
       updatedAt: DateTime.fromMillisecondsSinceEpoch(1689701025000),
     ),
     EscapeManualTaskRemoteModel(
+      id: '101',
+      type: EscapeManualTaskType.contacts,
+      group: 'Contatos',
+      description: 'Informe os contatos de pessoas de confiança.',
+      updatedAt: DateTime.fromMillisecondsSinceEpoch(1696116772000),
+      userInputValue: [
+        ContactModel(
+          id: 1,
+          name: 'Contact name',
+          phone: '(11) 99999-9999',
+        ),
+      ],
+    ),
+    EscapeManualTaskRemoteModel(
       id: '76',
-      type: 'checkbox',
+      type: EscapeManualTaskType.normal,
       group: 'Passos para fuga',
       description:
           'Leve ao CRAS toda documentação necessária, tanto sua, quanto das crianças, se houver.',
@@ -236,10 +275,23 @@ final updatedEscapeManualRemoteModelFixture = EscapeManualRemoteModel(
   ],
 );
 
-final escapeManualTaskEntityFixture = EscapeManualTaskEntity(
+final EscapeManualTaskEntity escapeManualTaskEntityFixture =
+    EscapeManualDefaultTaskEntity(
   id: '1',
-  type: 'checkbox',
   description: 'description',
   isDone: true,
-  userInputValue: null,
+);
+
+final EscapeManualEditableTaskEntity escapeManualEditableTaskEntityFixture =
+    EscapeManualContactsTaskEntity(
+  id: '1',
+  description: 'description',
+  isDone: true,
+  value: <ContactEntity>[
+    ContactModel(
+      id: 1,
+      name: 'Contact name',
+      phone: '(00) 00000-0000',
+    ),
+  ],
 );

--- a/test/app/features/escape_manual/data/repository/escape_manual_repository_test.dart
+++ b/test/app/features/escape_manual/data/repository/escape_manual_repository_test.dart
@@ -176,10 +176,12 @@ void main() {
         'should call datasource updateTask',
         () async {
           // arrange
-          final task = escapeManualTaskEntityFixture;
+          final task = escapeManualEditableTaskEntityFixture;
           final localTask = EscapeManualTaskLocalModel(
             id: task.id,
+            type: EscapeManualTaskType.contacts,
             isDone: task.isDone,
+            value: task.value,
           );
           when(() => mockLocalDatasource.saveTask(any()))
               .thenAnswer((_) async => unit);
@@ -197,7 +199,7 @@ void main() {
         'should return failure when datasource updateTask throws',
         () async {
           // arrange
-          final task = escapeManualTaskEntityFixture;
+          final task = escapeManualEditableTaskEntityFixture;
           when(() => mockLocalDatasource.saveTask(any()))
               .thenThrow(Exception());
 

--- a/test/app/features/escape_manual/domain/escape_manual_toggle_test.dart
+++ b/test/app/features/escape_manual/domain/escape_manual_toggle_test.dart
@@ -1,6 +1,9 @@
+import 'dart:math';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:penhas/app/core/managers/modules_sevices.dart';
+import 'package:penhas/app/features/appstate/domain/entities/app_state_entity.dart';
 import 'package:penhas/app/features/escape_manual/domain/escape_manual_toggle.dart';
 
 class MockAppModulesServices extends Mock implements IAppModulesServices {}
@@ -16,54 +19,110 @@ void main() {
   });
 
   group('EscapeManualToggleFeature', () {
-    test(
-      'should call modules services isEnabled with name mf',
-      () async {
+    group('isEnabled', () {
+      test(
+        'should call modules services isEnabled with name mf',
+        () async {
+          // arrange
+          when(() => mockModulesServices.isEnabled(any()))
+              .thenAnswer((_) async => true);
+
+          // act
+          await sut.isEnabled;
+
+          // assert
+          verify(() => mockModulesServices.isEnabled('mf')).called(1);
+        },
+      );
+
+      test('should return true when feature is enabled', () async {
         // arrange
         when(() => mockModulesServices.isEnabled(any()))
             .thenAnswer((_) async => true);
 
         // act
-        await sut.isEnabled;
+        final result = await sut.isEnabled;
 
         // assert
-        verify(() => mockModulesServices.isEnabled('mf')).called(1);
-      },
-    );
+        expect(result, true);
+      });
 
-    test('should return true when feature is enabled', () async {
-      // arrange
-      when(() => mockModulesServices.isEnabled(any()))
-          .thenAnswer((_) async => true);
+      test('should return false when feature is disabled', () async {
+        // arrange
+        when(() => mockModulesServices.isEnabled(any()))
+            .thenAnswer((_) async => false);
 
-      // act
-      final result = await sut.isEnabled;
+        // act
+        final result = await sut.isEnabled;
 
-      // assert
-      expect(result, true);
+        // assert
+        expect(result, false);
+      });
+
+      test('should return false when isEnabled throws error', () async {
+        // arrange
+        when(() => mockModulesServices.isEnabled(any())).thenThrow(Exception());
+
+        // act
+        final result = await sut.isEnabled;
+
+        // assert
+        expect(result, false);
+      });
     });
 
-    test('should return false when feature is disabled', () async {
-      // arrange
-      when(() => mockModulesServices.isEnabled(any()))
-          .thenAnswer((_) async => false);
+    group('maxTrustedContacts', () {
+      test(
+        'should call modulesServices.feature with mf',
+        () async {
+          // arrange
+          when(() => mockModulesServices.feature(name: any(named: 'name')))
+              .thenAnswer((_) async => null);
 
-      // act
-      final result = await sut.isEnabled;
+          // act
+          await sut.maxTrustedContacts;
 
-      // assert
-      expect(result, false);
-    });
+          // assert
+          verify(() => mockModulesServices.feature(name: 'mf')).called(1);
+        },
+      );
 
-    test('should return false when isEnabled throws error', () async {
-      // arrange
-      when(() => mockModulesServices.isEnabled(any())).thenThrow(Exception());
+      test(
+        'should return max_checkbox_contato value',
+        () async {
+          // arrange
+          final maxTrustedContacts = Random().nextInt(10);
+          when(() => mockModulesServices.feature(name: any(named: 'name')))
+              .thenAnswer(
+            (_) async => AppStateModuleEntity(
+              code: 'mf',
+              meta: '{"max_checkbox_contato": $maxTrustedContacts}',
+            ),
+          );
 
-      // act
-      final result = await sut.isEnabled;
+          // act
+          final actual = await sut.maxTrustedContacts;
 
-      // assert
-      expect(result, false);
+          // assert
+          expect(actual, equals(maxTrustedContacts));
+        },
+      );
+
+      test(
+        'should return default maxTrustedContacts value when modulesServices throws error',
+        () async {
+          // arrange
+          final expectedMaxTrustedContacts = 3;
+          when(() => mockModulesServices.feature(name: any(named: 'name')))
+              .thenAnswer((_) async => throw Exception());
+
+          // act
+          final actual = await sut.maxTrustedContacts;
+
+          // assert
+          expect(actual, equals(expectedMaxTrustedContacts));
+        },
+      );
     });
   });
 }

--- a/test/app/features/escape_manual/domain/escape_manual_toggle_test.dart
+++ b/test/app/features/escape_manual/domain/escape_manual_toggle_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:penhas/app/core/managers/modules_sevices.dart';
-import 'package:penhas/app/features/feed/domain/usecases/escape_manual_toggle.dart';
+import 'package:penhas/app/features/escape_manual/domain/escape_manual_toggle.dart';
 
 class MockAppModulesServices extends Mock implements IAppModulesServices {}
 

--- a/test/app/features/escape_manual/domain/get_escape_manual_test.dart
+++ b/test/app/features/escape_manual/domain/get_escape_manual_test.dart
@@ -118,63 +118,47 @@ void main() {
 }
 
 final unsortedTasks = [
-  EscapeManualTaskEntity(
+  EscapeManualDefaultTaskEntity(
     id: '1',
-    type: 'checkbox',
     description: 'description',
-    userInputValue: null,
     isDone: false,
   ),
-  EscapeManualTaskEntity(
+  EscapeManualDefaultTaskEntity(
     id: '2',
-    type: 'checkbox',
     description: 'description',
-    userInputValue: null,
     isDone: true,
   ),
-  EscapeManualTaskEntity(
+  EscapeManualDefaultTaskEntity(
     id: '3',
-    type: 'checkbox',
     description: 'description',
-    userInputValue: null,
     isDone: false,
   ),
-  EscapeManualTaskEntity(
+  EscapeManualDefaultTaskEntity(
     id: '4',
-    type: 'checkbox',
     description: 'description',
-    userInputValue: null,
     isDone: true,
   ),
 ];
 
 final sortedTasks = [
-  EscapeManualTaskEntity(
+  EscapeManualDefaultTaskEntity(
     id: '1',
-    type: 'checkbox',
     description: 'description',
-    userInputValue: null,
     isDone: false,
   ),
-  EscapeManualTaskEntity(
+  EscapeManualDefaultTaskEntity(
     id: '3',
-    type: 'checkbox',
     description: 'description',
-    userInputValue: null,
     isDone: false,
   ),
-  EscapeManualTaskEntity(
+  EscapeManualDefaultTaskEntity(
     id: '2',
-    type: 'checkbox',
     description: 'description',
-    userInputValue: null,
     isDone: true,
   ),
-  EscapeManualTaskEntity(
+  EscapeManualDefaultTaskEntity(
     id: '4',
-    type: 'checkbox',
     description: 'description',
-    userInputValue: null,
     isDone: true,
   ),
 ];

--- a/test/app/features/escape_manual/presentation/escape_manual_controller_test.dart
+++ b/test/app/features/escape_manual/presentation/escape_manual_controller_test.dart
@@ -184,11 +184,10 @@ void main() {
     });
 
     group('updateTask', () {
-      final task = EscapeManualTaskEntity(
+      final task = EscapeManualContactsTaskEntity(
         id: 'id',
-        type: 'type',
         description: 'description',
-        userInputValue: null,
+        value: null,
         isDone: Random().nextBool(),
       );
 
@@ -264,11 +263,9 @@ void main() {
     });
 
     group('deleteTask', () {
-      final task = EscapeManualTaskEntity(
+      final task = EscapeManualDefaultTaskEntity(
         id: 'id',
-        type: 'type',
         description: 'description',
-        userInputValue: null,
         isDone: Random().nextBool(),
       );
 

--- a/test/app/features/escape_manual/presentation/escape_manual_page_test.dart
+++ b/test/app/features/escape_manual/presentation/escape_manual_page_test.dart
@@ -170,7 +170,7 @@ void main() {
       (tester) async {
         // arrange
         final expectedTask =
-            escapeManualEntity.sections[1].tasks[1].copyWith(isDone: true);
+            escapeManualEntity.sections[1].tasks[4].copyWith(isDone: true);
         when(() => mockController.state)
             .thenReturn(EscapeManualState.loaded(escapeManualEntity));
         when(() => mockController.updateTask(any()))
@@ -184,7 +184,7 @@ void main() {
         await tester.pumpAndSettle();
         await tester.tap(
           find.descendant(
-            of: find.byKey(Key('escape-manual-task-1-1')),
+            of: find.byKey(Key('escape-manual-task-1-4')),
             matching: find.byType(Checkbox),
           ),
         );
@@ -393,13 +393,16 @@ EscapeManualEntity get escapeManualEntity => EscapeManualEntity(
           title: 'Section $section',
           tasks: List.generate(
             5,
-            (task) => EscapeManualTaskEntity(
-              id: '${section}-${task}',
-              type: 'checkbox',
-              description: 'Task #${task} of section ${section}',
-              isDone: task == 2,
-              userInputValue: null,
-            ),
+            (task) => task != 4
+                ? EscapeManualDefaultTaskEntity(
+                    id: '${section}-${task}',
+                    description: 'Task #${task} of section ${section}',
+                    isDone: task == 2,
+                  )
+                : EscapeManualContactsTaskEntity(
+                    id: '${section}-${task}',
+                    description: 'Task #${task} of section ${section}',
+                  ),
           ),
         ),
       ),

--- a/test/app/features/feed/domain/usecases/compose_tweet_fab_toggle_test.dart
+++ b/test/app/features/feed/domain/usecases/compose_tweet_fab_toggle_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:penhas/app/features/escape_manual/domain/escape_manual_toggle.dart';
 import 'package:penhas/app/features/feed/domain/usecases/compose_tweet_fab_toggle.dart';
-import 'package:penhas/app/features/feed/domain/usecases/escape_manual_toggle.dart';
 import 'package:penhas/app/features/feed/domain/usecases/tweet_toggle_feature.dart';
 
 class MockEscapeManualToggleFeature extends Mock

--- a/test/app/features/mainboard/domain/states/mainboard_store_test.dart
+++ b/test/app/features/mainboard/domain/states/mainboard_store_test.dart
@@ -5,7 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:penhas/app/core/managers/modules_sevices.dart';
 import 'package:penhas/app/features/appstate/domain/entities/app_state_entity.dart';
-import 'package:penhas/app/features/feed/domain/usecases/escape_manual_toggle.dart';
+import 'package:penhas/app/features/escape_manual/domain/escape_manual_toggle.dart';
 import 'package:penhas/app/features/mainboard/domain/states/mainboard_state.dart';
 import 'package:penhas/app/features/mainboard/domain/states/mainboard_store.dart';
 

--- a/test/assets/json/escape_manual/escape_manual_latest_response.json
+++ b/test/assets/json/escape_manual/escape_manual_latest_response.json
@@ -22,12 +22,40 @@
         {
             "agrupador": "Passos para fuga",
             "atualizado_em": 1696116772,
-            "campo_livre": "campo livre",
+            "campo_livre": null,
             "checkbox_feito": 0,
             "descricao": "Cadastre-se e/ou verifique se o seu Cadastro Único (CadÚnico) está ativo.",
             "eh_customizada": 1,
             "id": 73,
             "tipo": "checkbox",
+            "titulo": ""
+        },
+        {
+            "agrupador": "Passos para fuga",
+            "atualizado_em": 1689701025,
+            "campo_livre": null,
+            "checkbox_feito": 0,
+            "descricao": "Leve ao CRAS toda documentação necessária, tanto sua, quanto das crianças, se houver.",
+            "eh_customizada": 0,
+            "id": 76,
+            "tipo": "checkbox",
+            "titulo": ""
+        },
+        {
+            "agrupador": "Contatos",
+            "atualizado_em": 1696116772,
+            "campo_livre": [
+                {
+                    "id": 1,
+                    "name": "Contact name",
+                    "phone": "(11) 99999-9999"
+                }
+            ],
+            "checkbox_feito": 0,
+            "descricao": "Informe os contatos de pessoas de confiança.",
+            "eh_customizada": 1,
+            "id": 101,
+            "tipo": "checkbox_contato",
             "titulo": ""
         }
     ],

--- a/test/assets/json/escape_manual/escape_manual_response.json
+++ b/test/assets/json/escape_manual/escape_manual_response.json
@@ -53,14 +53,14 @@
             "titulo": ""
         },
         {
-            "agrupador": "Passos para fuga",
+            "agrupador": "Contatos",
             "atualizado_em": 1689701025,
             "campo_livre": null,
             "checkbox_feito": 0,
-            "descricao": "Leve ao CRAS toda documentação necessária, tanto sua, quanto das crianças, se houver.",
+            "descricao": "Informe os contatos de pessoas de confiança.",
             "eh_customizada": 0,
-            "id": 76,
-            "tipo": "checkbox",
+            "id": 101,
+            "tipo": "checkbox_contato",
             "titulo": ""
         }
     ]


### PR DESCRIPTION
- Adiciona entidade/model que representa os dados do contato;
- Transforma o valor para o tipo da tarefa, passando a utilizar `enum` em vez de `string`;
- Move a classe `EscapeManualToggleFeature` para o pacote do contexto e adiciona a propriedade que contem o limite de contatos de confiança;
- Atualiza mappers.