### PR TITLE
Proposta de abordagem para testes automatizados de módulos

### DIFF
--- a/test/app/features/escape_manual/escape_manual_module_test.dart
+++ b/test/app/features/escape_manual/escape_manual_module_test.dart
@@ -1,40 +1,37 @@
 import 'package:flutter_modular/flutter_modular.dart';
-import 'package:flutter_modular_test/flutter_modular_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:penhas/app/app_module.dart';
 import 'package:penhas/app/core/network/api_client.dart';
+import 'package:penhas/app/core/storage/i_local_storage.dart';
 import 'package:penhas/app/features/escape_manual/escape_manual_module.dart';
-import 'package:penhas/app/features/escape_manual/presentation/escape_manual_controller.dart';
+import 'package:penhas/app/features/escape_manual/presentation/escape_manual_page.dart';
+
+import '../../../utils/module_testing.dart';
 
 void main() {
-  setUp(() {
-    initModules(
-      [
-        AppModule(),
-        EscapeManualModule(),
-      ],
-      replaceBinds: [
-        Bind<IApiProvider>((i) => ApiProviderMock()),
-      ],
+  group(EscapeManualModule, () {
+    testWidgets(
+      'should start with EscapeManualPage widget',
+      (tester) async {
+        // arrange
+        await tester.pumpWidget(
+          buildTestableApp(
+            home: EscapeManualModule(),
+            overrides: [
+              Bind<IApiProvider>((i) => _MockApiProvider()),
+              Bind<ILocalStorage>((i) => _MockLocalStorage()),
+            ],
+          ),
+        );
+        await tester.pump();
+
+        // assert
+        expect(find.byType(EscapeManualPage), findsOneWidget);
+      },
     );
   });
-
-  group(
-    EscapeManualModule,
-    () {
-      test(
-        'should have EscapeManualController instance',
-        () {
-          // act
-          final controller = Modular.get<EscapeManualController>();
-
-          // assert
-          expect(controller, isNotNull);
-        },
-      );
-    },
-  );
 }
 
-class ApiProviderMock extends Mock implements IApiProvider {}
+class _MockApiProvider extends Mock implements IApiProvider {}
+
+class _MockLocalStorage extends Mock implements ILocalStorage {}

--- a/test/utils/module_testing.dart
+++ b/test/utils/module_testing.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:penhas/app/app_module.dart';
+
+Widget buildTestableApp({
+  Widget? home,
+  String? initialRoute,
+  List<Module>? modules,
+  List<Bind> overrides = const [],
+}) =>
+    ModularApp(
+      module: _TestModule(
+        home: home,
+        modules: modules ?? [AppModule()],
+        overrides: overrides,
+      ),
+      child: MediaQuery(
+        data: MediaQueryData(),
+        child: MaterialApp(
+          initialRoute: initialRoute,
+        ).modular(),
+      ),
+    );
+
+class _TestModule extends Module {
+  _TestModule({
+    this.home,
+    this.modules = const [],
+    this.overrides = const [],
+  });
+
+  final Widget? home;
+  final List<Module> modules;
+  final List<Bind> overrides;
+
+  @override
+  List<Module> get imports =>
+      modules.expand((module) => module.imports).toList();
+
+  @override
+  List<Bind> get binds => [
+        ...overrides,
+        ...modules.expand((module) => module.binds),
+      ];
+
+  @override
+  List<ModularRoute> get routes => [
+        if (home != null) ChildRoute('/', child: (_, __) => home!),
+        ...modules.expand((module) => module.routes),
+      ];
+}


### PR DESCRIPTION
### Proposta para aprimoramento nos testes de módulos

Anteriormente, para oferecer a cobertura de testes para as declarações de dependências era realizada verificando a disponibilidade das mesmas, porém essa abordagem não garantia completamente o carregamento correto da página nem a provisão efetiva das dependências necessárias.

Com a nova abordagem proposta, torna-se viável executar testes mais simples e precisos. Isso inclui a capacidade de carregar a página principal do módulo, assegurando sua funcionalidade sem a necessidade explícita de declarar cada dependência nesse tipo de teste. Além disso, essa maneira possibilita o teste da navegação, um aspecto que não era contemplado anteriormente.

Nesse PR, apliquei essa abordagem apenas ao `EscapeManualModule`, a ideia é futuramente ir aplicando em todos os módulos do projeto, garantindo assim a validação da navegação e aumento da cobertura dos testes.
