### PR TITLE
Desabilita avisos do Mobx durante a execução dos testes

### DIFF
--- a/test/app/features/escape_manual/presentation/escape_manual_page_test.dart
+++ b/test/app/features/escape_manual/presentation/escape_manual_page_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_modular_test/flutter_modular_test.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -17,8 +16,6 @@ import '../../../../utils/golden_tests.dart';
 import '../../../../utils/widget_tester_ext.dart';
 
 void main() {
-  enableWarnWhenNoObservables = false;
-
   late EscapeManualController mockController;
   late Module module = AditionalBindModule(
     binds: [

--- a/test/utils/test_utils.dart
+++ b/test/utils/test_utils.dart
@@ -1,10 +1,12 @@
 import 'dart:async';
 
 import 'package:alchemist/alchemist.dart';
+import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:golden_toolkit/golden_toolkit.dart';
 
 Future<void> preparePageTests(FutureOr<void> Function() testMain) async {
+  enableWarnWhenNoObservables = false;
   TestWidgetsFlutterBinding.ensureInitialized();
   await loadAppFonts();
 


### PR DESCRIPTION
Desabilita globalmente o seguinte aviso do Mobx que acaba poluindo o output durante a execução dos testes:

_No observables detected in the build method of Observer_ 