### PR TITLE
Adiciona controller para a funcionalidade de edição de contatos de confiança

### DIFF
--- a/lib/app/features/escape_manual/domain/entity/contact.dart
+++ b/lib/app/features/escape_manual/domain/entity/contact.dart
@@ -13,4 +13,14 @@ class ContactEntity extends Equatable {
 
   @override
   List<Object?> get props => [id, name, phone];
+
+  ContactEntity copyWith({
+    required String name,
+    required String phone,
+  }) =>
+      ContactEntity(
+        id: id,
+        name: name,
+        phone: phone,
+      );
 }

--- a/lib/app/features/escape_manual/presentation/edit/edit_trusted_contacts_controller.dart
+++ b/lib/app/features/escape_manual/presentation/edit/edit_trusted_contacts_controller.dart
@@ -1,0 +1,93 @@
+import 'dart:async';
+
+import 'package:mobx/mobx.dart';
+
+import '../../domain/entity/escape_manual.dart';
+import '../../domain/escape_manual_toggle.dart';
+import 'edit_trusted_contacts_state.dart';
+
+part 'edit_trusted_contacts_controller.g.dart';
+
+typedef OnEditTrustedContactsReaction = void Function(
+  EditTrustedContactsReaction? reaction,
+);
+
+class EditTrustedContactsController = _EditTrustedContactsControllerBase
+    with _$EditTrustedContactsController;
+
+abstract class _EditTrustedContactsControllerBase with Store {
+  _EditTrustedContactsControllerBase({
+    required List<ContactEntity>? contacts,
+    required EscapeManualToggleFeature escapeManualToggleFeature,
+  })  : contacts = contacts ?? <ContactEntity>[],
+        _escapeManualToggleFeature = escapeManualToggleFeature {
+    _loadMaxTrustedContacts();
+  }
+
+  final EscapeManualToggleFeature _escapeManualToggleFeature;
+
+  @observable
+  List<ContactEntity> contacts;
+
+  @observable
+  int _maxTrustedContacts = 0;
+
+  @computed
+  EditTrustedContactsState get state => _state();
+
+  @observable
+  EditTrustedContactsReaction? _reaction;
+
+  @action
+  void onUpdateContactPressed(ContactEntity contact) {
+    contact = contact is ContactPlaceholder
+        ? contact.copyWith(name: '', phone: '')
+        : contact;
+    _reaction = EditTrustedContactsReaction.requestContactInfo(contact);
+  }
+
+  @action
+  void onRemoveContactPressed(ContactEntity contact) {
+    if (contact is ContactPlaceholder) return;
+    _reaction = EditTrustedContactsReaction.askForDeleteConfirmation(contact);
+  }
+
+  @action
+  Future<void> updateContact(ContactEntity contact) async {
+    contacts = [
+      contact,
+      ...contacts.where((e) => e.id != contact.id),
+    ];
+  }
+
+  @action
+  Future<void> removeContact(ContactEntity contact) async {
+    contacts = contacts.where((e) => e.id != contact.id).toList();
+  }
+
+  ReactionDisposer onReaction(OnEditTrustedContactsReaction fn) =>
+      reaction<EditTrustedContactsReaction?>(
+        (_) => _reaction,
+        fn,
+        equals: (_, __) => false,
+      );
+
+  void _loadMaxTrustedContacts() async {
+    _maxTrustedContacts = await _escapeManualToggleFeature.maxTrustedContacts;
+  }
+
+  EditTrustedContactsState _state() {
+    final contacts = _contactsWithPlaceholder();
+    return EditTrustedContactsState.loaded(contacts);
+  }
+
+  List<ContactEntity> _contactsWithPlaceholder() {
+    return List.generate(
+      _maxTrustedContacts,
+      (index) => contacts.firstWhere(
+        (el) => el.id == index + 1,
+        orElse: () => ContactPlaceholder(index + 1),
+      ),
+    );
+  }
+}

--- a/lib/app/features/escape_manual/presentation/edit/edit_trusted_contacts_controller.g.dart
+++ b/lib/app/features/escape_manual/presentation/edit/edit_trusted_contacts_controller.g.dart
@@ -1,0 +1,121 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'edit_trusted_contacts_controller.dart';
+
+// **************************************************************************
+// StoreGenerator
+// **************************************************************************
+
+// ignore_for_file: non_constant_identifier_names, unnecessary_brace_in_string_interps, unnecessary_lambdas, prefer_expression_function_bodies, lines_longer_than_80_chars, avoid_as, avoid_annotating_with_dynamic
+
+mixin _$EditTrustedContactsController
+    on _EditTrustedContactsControllerBase, Store {
+  Computed<EditTrustedContactsState>? _$stateComputed;
+
+  @override
+  EditTrustedContactsState get state =>
+      (_$stateComputed ??= Computed<EditTrustedContactsState>(() => super.state,
+              name: '_EditTrustedContactsControllerBase.state'))
+          .value;
+
+  final _$contactsAtom =
+      Atom(name: '_EditTrustedContactsControllerBase.contacts');
+
+  @override
+  List<ContactEntity> get contacts {
+    _$contactsAtom.reportRead();
+    return super.contacts;
+  }
+
+  @override
+  set contacts(List<ContactEntity> value) {
+    _$contactsAtom.reportWrite(value, super.contacts, () {
+      super.contacts = value;
+    });
+  }
+
+  final _$_maxTrustedContactsAtom =
+      Atom(name: '_EditTrustedContactsControllerBase._maxTrustedContacts');
+
+  @override
+  int get _maxTrustedContacts {
+    _$_maxTrustedContactsAtom.reportRead();
+    return super._maxTrustedContacts;
+  }
+
+  @override
+  set _maxTrustedContacts(int value) {
+    _$_maxTrustedContactsAtom.reportWrite(value, super._maxTrustedContacts, () {
+      super._maxTrustedContacts = value;
+    });
+  }
+
+  final _$_reactionAtom =
+      Atom(name: '_EditTrustedContactsControllerBase._reaction');
+
+  @override
+  EditTrustedContactsReaction? get _reaction {
+    _$_reactionAtom.reportRead();
+    return super._reaction;
+  }
+
+  @override
+  set _reaction(EditTrustedContactsReaction? value) {
+    _$_reactionAtom.reportWrite(value, super._reaction, () {
+      super._reaction = value;
+    });
+  }
+
+  final _$updateContactAsyncAction =
+      AsyncAction('_EditTrustedContactsControllerBase.updateContact');
+
+  @override
+  Future<void> updateContact(ContactEntity contact) {
+    return _$updateContactAsyncAction.run(() => super.updateContact(contact));
+  }
+
+  final _$removeContactAsyncAction =
+      AsyncAction('_EditTrustedContactsControllerBase.removeContact');
+
+  @override
+  Future<void> removeContact(ContactEntity contact) {
+    return _$removeContactAsyncAction.run(() => super.removeContact(contact));
+  }
+
+  final _$_EditTrustedContactsControllerBaseActionController =
+      ActionController(name: '_EditTrustedContactsControllerBase');
+
+  @override
+  void onUpdateContactPressed(ContactEntity contact) {
+    final _$actionInfo =
+        _$_EditTrustedContactsControllerBaseActionController.startAction(
+            name: '_EditTrustedContactsControllerBase.onUpdateContactPressed');
+    try {
+      return super.onUpdateContactPressed(contact);
+    } finally {
+      _$_EditTrustedContactsControllerBaseActionController
+          .endAction(_$actionInfo);
+    }
+  }
+
+  @override
+  void onRemoveContactPressed(ContactEntity contact) {
+    final _$actionInfo =
+        _$_EditTrustedContactsControllerBaseActionController.startAction(
+            name: '_EditTrustedContactsControllerBase.onRemoveContactPressed');
+    try {
+      return super.onRemoveContactPressed(contact);
+    } finally {
+      _$_EditTrustedContactsControllerBaseActionController
+          .endAction(_$actionInfo);
+    }
+  }
+
+  @override
+  String toString() {
+    return '''
+contacts: ${contacts},
+state: ${state}
+    ''';
+  }
+}

--- a/lib/app/features/escape_manual/presentation/edit/edit_trusted_contacts_state.dart
+++ b/lib/app/features/escape_manual/presentation/edit/edit_trusted_contacts_state.dart
@@ -1,0 +1,31 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../../domain/entity/contact.dart';
+
+part 'edit_trusted_contacts_state.freezed.dart';
+
+@freezed
+class EditTrustedContactsState with _$EditTrustedContactsState {
+  const factory EditTrustedContactsState.loaded(List<ContactEntity> contacts) =
+      _LoadedState;
+}
+
+@freezed
+class EditTrustedContactsReaction with _$EditTrustedContactsReaction {
+  const factory EditTrustedContactsReaction.requestContactInfo(
+    ContactEntity contact,
+  ) = _RequestContactInfo;
+
+  const factory EditTrustedContactsReaction.askForDeleteConfirmation(
+    ContactEntity contact,
+  ) = _AskForDeleteConfirmation;
+}
+
+class ContactPlaceholder extends ContactEntity {
+  const ContactPlaceholder(int id)
+      : super(
+          id: id,
+          name: 'Contato $id',
+          phone: '(00) 0000-0000',
+        );
+}

--- a/lib/app/features/escape_manual/presentation/edit/edit_trusted_contacts_state.freezed.dart
+++ b/lib/app/features/escape_manual/presentation/edit/edit_trusted_contacts_state.freezed.dart
@@ -1,0 +1,615 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'edit_trusted_contacts_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more informations: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+/// @nodoc
+class _$EditTrustedContactsStateTearOff {
+  const _$EditTrustedContactsStateTearOff();
+
+  _LoadedState loaded(List<ContactEntity> contacts) {
+    return _LoadedState(
+      contacts,
+    );
+  }
+}
+
+/// @nodoc
+const $EditTrustedContactsState = _$EditTrustedContactsStateTearOff();
+
+/// @nodoc
+mixin _$EditTrustedContactsState {
+  List<ContactEntity> get contacts => throw _privateConstructorUsedError;
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(List<ContactEntity> contacts) loaded,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function(List<ContactEntity> contacts)? loaded,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(List<ContactEntity> contacts)? loaded,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_LoadedState value) loaded,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(_LoadedState value)? loaded,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_LoadedState value)? loaded,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $EditTrustedContactsStateCopyWith<EditTrustedContactsState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $EditTrustedContactsStateCopyWith<$Res> {
+  factory $EditTrustedContactsStateCopyWith(EditTrustedContactsState value,
+          $Res Function(EditTrustedContactsState) then) =
+      _$EditTrustedContactsStateCopyWithImpl<$Res>;
+  $Res call({List<ContactEntity> contacts});
+}
+
+/// @nodoc
+class _$EditTrustedContactsStateCopyWithImpl<$Res>
+    implements $EditTrustedContactsStateCopyWith<$Res> {
+  _$EditTrustedContactsStateCopyWithImpl(this._value, this._then);
+
+  final EditTrustedContactsState _value;
+  // ignore: unused_field
+  final $Res Function(EditTrustedContactsState) _then;
+
+  @override
+  $Res call({
+    Object? contacts = freezed,
+  }) {
+    return _then(_value.copyWith(
+      contacts: contacts == freezed
+          ? _value.contacts
+          : contacts // ignore: cast_nullable_to_non_nullable
+              as List<ContactEntity>,
+    ));
+  }
+}
+
+/// @nodoc
+abstract class _$LoadedStateCopyWith<$Res>
+    implements $EditTrustedContactsStateCopyWith<$Res> {
+  factory _$LoadedStateCopyWith(
+          _LoadedState value, $Res Function(_LoadedState) then) =
+      __$LoadedStateCopyWithImpl<$Res>;
+  @override
+  $Res call({List<ContactEntity> contacts});
+}
+
+/// @nodoc
+class __$LoadedStateCopyWithImpl<$Res>
+    extends _$EditTrustedContactsStateCopyWithImpl<$Res>
+    implements _$LoadedStateCopyWith<$Res> {
+  __$LoadedStateCopyWithImpl(
+      _LoadedState _value, $Res Function(_LoadedState) _then)
+      : super(_value, (v) => _then(v as _LoadedState));
+
+  @override
+  _LoadedState get _value => super._value as _LoadedState;
+
+  @override
+  $Res call({
+    Object? contacts = freezed,
+  }) {
+    return _then(_LoadedState(
+      contacts == freezed
+          ? _value.contacts
+          : contacts // ignore: cast_nullable_to_non_nullable
+              as List<ContactEntity>,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$_LoadedState implements _LoadedState {
+  const _$_LoadedState(this.contacts);
+
+  @override
+  final List<ContactEntity> contacts;
+
+  @override
+  String toString() {
+    return 'EditTrustedContactsState.loaded(contacts: $contacts)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _LoadedState &&
+            const DeepCollectionEquality().equals(other.contacts, contacts));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(contacts));
+
+  @JsonKey(ignore: true)
+  @override
+  _$LoadedStateCopyWith<_LoadedState> get copyWith =>
+      __$LoadedStateCopyWithImpl<_LoadedState>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(List<ContactEntity> contacts) loaded,
+  }) {
+    return loaded(contacts);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function(List<ContactEntity> contacts)? loaded,
+  }) {
+    return loaded?.call(contacts);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(List<ContactEntity> contacts)? loaded,
+    required TResult orElse(),
+  }) {
+    if (loaded != null) {
+      return loaded(contacts);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_LoadedState value) loaded,
+  }) {
+    return loaded(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(_LoadedState value)? loaded,
+  }) {
+    return loaded?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_LoadedState value)? loaded,
+    required TResult orElse(),
+  }) {
+    if (loaded != null) {
+      return loaded(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _LoadedState implements EditTrustedContactsState {
+  const factory _LoadedState(List<ContactEntity> contacts) = _$_LoadedState;
+
+  @override
+  List<ContactEntity> get contacts;
+  @override
+  @JsonKey(ignore: true)
+  _$LoadedStateCopyWith<_LoadedState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+class _$EditTrustedContactsReactionTearOff {
+  const _$EditTrustedContactsReactionTearOff();
+
+  _RequestContactInfo requestContactInfo(ContactEntity contact) {
+    return _RequestContactInfo(
+      contact,
+    );
+  }
+
+  _AskForDeleteConfirmation askForDeleteConfirmation(ContactEntity contact) {
+    return _AskForDeleteConfirmation(
+      contact,
+    );
+  }
+}
+
+/// @nodoc
+const $EditTrustedContactsReaction = _$EditTrustedContactsReactionTearOff();
+
+/// @nodoc
+mixin _$EditTrustedContactsReaction {
+  ContactEntity get contact => throw _privateConstructorUsedError;
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(ContactEntity contact) requestContactInfo,
+    required TResult Function(ContactEntity contact) askForDeleteConfirmation,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function(ContactEntity contact)? requestContactInfo,
+    TResult Function(ContactEntity contact)? askForDeleteConfirmation,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(ContactEntity contact)? requestContactInfo,
+    TResult Function(ContactEntity contact)? askForDeleteConfirmation,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_RequestContactInfo value) requestContactInfo,
+    required TResult Function(_AskForDeleteConfirmation value)
+        askForDeleteConfirmation,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(_RequestContactInfo value)? requestContactInfo,
+    TResult Function(_AskForDeleteConfirmation value)? askForDeleteConfirmation,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_RequestContactInfo value)? requestContactInfo,
+    TResult Function(_AskForDeleteConfirmation value)? askForDeleteConfirmation,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $EditTrustedContactsReactionCopyWith<EditTrustedContactsReaction>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $EditTrustedContactsReactionCopyWith<$Res> {
+  factory $EditTrustedContactsReactionCopyWith(
+          EditTrustedContactsReaction value,
+          $Res Function(EditTrustedContactsReaction) then) =
+      _$EditTrustedContactsReactionCopyWithImpl<$Res>;
+  $Res call({ContactEntity contact});
+}
+
+/// @nodoc
+class _$EditTrustedContactsReactionCopyWithImpl<$Res>
+    implements $EditTrustedContactsReactionCopyWith<$Res> {
+  _$EditTrustedContactsReactionCopyWithImpl(this._value, this._then);
+
+  final EditTrustedContactsReaction _value;
+  // ignore: unused_field
+  final $Res Function(EditTrustedContactsReaction) _then;
+
+  @override
+  $Res call({
+    Object? contact = freezed,
+  }) {
+    return _then(_value.copyWith(
+      contact: contact == freezed
+          ? _value.contact
+          : contact // ignore: cast_nullable_to_non_nullable
+              as ContactEntity,
+    ));
+  }
+}
+
+/// @nodoc
+abstract class _$RequestContactInfoCopyWith<$Res>
+    implements $EditTrustedContactsReactionCopyWith<$Res> {
+  factory _$RequestContactInfoCopyWith(
+          _RequestContactInfo value, $Res Function(_RequestContactInfo) then) =
+      __$RequestContactInfoCopyWithImpl<$Res>;
+  @override
+  $Res call({ContactEntity contact});
+}
+
+/// @nodoc
+class __$RequestContactInfoCopyWithImpl<$Res>
+    extends _$EditTrustedContactsReactionCopyWithImpl<$Res>
+    implements _$RequestContactInfoCopyWith<$Res> {
+  __$RequestContactInfoCopyWithImpl(
+      _RequestContactInfo _value, $Res Function(_RequestContactInfo) _then)
+      : super(_value, (v) => _then(v as _RequestContactInfo));
+
+  @override
+  _RequestContactInfo get _value => super._value as _RequestContactInfo;
+
+  @override
+  $Res call({
+    Object? contact = freezed,
+  }) {
+    return _then(_RequestContactInfo(
+      contact == freezed
+          ? _value.contact
+          : contact // ignore: cast_nullable_to_non_nullable
+              as ContactEntity,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$_RequestContactInfo implements _RequestContactInfo {
+  const _$_RequestContactInfo(this.contact);
+
+  @override
+  final ContactEntity contact;
+
+  @override
+  String toString() {
+    return 'EditTrustedContactsReaction.requestContactInfo(contact: $contact)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _RequestContactInfo &&
+            const DeepCollectionEquality().equals(other.contact, contact));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(contact));
+
+  @JsonKey(ignore: true)
+  @override
+  _$RequestContactInfoCopyWith<_RequestContactInfo> get copyWith =>
+      __$RequestContactInfoCopyWithImpl<_RequestContactInfo>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(ContactEntity contact) requestContactInfo,
+    required TResult Function(ContactEntity contact) askForDeleteConfirmation,
+  }) {
+    return requestContactInfo(contact);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function(ContactEntity contact)? requestContactInfo,
+    TResult Function(ContactEntity contact)? askForDeleteConfirmation,
+  }) {
+    return requestContactInfo?.call(contact);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(ContactEntity contact)? requestContactInfo,
+    TResult Function(ContactEntity contact)? askForDeleteConfirmation,
+    required TResult orElse(),
+  }) {
+    if (requestContactInfo != null) {
+      return requestContactInfo(contact);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_RequestContactInfo value) requestContactInfo,
+    required TResult Function(_AskForDeleteConfirmation value)
+        askForDeleteConfirmation,
+  }) {
+    return requestContactInfo(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(_RequestContactInfo value)? requestContactInfo,
+    TResult Function(_AskForDeleteConfirmation value)? askForDeleteConfirmation,
+  }) {
+    return requestContactInfo?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_RequestContactInfo value)? requestContactInfo,
+    TResult Function(_AskForDeleteConfirmation value)? askForDeleteConfirmation,
+    required TResult orElse(),
+  }) {
+    if (requestContactInfo != null) {
+      return requestContactInfo(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _RequestContactInfo implements EditTrustedContactsReaction {
+  const factory _RequestContactInfo(ContactEntity contact) =
+      _$_RequestContactInfo;
+
+  @override
+  ContactEntity get contact;
+  @override
+  @JsonKey(ignore: true)
+  _$RequestContactInfoCopyWith<_RequestContactInfo> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$AskForDeleteConfirmationCopyWith<$Res>
+    implements $EditTrustedContactsReactionCopyWith<$Res> {
+  factory _$AskForDeleteConfirmationCopyWith(_AskForDeleteConfirmation value,
+          $Res Function(_AskForDeleteConfirmation) then) =
+      __$AskForDeleteConfirmationCopyWithImpl<$Res>;
+  @override
+  $Res call({ContactEntity contact});
+}
+
+/// @nodoc
+class __$AskForDeleteConfirmationCopyWithImpl<$Res>
+    extends _$EditTrustedContactsReactionCopyWithImpl<$Res>
+    implements _$AskForDeleteConfirmationCopyWith<$Res> {
+  __$AskForDeleteConfirmationCopyWithImpl(_AskForDeleteConfirmation _value,
+      $Res Function(_AskForDeleteConfirmation) _then)
+      : super(_value, (v) => _then(v as _AskForDeleteConfirmation));
+
+  @override
+  _AskForDeleteConfirmation get _value =>
+      super._value as _AskForDeleteConfirmation;
+
+  @override
+  $Res call({
+    Object? contact = freezed,
+  }) {
+    return _then(_AskForDeleteConfirmation(
+      contact == freezed
+          ? _value.contact
+          : contact // ignore: cast_nullable_to_non_nullable
+              as ContactEntity,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$_AskForDeleteConfirmation implements _AskForDeleteConfirmation {
+  const _$_AskForDeleteConfirmation(this.contact);
+
+  @override
+  final ContactEntity contact;
+
+  @override
+  String toString() {
+    return 'EditTrustedContactsReaction.askForDeleteConfirmation(contact: $contact)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _AskForDeleteConfirmation &&
+            const DeepCollectionEquality().equals(other.contact, contact));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(contact));
+
+  @JsonKey(ignore: true)
+  @override
+  _$AskForDeleteConfirmationCopyWith<_AskForDeleteConfirmation> get copyWith =>
+      __$AskForDeleteConfirmationCopyWithImpl<_AskForDeleteConfirmation>(
+          this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(ContactEntity contact) requestContactInfo,
+    required TResult Function(ContactEntity contact) askForDeleteConfirmation,
+  }) {
+    return askForDeleteConfirmation(contact);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function(ContactEntity contact)? requestContactInfo,
+    TResult Function(ContactEntity contact)? askForDeleteConfirmation,
+  }) {
+    return askForDeleteConfirmation?.call(contact);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(ContactEntity contact)? requestContactInfo,
+    TResult Function(ContactEntity contact)? askForDeleteConfirmation,
+    required TResult orElse(),
+  }) {
+    if (askForDeleteConfirmation != null) {
+      return askForDeleteConfirmation(contact);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_RequestContactInfo value) requestContactInfo,
+    required TResult Function(_AskForDeleteConfirmation value)
+        askForDeleteConfirmation,
+  }) {
+    return askForDeleteConfirmation(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(_RequestContactInfo value)? requestContactInfo,
+    TResult Function(_AskForDeleteConfirmation value)? askForDeleteConfirmation,
+  }) {
+    return askForDeleteConfirmation?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_RequestContactInfo value)? requestContactInfo,
+    TResult Function(_AskForDeleteConfirmation value)? askForDeleteConfirmation,
+    required TResult orElse(),
+  }) {
+    if (askForDeleteConfirmation != null) {
+      return askForDeleteConfirmation(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _AskForDeleteConfirmation
+    implements EditTrustedContactsReaction {
+  const factory _AskForDeleteConfirmation(ContactEntity contact) =
+      _$_AskForDeleteConfirmation;
+
+  @override
+  ContactEntity get contact;
+  @override
+  @JsonKey(ignore: true)
+  _$AskForDeleteConfirmationCopyWith<_AskForDeleteConfirmation> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/test/app/features/escape_manual/presentation/edit/edit_trusted_contacts_controller_test.dart
+++ b/test/app/features/escape_manual/presentation/edit/edit_trusted_contacts_controller_test.dart
@@ -1,0 +1,259 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:penhas/app/features/escape_manual/domain/entity/escape_manual_task.dart';
+import 'package:penhas/app/features/escape_manual/domain/escape_manual_toggle.dart';
+import 'package:penhas/app/features/escape_manual/presentation/edit/edit_trusted_contacts_controller.dart';
+import 'package:penhas/app/features/escape_manual/presentation/edit/edit_trusted_contacts_state.dart';
+
+const _maxTrustedContacts = 3;
+
+void main() {
+  group(EditTrustedContactsController, () {
+    late EscapeManualToggleFeature mockToggleFeature;
+    late _IOnEditTrustedContactsReaction mockOnReaction;
+    late Completer<int> maxTrustedContactsCompleter;
+
+    setUp(() {
+      mockToggleFeature = _MockEscapeManualToggleFeature();
+      mockOnReaction = _MockOnEditTrustedContactsReaction();
+
+      maxTrustedContactsCompleter = Completer<int>();
+      when(() => mockToggleFeature.maxTrustedContacts)
+          .thenAnswer((_) => maxTrustedContactsCompleter.future);
+      maxTrustedContactsCompleter.complete(_maxTrustedContacts);
+    });
+
+    EditTrustedContactsController createController([
+      List<ContactEntity>? contacts,
+    ]) =>
+        EditTrustedContactsController(
+          contacts: contacts,
+          escapeManualToggleFeature: mockToggleFeature,
+        )..onReaction(mockOnReaction);
+
+    group('init', () {
+      test(
+        'should have all placeholders when value is null',
+        () async {
+          // arrange
+          final controller = createController();
+          await maxTrustedContactsCompleter.future;
+
+          // assert
+          expect(
+            controller.state.contacts,
+            [
+              ContactPlaceholder(1),
+              ContactPlaceholder(2),
+              ContactPlaceholder(3),
+            ],
+          );
+        },
+      );
+
+      test(
+        'should have all placeholders when value is empty',
+        () async {
+          // arrange
+          final controller = createController([]);
+          await maxTrustedContactsCompleter.future;
+
+          // assert
+          expect(
+            controller.state.contacts,
+            [
+              ContactPlaceholder(1),
+              ContactPlaceholder(2),
+              ContactPlaceholder(3),
+            ],
+          );
+        },
+      );
+
+      test(
+        'should fill contacts with placeholders',
+        () async {
+          // arrange
+          final controller = createController(
+            [
+              ContactEntity(id: 2, name: 'name', phone: 'phone'),
+            ],
+          );
+          await maxTrustedContactsCompleter.future;
+
+          // assert
+          expect(
+            controller.state.contacts,
+            [
+              ContactPlaceholder(1),
+              ContactEntity(id: 2, name: 'name', phone: 'phone'),
+              ContactPlaceholder(3),
+            ],
+          );
+        },
+      );
+    });
+
+    group('onUpdateContactPressed', () {
+      test(
+        'should open dialog with empty contact',
+        () async {
+          // arrange
+          final controller = createController();
+          await maxTrustedContactsCompleter.future;
+
+          // act
+          controller.onUpdateContactPressed(ContactPlaceholder(1));
+
+          // assert
+          verify(
+            () => mockOnReaction(
+              EditTrustedContactsReaction.requestContactInfo(
+                ContactEntity(id: 1, name: '', phone: ''),
+              ),
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
+        'should open dialog with contact',
+        () async {
+          // arrange
+          final controller = createController(
+            [
+              ContactEntity(id: 1, name: 'name', phone: 'phone'),
+            ],
+          );
+          await maxTrustedContactsCompleter.future;
+
+          // act
+          controller.onUpdateContactPressed(
+            ContactEntity(id: 1, name: 'name', phone: 'phone'),
+          );
+
+          // assert
+          verify(
+            () => mockOnReaction(
+              EditTrustedContactsReaction.requestContactInfo(
+                ContactEntity(id: 1, name: 'name', phone: 'phone'),
+              ),
+            ),
+          ).called(1);
+        },
+      );
+    });
+
+    group('onRemoveContactPressed', () {
+      test(
+        'should emit askForDeleteConfirmation reaction',
+        () async {
+          // arrange
+          final controller = createController(
+            [
+              ContactEntity(id: 1, name: 'name', phone: 'phone'),
+            ],
+          );
+          await maxTrustedContactsCompleter.future;
+
+          // act
+          controller.onRemoveContactPressed(
+            ContactEntity(id: 1, name: 'name', phone: 'phone'),
+          );
+
+          // assert
+          verify(
+            () => mockOnReaction(
+              EditTrustedContactsReaction.askForDeleteConfirmation(
+                ContactEntity(id: 1, name: 'name', phone: 'phone'),
+              ),
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
+        'should not emit askForDeleteConfirmation reaction',
+        () async {
+          // arrange
+          final controller = createController();
+          await maxTrustedContactsCompleter.future;
+
+          // act
+          controller.onRemoveContactPressed(ContactPlaceholder(1));
+
+          // assert
+          verifyNever(() => mockOnReaction(any()));
+        },
+      );
+    });
+
+    test(
+      'updateContact should update contact',
+      () async {
+        // arrange
+        final controller = createController(
+          [
+            ContactEntity(id: 1, name: 'name', phone: 'phone'),
+          ],
+        );
+        await maxTrustedContactsCompleter.future;
+
+        // act
+        await controller.updateContact(
+          ContactEntity(id: 1, name: 'name2', phone: 'phone2'),
+        );
+
+        // assert
+        expect(
+          controller.state.contacts,
+          [
+            ContactEntity(id: 1, name: 'name2', phone: 'phone2'),
+            ContactPlaceholder(2),
+            ContactPlaceholder(3),
+          ],
+        );
+      },
+    );
+
+    test(
+      'removeContact should remove contact',
+      () async {
+        // arrange
+        final controller = createController(
+          [
+            ContactEntity(id: 1, name: 'name', phone: 'phone'),
+          ],
+        );
+        await maxTrustedContactsCompleter.future;
+
+        // act
+        await controller.removeContact(
+          ContactEntity(id: 1, name: 'name', phone: 'phone'),
+        );
+
+        // assert
+        expect(
+          controller.state.contacts,
+          [
+            ContactPlaceholder(1),
+            ContactPlaceholder(2),
+            ContactPlaceholder(3),
+          ],
+        );
+      },
+    );
+  });
+}
+
+class _MockEscapeManualToggleFeature extends Mock
+    implements EscapeManualToggleFeature {}
+
+class _MockOnEditTrustedContactsReaction extends Mock
+    implements _IOnEditTrustedContactsReaction {}
+
+abstract class _IOnEditTrustedContactsReaction {
+  void call(EditTrustedContactsReaction? reaction);
+}


### PR DESCRIPTION
Como as mudanças ficaram bem grandes, precisei dividi-las em algumas partes, aqui incluo as implementações para o controller e posteriormente virá um novo PR com o seu uso na implementação da tela.

 A proposta aqui é deixar a lista de contatos salva apenas em memória durante as inclusões/alterações, por isso toda a interação é feita sob a lista contida nesse controller, as modificações somente serão salvas no momento que voltar para a tela anterior, decidi implementar dessa maneira para evitar complexidades e multiplas escritas que acredito não serem necessárias.