### PR TITLE
Envia alterações das tarefas do manual de fuga para a API

### DIFF
--- a/lib/app/core/extension/date_time.dart
+++ b/lib/app/core/extension/date_time.dart
@@ -2,6 +2,22 @@ extension DateTimeExt on DateTime {
   int get secondsSinceEpoch =>
       millisecondsSinceEpoch ~/ Duration.millisecondsPerSecond;
 
+  static const months = {
+    'Jan': DateTime.january,
+    'Feb': DateTime.february,
+    'Mar': DateTime.march,
+    'Apr': DateTime.april,
+    'May': DateTime.may,
+    'Jun': DateTime.june,
+    'Jul': DateTime.july,
+    'Aug': DateTime.august,
+    'Sep': DateTime.september,
+    'Oct': DateTime.october,
+    'Nov': DateTime.november,
+    'Dec': DateTime.december,
+  };
+
+  /// Converts seconds since epoch to a [DateTime] object.
   static DateTime fromSecondsSinceEpoch(
     int secondsSinceEpoch, {
     bool isUtc = false,
@@ -10,6 +26,21 @@ extension DateTimeExt on DateTime {
         secondsSinceEpoch * Duration.millisecondsPerSecond,
         isUtc: isUtc,
       );
+
+  /// Converts a date in the format `Wed, 20 Dec 2023 01:45:39 GMT` to a
+  /// [DateTime] object.
+  static DateTime fromHttpFormat(String date) {
+    final parts = date.split(' ');
+    final day = int.parse(parts[1]);
+    final month = DateTimeExt.months[parts[2]]!;
+    final year = int.parse(parts[3]);
+    final time = parts[4].split(':');
+    final hour = int.parse(time[0]);
+    final minute = int.parse(time[1]);
+    final second = int.parse(time[2]);
+
+    return DateTime.utc(year, month, day, hour, minute, second);
+  }
 
   operator <(DateTime other) => isBefore(other);
 

--- a/lib/app/features/escape_manual/data/datasource/escape_manual_datasource.dart
+++ b/lib/app/features/escape_manual/data/datasource/escape_manual_datasource.dart
@@ -1,6 +1,6 @@
 import '../../../appstate/data/model/quiz_session_model.dart';
-import '../model/escape_manual_local.dart';
 import '../model/escape_manual_remote.dart';
+import '../model/escape_manual_task.dart';
 
 abstract class IEscapeManualDatasource {}
 
@@ -11,13 +11,13 @@ abstract class IEscapeManualRemoteDatasource extends IEscapeManualDatasource {
 
 abstract class IEscapeManualLocalDatasource extends IEscapeManualDatasource {
   /// Retrieves the tasks not synced with the server from the local database
-  Stream<Iterable<EscapeManualTaskLocalModel>> fetchTasks();
+  Stream<Iterable<EscapeManualTaskModel>> fetchTasks();
 
   /// Saves the task to the local database to be synced with the server later
-  Future<void> saveTask(EscapeManualTaskLocalModel task);
+  Future<void> saveTask(EscapeManualTaskModel task);
 
   /// Delete the task logically from the local database
-  Future<void> removeTask(EscapeManualTaskLocalModel task);
+  Future<void> removeTask(EscapeManualTaskModel task);
 
   /// Removes all tasks before the given date from the local database
   /// This is used to clear the local database after the tasks have been synced with the server

--- a/lib/app/features/escape_manual/data/datasource/escape_manual_datasource.dart
+++ b/lib/app/features/escape_manual/data/datasource/escape_manual_datasource.dart
@@ -2,22 +2,23 @@ import '../../../appstate/data/model/quiz_session_model.dart';
 import '../model/escape_manual_remote.dart';
 import '../model/escape_manual_task.dart';
 
-abstract class IEscapeManualDatasource {}
+abstract class IEscapeManualDatasource {
+  /// Saves the task
+  Future<EscapeManualTaskModel> saveTask(EscapeManualTaskModel task);
+}
 
 abstract class IEscapeManualRemoteDatasource extends IEscapeManualDatasource {
+  /// Starts a new escape manual session
   Future<QuizSessionModel> start(String sessionId);
+
+  /// Fetch remote escape manual data
   Future<EscapeManualRemoteModel> fetch();
 }
 
 abstract class IEscapeManualLocalDatasource extends IEscapeManualDatasource {
   /// Retrieves the tasks not synced with the server from the local database
+  /// and emits new data every time the local data changes
   Stream<Iterable<EscapeManualTaskModel>> fetchTasks();
-
-  /// Saves the task to the local database to be synced with the server later
-  Future<void> saveTask(EscapeManualTaskModel task);
-
-  /// Delete the task logically from the local database
-  Future<void> removeTask(EscapeManualTaskModel task);
 
   /// Removes all tasks before the given date from the local database
   /// This is used to clear the local database after the tasks have been synced with the server

--- a/lib/app/features/escape_manual/data/datasource/impl/escape_manual_local_datasource.dart
+++ b/lib/app/features/escape_manual/data/datasource/impl/escape_manual_local_datasource.dart
@@ -18,13 +18,9 @@ class EscapeManualLocalDatasource implements IEscapeManualLocalDatasource {
   Stream<Iterable<EscapeManualTaskModel>> fetchTasks() => _store.watchAll();
 
   @override
-  Future<void> saveTask(EscapeManualTaskModel task) async {
+  Future<EscapeManualTaskModel> saveTask(EscapeManualTaskModel task) async {
     await _store.put(task.id, task);
-  }
-
-  @override
-  Future<void> removeTask(EscapeManualTaskModel task) async {
-    await saveTask(task.copyWith(isRemoved: true));
+    return task;
   }
 
   @override

--- a/lib/app/features/escape_manual/data/datasource/impl/escape_manual_local_datasource.dart
+++ b/lib/app/features/escape_manual/data/datasource/impl/escape_manual_local_datasource.dart
@@ -2,29 +2,28 @@ import 'dart:async';
 
 import '../../../../../core/extension/iterable.dart';
 import '../../../../../core/storage/collection_store.dart';
-import '../../model/escape_manual_local.dart';
+import '../../model/escape_manual_task.dart';
 import '../escape_manual_datasource.dart';
 
 export '../escape_manual_datasource.dart' show IEscapeManualLocalDatasource;
 
 class EscapeManualLocalDatasource implements IEscapeManualLocalDatasource {
   EscapeManualLocalDatasource({
-    required ICollectionStore<EscapeManualTaskLocalModel> store,
+    required ICollectionStore<EscapeManualTaskModel> store,
   }) : _store = store;
 
-  final ICollectionStore<EscapeManualTaskLocalModel> _store;
+  final ICollectionStore<EscapeManualTaskModel> _store;
 
   @override
-  Stream<Iterable<EscapeManualTaskLocalModel>> fetchTasks() =>
-      _store.watchAll();
+  Stream<Iterable<EscapeManualTaskModel>> fetchTasks() => _store.watchAll();
 
   @override
-  Future<void> saveTask(EscapeManualTaskLocalModel task) async {
+  Future<void> saveTask(EscapeManualTaskModel task) async {
     await _store.put(task.id, task);
   }
 
   @override
-  Future<void> removeTask(EscapeManualTaskLocalModel task) async {
+  Future<void> removeTask(EscapeManualTaskModel task) async {
     await saveTask(task.copyWith(isRemoved: true));
   }
 

--- a/lib/app/features/escape_manual/data/datasource/impl/escape_manual_remote_datasource.dart
+++ b/lib/app/features/escape_manual/data/datasource/impl/escape_manual_remote_datasource.dart
@@ -7,6 +7,7 @@ import '../../../../../core/storage/object_store.dart';
 import '../../../../../shared/logger/log.dart';
 import '../../../../appstate/data/model/quiz_session_model.dart';
 import '../../model/escape_manual_remote.dart';
+import '../../model/escape_manual_task.dart';
 import '../escape_manual_datasource.dart';
 
 export '../escape_manual_datasource.dart' show IEscapeManualRemoteDatasource;
@@ -59,6 +60,22 @@ class EscapeManualRemoteDatasource implements IEscapeManualRemoteDatasource {
     }
   }
 
+  @override
+  Future<EscapeManualTaskModel> saveTask(EscapeManualTaskModel task) async {
+    final response = await _apiProvider.request(
+      method: 'POST',
+      path: '/me/tarefas/batch',
+      headers: {'Content-Type': 'application/json; charset=utf-8'},
+      body: jsonEncode([task.asRequest]),
+    );
+
+    final updatedAt = DateTimeExt.fromHttpFormat(response.headers['date']!);
+
+    return task.copyWith(
+      updatedAt: updatedAt,
+    );
+  }
+
   Future<EscapeManualRemoteModel> _incrementalCache({
     required EscapeManualRemoteModel? cached,
     required EscapeManualRemoteModel newer,
@@ -82,4 +99,13 @@ class EscapeManualRemoteDatasource implements IEscapeManualRemoteDatasource {
       tasks: updatedTasks + changedTasks.values,
     );
   }
+}
+
+extension _EscapeManualTaskModelExt on EscapeManualTaskModel {
+  Map<String, dynamic> get asRequest => {
+        'id': id,
+        'checkbox_feito': isDone ? 1 : 0,
+        'campo_livre': value,
+        'remove': isRemoved ? 1 : 0,
+      };
 }

--- a/lib/app/features/escape_manual/data/datastore/escape_manual_persistent_store.dart
+++ b/lib/app/features/escape_manual/data/datastore/escape_manual_persistent_store.dart
@@ -3,9 +3,9 @@ import 'dart:convert';
 import '../../../../core/storage/collection_store.dart';
 import '../../../../core/storage/persistent_storage.dart';
 import '../model/escape_manual_local.dart';
+import '../model/escape_manual_task.dart';
 
-class EscapeManualTasksStore
-    extends ICollectionStore<EscapeManualTaskLocalModel>
+class EscapeManualTasksStore extends ICollectionStore<EscapeManualTaskModel>
     with SerializableCollectionStore {
   EscapeManualTasksStore({
     required this.storageFactory,
@@ -18,10 +18,9 @@ class EscapeManualTasksStore
   final IPersistentStorageFactory storageFactory;
 
   @override
-  EscapeManualTaskLocalModel deserialize(String source) =>
+  EscapeManualTaskModel deserialize(String source) =>
       EscapeManualTaskLocalModel.fromJson(jsonDecode(source));
 
   @override
-  String serialize(EscapeManualTaskLocalModel object) =>
-      jsonEncode(object.toJson());
+  String serialize(EscapeManualTaskModel object) => jsonEncode(object.toJson());
 }

--- a/lib/app/features/escape_manual/data/model/escape_manual_local.dart
+++ b/lib/app/features/escape_manual/data/model/escape_manual_local.dart
@@ -1,10 +1,10 @@
-import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 import '../../../../core/extension/json_serializer.dart';
 import '../../domain/entity/escape_manual.dart';
 import 'escape_manual_mapper.dart'
     show readUserInputValue, userInputValueFromJson;
+import 'escape_manual_task.dart';
 import 'escape_manual_task_type.dart';
 
 export 'contact.dart';
@@ -13,7 +13,7 @@ export 'escape_manual_task_type.dart';
 part 'escape_manual_local.g.dart';
 
 @JsonSerializable()
-class EscapeManualTaskLocalModel extends Equatable {
+class EscapeManualTaskLocalModel extends EscapeManualTaskModel {
   const EscapeManualTaskLocalModel({
     required this.id,
     this.type = EscapeManualTaskType.normal,
@@ -31,36 +31,41 @@ class EscapeManualTaskLocalModel extends Equatable {
   factory EscapeManualTaskLocalModel.fromJson(Map<String, dynamic> map) =>
       _$EscapeManualTaskLocalModelFromJson(map);
 
+  @override
   @JsonKey(fromJson: FromJson.parseAsString)
   final String id;
 
+  @override
   @JsonKey(
-    defaultValue: EscapeManualTaskType.normal,
     unknownEnumValue: EscapeManualTaskType.unknown,
   )
   final EscapeManualTaskType type;
 
+  @override
   @JsonKey(
     readValue: readUserInputValue,
     fromJson: userInputValueFromJson,
   )
   final dynamic value;
 
+  @override
   @JsonKey()
   final bool isDone;
 
+  @override
   @JsonKey()
   final bool isRemoved;
 
+  @override
   @JsonKey()
   final DateTime? updatedAt;
 
   @override
-  List<Object?> get props => [id, type, value, isDone, isRemoved, updatedAt];
-
   Map<String, dynamic> toJson() => _$EscapeManualTaskLocalModelToJson(this);
 
+  @override
   EscapeManualTaskLocalModel copyWith({
+    dynamic value,
     bool? isDone,
     bool? isRemoved,
     DateTime? updatedAt,
@@ -68,7 +73,7 @@ class EscapeManualTaskLocalModel extends Equatable {
       EscapeManualTaskLocalModel(
         id: id,
         type: type,
-        value: value,
+        value: value ?? this.value,
         isDone: isDone ?? this.isDone,
         isRemoved: isRemoved ?? this.isRemoved,
         updatedAt: updatedAt ?? this.updatedAt,

--- a/lib/app/features/escape_manual/data/model/escape_manual_mapper.dart
+++ b/lib/app/features/escape_manual/data/model/escape_manual_mapper.dart
@@ -53,7 +53,7 @@ extension EscapeManualTaskRemoteMapper on EscapeManualTaskRemoteModel {
         id: id,
         description: description,
         isDone: isDone,
-        value: userInputValue,
+        value: value,
       );
     }
 

--- a/lib/app/features/escape_manual/data/model/escape_manual_remote.dart
+++ b/lib/app/features/escape_manual/data/model/escape_manual_remote.dart
@@ -94,14 +94,14 @@ class EscapeManualTaskRemoteModel extends Equatable {
     this.title,
     required this.description,
     this.isDone = false,
-    this.userInputValue,
+    this.value,
     required this.updatedAt,
   })  : assert(type != EscapeManualTaskType.unknown),
         assert(
           type == EscapeManualTaskType.contacts
-              ? userInputValue is List<ContactEntity>?
+              ? value is List<ContactEntity>?
               : true,
-          'Invalid userInputValue: $userInputValue', // coverage:ignore-line
+          'Invalid value: $value', // coverage:ignore-line
         );
 
   factory EscapeManualTaskRemoteModel.fromJson(Map<String, dynamic> json) =>
@@ -128,7 +128,7 @@ class EscapeManualTaskRemoteModel extends Equatable {
     readValue: readUserInputValue,
     fromJson: userInputValueFromJson,
   )
-  final dynamic userInputValue;
+  final dynamic value;
 
   @JsonKey(name: 'checkbox_feito')
   @JsonBoolConverter()
@@ -146,14 +146,14 @@ class EscapeManualTaskRemoteModel extends Equatable {
         title,
         description,
         isDone,
-        userInputValue,
+        value,
         updatedAt,
       ];
 
   Map<String, Object?> toJson() => _$EscapeManualTaskRemoteModelToJson(this);
 
   EscapeManualTaskRemoteModel copyWith({
-    dynamic userInputValue,
+    dynamic value,
     bool? isDone,
   }) =>
       EscapeManualTaskRemoteModel(
@@ -162,7 +162,7 @@ class EscapeManualTaskRemoteModel extends Equatable {
         group: group,
         title: title,
         description: description,
-        userInputValue: userInputValue ?? this.userInputValue,
+        value: value ?? this.value,
         isDone: isDone ?? this.isDone,
         updatedAt: updatedAt,
       );

--- a/lib/app/features/escape_manual/data/model/escape_manual_remote.dart
+++ b/lib/app/features/escape_manual/data/model/escape_manual_remote.dart
@@ -6,6 +6,7 @@ import '../../../appstate/data/model/quiz_session_model.dart';
 import 'contact.dart';
 import 'escape_manual_mapper.dart'
     show readUserInputValue, userInputValueFromJson;
+import 'escape_manual_task.dart';
 import 'escape_manual_task_type.dart';
 
 export 'contact.dart';
@@ -86,7 +87,7 @@ class EscapeManualAssistantRemoteModel extends Equatable {
 }
 
 @JsonSerializable()
-class EscapeManualTaskRemoteModel extends Equatable {
+class EscapeManualTaskRemoteModel extends EscapeManualTaskModel {
   const EscapeManualTaskRemoteModel({
     required this.id,
     required this.type,
@@ -96,6 +97,7 @@ class EscapeManualTaskRemoteModel extends Equatable {
     this.isDone = false,
     this.value,
     required this.updatedAt,
+    this.isRemoved = false,
   })  : assert(type != EscapeManualTaskType.unknown),
         assert(
           type == EscapeManualTaskType.contacts
@@ -107,9 +109,11 @@ class EscapeManualTaskRemoteModel extends Equatable {
   factory EscapeManualTaskRemoteModel.fromJson(Map<String, dynamic> json) =>
       _$EscapeManualTaskRemoteModelFromJson(json);
 
+  @override
   @JsonKey(fromJson: FromJson.parseAsString)
   final String id;
 
+  @override
   @JsonKey(name: 'tipo')
   final EscapeManualTaskType type;
 
@@ -123,6 +127,7 @@ class EscapeManualTaskRemoteModel extends Equatable {
   @JsonKey(name: 'descricao')
   final String description;
 
+  @override
   @JsonKey(
     name: 'campo_livre',
     readValue: readUserInputValue,
@@ -130,31 +135,36 @@ class EscapeManualTaskRemoteModel extends Equatable {
   )
   final dynamic value;
 
+  @override
   @JsonKey(name: 'checkbox_feito')
   @JsonBoolConverter()
   final bool isDone;
 
+  @override
   @JsonKey(name: 'atualizado_em')
   @JsonSecondsFromEpochConverter()
   final DateTime updatedAt;
 
   @override
+  final bool isRemoved;
+
+  @override
   List<Object?> get props => [
-        id,
-        type,
+        ...super.props,
         group,
         title,
         description,
-        isDone,
-        value,
-        updatedAt,
       ];
 
+  @override
   Map<String, Object?> toJson() => _$EscapeManualTaskRemoteModelToJson(this);
 
+  @override
   EscapeManualTaskRemoteModel copyWith({
     dynamic value,
     bool? isDone,
+    bool? isRemoved,
+    DateTime? updatedAt,
   }) =>
       EscapeManualTaskRemoteModel(
         id: id,
@@ -164,6 +174,7 @@ class EscapeManualTaskRemoteModel extends Equatable {
         description: description,
         value: value ?? this.value,
         isDone: isDone ?? this.isDone,
-        updatedAt: updatedAt,
+        isRemoved: isRemoved ?? this.isRemoved,
+        updatedAt: updatedAt ?? this.updatedAt,
       );
 }

--- a/lib/app/features/escape_manual/data/model/escape_manual_remote.g.dart
+++ b/lib/app/features/escape_manual/data/model/escape_manual_remote.g.dart
@@ -79,7 +79,7 @@ EscapeManualTaskRemoteModel _$EscapeManualTaskRemoteModelFromJson(
       isDone: json['checkbox_feito'] == null
           ? false
           : const JsonBoolConverter().fromJson(json['checkbox_feito']),
-      userInputValue: userInputValueFromJson(
+      value: userInputValueFromJson(
           readUserInputValue(json, 'campo_livre') as Map<String, dynamic>),
       updatedAt: const JsonSecondsFromEpochConverter()
           .fromJson(json['atualizado_em'] as int),
@@ -102,7 +102,7 @@ Map<String, dynamic> _$EscapeManualTaskRemoteModelToJson(
   writeNotNull(
       'titulo', const JsonEmptyStringToNullConverter().toJson(instance.title));
   val['descricao'] = instance.description;
-  writeNotNull('campo_livre', instance.userInputValue);
+  writeNotNull('campo_livre', instance.value);
   writeNotNull(
       'checkbox_feito', const JsonBoolConverter().toJson(instance.isDone));
   writeNotNull('atualizado_em',

--- a/lib/app/features/escape_manual/data/model/escape_manual_task.dart
+++ b/lib/app/features/escape_manual/data/model/escape_manual_task.dart
@@ -1,0 +1,31 @@
+import 'package:equatable/equatable.dart';
+
+import 'escape_manual_task_type.dart';
+
+abstract class EscapeManualTaskModel extends Equatable {
+  const EscapeManualTaskModel();
+
+  String get id;
+
+  EscapeManualTaskType get type;
+
+  dynamic get value;
+
+  bool get isDone;
+
+  bool get isRemoved;
+
+  DateTime? get updatedAt;
+
+  @override
+  List<Object?> get props => [id, type, value, isRemoved];
+
+  Map<String, Object?> toJson();
+
+  EscapeManualTaskModel copyWith({
+    dynamic value,
+    bool? isDone,
+    bool? isRemoved,
+    DateTime? updatedAt,
+  });
+}

--- a/lib/app/features/escape_manual/data/repository/escape_manual_repository.dart
+++ b/lib/app/features/escape_manual/data/repository/escape_manual_repository.dart
@@ -116,7 +116,7 @@ class EscapeManualRepository implements IEscapeManualRepository {
 
       return remoteTask.copyWith(
         isDone: localTask.isDone,
-        userInputValue: localTask.value,
+        value: localTask.value,
       );
     });
 

--- a/lib/app/features/escape_manual/data/repository/escape_manual_repository.dart
+++ b/lib/app/features/escape_manual/data/repository/escape_manual_repository.dart
@@ -11,9 +11,9 @@ import '../../../authentication/presentation/shared/map_exception_to_failure.dar
 import '../../domain/entity/escape_manual.dart';
 import '../../domain/repository/escape_manual_repository.dart';
 import '../datasource/escape_manual_datasource.dart';
-import '../model/escape_manual_local.dart';
 import '../model/escape_manual_mapper.dart';
 import '../model/escape_manual_remote.dart';
+import '../model/escape_manual_task.dart';
 
 export '../../domain/repository/escape_manual_repository.dart'
     show IEscapeManualRepository;
@@ -98,9 +98,9 @@ class EscapeManualRepository implements IEscapeManualRepository {
   /// and return the updated remote data
   EscapeManualEntity _updateFromLocal(
     EscapeManualRemoteModel remote,
-    Iterable<EscapeManualTaskLocalModel> localTasks,
+    Iterable<EscapeManualTaskModel> localTasks,
   ) {
-    final tasksMap = Map<String, EscapeManualTaskLocalModel>.fromIterable(
+    final tasksMap = Map<String, EscapeManualTaskModel>.fromIterable(
       localTasks,
       key: (el) => '${el.id}',
     );

--- a/lib/app/features/escape_manual/data/repository/escape_manual_repository.dart
+++ b/lib/app/features/escape_manual/data/repository/escape_manual_repository.dart
@@ -11,6 +11,7 @@ import '../../../authentication/presentation/shared/map_exception_to_failure.dar
 import '../../domain/entity/escape_manual.dart';
 import '../../domain/repository/escape_manual_repository.dart';
 import '../datasource/escape_manual_datasource.dart';
+import '../model/escape_manual_local.dart';
 import '../model/escape_manual_mapper.dart';
 import '../model/escape_manual_remote.dart';
 import '../model/escape_manual_task.dart';
@@ -57,7 +58,9 @@ class EscapeManualRepository implements IEscapeManualRepository {
 
       await _localDatasource.clearBefore(response.lastModifiedAt);
 
-      final iterator = StreamIterator(_localDatasource.fetchTasks());
+      final iterator = StreamIterator(
+        _localDatasource.fetchTasks().distinct(),
+      );
 
       while (await iterator.moveNext()) {
         yield _updateFromLocal(response, iterator.current);
@@ -70,27 +73,14 @@ class EscapeManualRepository implements IEscapeManualRepository {
 
   /// Update a task from the escape manual locally
   @override
-  VoidResult updateTask(EscapeManualTaskEntity task) async {
-    try {
-      final result = await _localDatasource.saveTask(task.asLocalModel);
-      return right(result);
-    } catch (error, stack) {
-      logError(error, stack);
-      return left(MapExceptionToFailure.map(error));
-    }
-  }
+  VoidResult updateTask(EscapeManualTaskEntity task) =>
+      _saveInAllDataSources(task.asLocalModel);
 
   /// Remove a task from the escape manual locally
   @override
-  VoidResult removeTask(EscapeManualTaskEntity task) async {
-    try {
-      final result = await _localDatasource.removeTask(task.asLocalModel);
-      return right(result);
-    } catch (error, stack) {
-      logError(error, stack);
-      return left(MapExceptionToFailure.map(error));
-    }
-  }
+  VoidResult removeTask(EscapeManualTaskEntity task) => _saveInAllDataSources(
+        task.asLocalModel.copyWith(isRemoved: true),
+      );
 
   /// Apply local changes to the remote data
   /// if local task is newer than remote task
@@ -121,5 +111,27 @@ class EscapeManualRepository implements IEscapeManualRepository {
     });
 
     return remote.copyWith(tasks: tasks).asEntity;
+  }
+
+  /// Save a task in all datasources
+  VoidResult _saveInAllDataSources(
+    EscapeManualTaskLocalModel model,
+  ) async {
+    try {
+      final results = await Future.wait([
+        // save in local datasource first to prevent losing data
+        _localDatasource.saveTask(model),
+        // save in remote datasource
+        _remoteDatasource.saveTask(model),
+      ]);
+
+      // update local task from remote task containing the updatedAt
+      await _localDatasource.saveTask(results[1]);
+
+      return right(null);
+    } catch (error, stack) {
+      logError(error, stack);
+      return left(MapExceptionToFailure.map(error));
+    }
   }
 }

--- a/test/app/core/extension/date_time_test.dart
+++ b/test/app/core/extension/date_time_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:penhas/app/core/extension/date_time.dart';
+
+void main() {
+  test(
+    'secondsSinceEpoch should return seconds since epoch',
+    () async {
+      // arrange
+      final expected = 1703714581;
+
+      // act
+      final actual = DateTime.utc(2023, 12, 27, 22, 3, 1).secondsSinceEpoch;
+
+      // assert
+      expect(actual, expected);
+    },
+  );
+
+  test(
+    'fromSecondsSinceEpoch should return DateTime from seconds since epoch',
+    () async {
+      // arrange
+      final expected = DateTime.utc(2023, 12, 27, 22, 3, 1);
+
+      // act
+      final actual = DateTimeExt.fromSecondsSinceEpoch(1703714581, isUtc: true);
+
+      // assert
+      expect(actual, expected);
+    },
+  );
+
+  test(
+    'fromHttpFormat should return DateTime from http format',
+    () async {
+      // arrange
+      final expected = DateTime.utc(2023, 12, 20, 1, 45, 39);
+
+      // act
+      final actual =
+          DateTimeExt.fromHttpFormat('Wed, 20 Dec 2023 01:45:39 GMT');
+
+      // assert
+      expect(actual, expected);
+    },
+  );
+
+  test(
+    'operator < should return true if date is before other',
+    () async {
+      // arrange
+      final date = DateTime.utc(2023, 12, 20, 1, 45, 39);
+      final other = DateTime.utc(2023, 12, 20, 1, 45, 40);
+
+      // act
+      final actual = date < other;
+
+      // assert
+      expect(actual, true);
+    },
+  );
+
+  test(
+    'operator < should return false if date is after other',
+    () async {
+      // arrange
+      final date = DateTime.utc(2023, 12, 20, 1, 45, 40);
+      final other = DateTime.utc(2023, 12, 20, 1, 45, 39);
+
+      // act
+      final actual = date < other;
+
+      // assert
+      expect(actual, false);
+    },
+  );
+
+  test(
+    'operator > should return true if date is after other',
+    () async {
+      // arrange
+      final date = DateTime.utc(2023, 12, 20, 1, 45, 40);
+      final other = DateTime.utc(2023, 12, 20, 1, 45, 39);
+
+      // act
+      final actual = date > other;
+
+      // assert
+      expect(actual, true);
+    },
+  );
+
+  test(
+    'operator > should return false if date is before other',
+    () async {
+      // arrange
+      final date = DateTime.utc(2023, 12, 20, 1, 45, 39);
+      final other = DateTime.utc(2023, 12, 20, 1, 45, 40);
+
+      // act
+      final actual = date > other;
+
+      // assert
+      expect(actual, false);
+    },
+  );
+}

--- a/test/app/features/escape_manual/data/datasource/impl/escape_manual_local_datasource_test.dart
+++ b/test/app/features/escape_manual/data/datasource/impl/escape_manual_local_datasource_test.dart
@@ -50,26 +50,11 @@ void main() {
       when(() => mockStore.put(any(), any())).thenAnswer((_) => Future.value());
 
       // act
-      await sut.saveTask(task);
+      final actual = await sut.saveTask(task);
 
       // assert
       verify(() => mockStore.put(task.id, task)).called(1);
-    });
-
-    test('should call store put with isRemoved true', () async {
-      // arrange
-      final task = EscapeManualTaskLocalModel(
-        id: 'id',
-        updatedAt: DateTime.now(),
-      );
-      when(() => mockStore.put(any(), any())).thenAnswer((_) => Future.value());
-
-      // act
-      await sut.removeTask(task);
-
-      // assert
-      verify(() => mockStore.put(task.id, task.copyWith(isRemoved: true)))
-          .called(1);
+      expect(actual, task);
     });
 
     test('should call store removeAll', () async {

--- a/test/app/features/escape_manual/data/datastore/escape_manual_persistent_store_test.dart
+++ b/test/app/features/escape_manual/data/datastore/escape_manual_persistent_store_test.dart
@@ -6,10 +6,11 @@ import 'package:penhas/app/core/storage/collection_store.dart';
 import 'package:penhas/app/core/storage/persistent_storage.dart';
 import 'package:penhas/app/features/escape_manual/data/datastore/escape_manual_persistent_store.dart';
 import 'package:penhas/app/features/escape_manual/data/model/escape_manual_local.dart';
+import 'package:penhas/app/features/escape_manual/data/model/escape_manual_task.dart';
 
 void main() {
   group(EscapeManualTasksStore, () {
-    late ICollectionStore<EscapeManualTaskLocalModel> sut;
+    late ICollectionStore<EscapeManualTaskModel> sut;
 
     late IPersistentStorageFactory mockStorageFactory;
     late IPersistentStorage mockStorage;

--- a/test/app/features/escape_manual/data/model/escape_manual_fixtures.dart
+++ b/test/app/features/escape_manual/data/model/escape_manual_fixtures.dart
@@ -44,7 +44,7 @@ final escapeManualModelFixture = EscapeManualRemoteModel(
       title: 'title',
       description: 'description',
       isDone: false,
-      userInputValue: null,
+      value: null,
       updatedAt: DateTime.now(),
     ),
     EscapeManualTaskRemoteModel(
@@ -63,7 +63,7 @@ final escapeManualModelFixture = EscapeManualRemoteModel(
       title: 'title',
       description: 'description',
       isDone: true,
-      userInputValue: [
+      value: [
         ContactModel(
           id: 1,
           name: 'Other contact name',
@@ -210,7 +210,7 @@ final escapeManualRemoteModelFixture = EscapeManualRemoteModel(
       group: 'Contatos',
       description: 'Informe os contatos de pessoas de confiança.',
       updatedAt: DateTime.fromMillisecondsSinceEpoch(1689701025000),
-      userInputValue: null,
+      value: null,
     ),
   ],
 );
@@ -240,7 +240,7 @@ final updatedEscapeManualRemoteModelFixture = EscapeManualRemoteModel(
       description:
           'Cadastre-se e/ou verifique se o seu Cadastro Único (CadÚnico) está ativo.',
       updatedAt: DateTime.fromMillisecondsSinceEpoch(1696116772000),
-      userInputValue: null,
+      value: null,
     ),
     EscapeManualTaskRemoteModel(
       id: '75',
@@ -256,7 +256,7 @@ final updatedEscapeManualRemoteModelFixture = EscapeManualRemoteModel(
       group: 'Contatos',
       description: 'Informe os contatos de pessoas de confiança.',
       updatedAt: DateTime.fromMillisecondsSinceEpoch(1696116772000),
-      userInputValue: [
+      value: [
         ContactModel(
           id: 1,
           name: 'Contact name',


### PR DESCRIPTION
Implementação da lógica para enviar as alterações feitas pela usuária das tarefas do manual de fuga.
Primeiramente as tarefas continuam sendo salvas localmente, após isso é feita a tentativa de envio para a API, se esse envio for bem sucedido, a tarefa é atualizada localmente com a data para que na próxima vez que a lista de tarefas for recebida do servidor, elas possam ser removidas localmente.

Para essa implementação foi necessário:
- Criar abstração das tarefas para a camada de dados, de maneira que o remoto e local sigam esse contrato, sendo necessário renomear a propriedade `userInputValue` para apenas `value`;
- Criar o método `request` para a abstração do `ApiProvider` para que seja possível ter acesso ao objeto `Response` e seus cabeçalhos;
- Unificar o salvar e remoção das tarefas localmente, por ser uma exclusão lógica e presente em ambos os datasources.

> Em próximo PR será implementada a lógica para tentar reenviar as tarefas em caso de falhas