### PR TITLE
Refatoração da serialização das tarefas do MF no cache local

### DIFF
--- a/lib/app/core/storage/impl/json_object_store.dart
+++ b/lib/app/core/storage/impl/json_object_store.dart
@@ -1,0 +1,33 @@
+import 'dart:convert';
+
+import '../../types/json.dart';
+import '../key_value_storage.dart';
+import '../object_store.dart';
+
+class JsonObjectStore extends IObjectStore<JsonObject> {
+  JsonObjectStore({
+    required this.name,
+    required this.storage,
+  });
+
+  @override
+  final String name;
+  final IKeyValueStorage storage;
+
+  @override
+  Future<JsonObject?> retrieve() async {
+    final data = await storage.getString(name);
+    if (data == null) return null;
+    final jsonObject = jsonDecode(data) as JsonObject;
+    return jsonObject;
+  }
+
+  @override
+  Future<void> save(JsonObject value) async {
+    final jsonString = jsonEncode(value);
+    await storage.put(name, jsonString);
+  }
+
+  @override
+  Future<void> delete() => storage.remove(name);
+}

--- a/lib/app/core/storage/object_store.dart
+++ b/lib/app/core/storage/object_store.dart
@@ -1,6 +1,4 @@
-import 'key_value_storage.dart';
-
-abstract class IObjectStore<T> {
+abstract class IObjectStore<T extends Object> {
   String get name;
 
   Future<T?> retrieve();
@@ -8,28 +6,4 @@ abstract class IObjectStore<T> {
   Future<void> save(T value);
 
   Future<void> delete();
-}
-
-mixin SerializableObjectStore<T> on IObjectStore<T> {
-  IKeyValueStorage get storage;
-
-  T deserialize(String data);
-
-  String serialize(T data);
-
-  @override
-  Future<T?> retrieve() async {
-    final data = await storage.getString(name);
-    if (data == null) return null;
-    return deserialize(data);
-  }
-
-  @override
-  Future<void> save(T value) async {
-    final data = serialize(value);
-    await storage.put(name, data);
-  }
-
-  @override
-  Future<void> delete() => storage.remove(name);
 }

--- a/lib/app/core/types/json.dart
+++ b/lib/app/core/types/json.dart
@@ -1,0 +1,3 @@
+typedef JsonObject = Map<String, dynamic>;
+
+typedef JsonList = List<dynamic>;

--- a/lib/app/features/escape_manual/data/datastore/escape_manual_cache_store.dart
+++ b/lib/app/features/escape_manual/data/datastore/escape_manual_cache_store.dart
@@ -1,27 +1,11 @@
-import 'dart:convert';
-
 import '../../../../core/storage/cache_storage.dart';
+import '../../../../core/storage/impl/json_object_store.dart';
 import '../../../../core/storage/object_store.dart';
-import '../model/escape_manual_remote.dart';
+import '../../../../core/types/json.dart';
 
-class EscapeManualCacheStore extends IObjectStore<EscapeManualRemoteModel>
-    with SerializableObjectStore<EscapeManualRemoteModel> {
+class EscapeManualCacheStore extends JsonObjectStore
+    implements IObjectStore<JsonObject> {
   EscapeManualCacheStore({
-    required this.storage,
-  });
-
-  @override
-  final name = 'escape_manual_cache';
-
-  @override
-  final ICacheStorage storage;
-
-  @override
-  EscapeManualRemoteModel deserialize(String data) {
-    final json = jsonDecode(data);
-    return EscapeManualRemoteModel.fromJson(json);
-  }
-
-  @override
-  String serialize(EscapeManualRemoteModel data) => jsonEncode(data);
+    required ICacheStorage storage,
+  }) : super(name: 'escape_manual_cache', storage: storage);
 }

--- a/lib/app/features/escape_manual/data/model/escape_manual_local.dart
+++ b/lib/app/features/escape_manual/data/model/escape_manual_local.dart
@@ -1,7 +1,6 @@
 import 'package:json_annotation/json_annotation.dart';
 
 import '../../../../core/extension/json_serializer.dart';
-import '../../domain/entity/escape_manual.dart';
 import 'escape_manual_mapper.dart'
     show readUserInputValue, userInputValueFromJson;
 import 'escape_manual_task.dart';
@@ -21,12 +20,7 @@ class EscapeManualTaskLocalModel extends EscapeManualTaskModel {
     this.isDone = false,
     this.isRemoved = false,
     this.updatedAt,
-  })  : assert(type != EscapeManualTaskType.unknown),
-        assert(
-          type != EscapeManualTaskType.contacts ||
-              value is List<ContactEntity>?,
-          'Item $id with invalid value: $value', // coverage:ignore-line
-        );
+  }) : super(type: type, value: value);
 
   factory EscapeManualTaskLocalModel.fromJson(Map<String, dynamic> map) =>
       _$EscapeManualTaskLocalModelFromJson(map);

--- a/lib/app/features/escape_manual/data/model/escape_manual_mapper.dart
+++ b/lib/app/features/escape_manual/data/model/escape_manual_mapper.dart
@@ -65,8 +65,10 @@ extension EscapeManualTaskRemoteMapper on EscapeManualTaskRemoteModel {
           value: value,
         );
 
+      // coverage:ignore-start
       case EscapeManualTaskType.unknown:
-        return null; // coverage:ignore-line
+        return null;
+      // coverage:ignore-end
     }
   }
 }

--- a/lib/app/features/escape_manual/data/model/escape_manual_mapper.dart
+++ b/lib/app/features/escape_manual/data/model/escape_manual_mapper.dart
@@ -67,6 +67,7 @@ extension EscapeManualTaskRemoteMapper on EscapeManualTaskRemoteModel {
 
       // coverage:ignore-start
       case EscapeManualTaskType.unknown:
+        logError('Invalid type "$rawType" for task "$id"');
         return null;
       // coverage:ignore-end
     }
@@ -101,6 +102,9 @@ extension ContactEntityMapper on ContactEntity {
         phone: phone,
       );
 }
+
+String? readRawType(Map map, String key) =>
+    (map[key] ?? map['tipo']) as String?;
 
 Map<String, dynamic> readUserInputValue(Map map, String key) =>
     <String, dynamic>{

--- a/lib/app/features/escape_manual/data/model/escape_manual_mapper.dart
+++ b/lib/app/features/escape_manual/data/model/escape_manual_mapper.dart
@@ -1,5 +1,6 @@
 import 'package:collection/collection.dart';
 
+import '../../../../core/extension/iterable.dart';
 import '../../../../shared/logger/log.dart';
 import '../../domain/entity/escape_manual.dart';
 import 'escape_manual_local.dart';
@@ -38,7 +39,7 @@ extension EscapeManualTasksSectionMapper
             (el) => EscapeManualTasksSectionEntity(
               title: el.key,
               tasks: el.value
-                  .map<EscapeManualTaskEntity>((el) => el.asEntity)
+                  .mapNotNull<EscapeManualTaskEntity>((el) => el.asEntity)
                   .toList(),
             ),
           )
@@ -47,22 +48,26 @@ extension EscapeManualTasksSectionMapper
 
 extension EscapeManualTaskRemoteMapper on EscapeManualTaskRemoteModel {
   /// Maps a [EscapeManualTaskRemoteModel] to a [EscapeManualTaskEntity].
-  EscapeManualTaskEntity get asEntity {
-    if (type == EscapeManualTaskType.contacts) {
-      return EscapeManualContactsTaskEntity(
-        id: id,
-        description: description,
-        isDone: isDone,
-        value: value,
-      );
-    }
+  EscapeManualTaskEntity? get asEntity {
+    switch (type) {
+      case EscapeManualTaskType.normal:
+        return EscapeManualDefaultTaskEntity(
+          id: id,
+          description: description,
+          isDone: isDone,
+        );
 
-    assert(type != EscapeManualTaskType.unknown);
-    return EscapeManualDefaultTaskEntity(
-      id: id,
-      description: description,
-      isDone: isDone,
-    );
+      case EscapeManualTaskType.contacts:
+        return EscapeManualContactsTaskEntity(
+          id: id,
+          description: description,
+          isDone: isDone,
+          value: value,
+        );
+
+      case EscapeManualTaskType.unknown:
+        return null; // coverage:ignore-line
+    }
   }
 }
 

--- a/lib/app/features/escape_manual/data/model/escape_manual_remote.dart
+++ b/lib/app/features/escape_manual/data/model/escape_manual_remote.dart
@@ -4,7 +4,7 @@ import 'package:json_annotation/json_annotation.dart';
 import '../../../../core/extension/json_serializer.dart';
 import '../../../appstate/data/model/quiz_session_model.dart';
 import 'escape_manual_mapper.dart'
-    show readUserInputValue, userInputValueFromJson;
+    show readRawType, readUserInputValue, userInputValueFromJson;
 import 'escape_manual_task.dart';
 import 'escape_manual_task_type.dart';
 
@@ -97,6 +97,7 @@ class EscapeManualTaskRemoteModel extends EscapeManualTaskModel {
     this.value,
     required this.updatedAt,
     this.isRemoved = false,
+    this.rawType,
   }) : super(type: type, value: value);
 
   factory EscapeManualTaskRemoteModel.fromJson(Map<String, dynamic> json) =>
@@ -112,6 +113,9 @@ class EscapeManualTaskRemoteModel extends EscapeManualTaskModel {
     unknownEnumValue: EscapeManualTaskType.unknown,
   )
   final EscapeManualTaskType type;
+
+  @JsonKey(readValue: readRawType)
+  final String? rawType;
 
   @JsonKey(name: 'agrupador')
   final String group;
@@ -172,5 +176,6 @@ class EscapeManualTaskRemoteModel extends EscapeManualTaskModel {
         isDone: isDone ?? this.isDone,
         isRemoved: isRemoved ?? this.isRemoved,
         updatedAt: updatedAt ?? this.updatedAt,
+        rawType: rawType,
       );
 }

--- a/lib/app/features/escape_manual/data/model/escape_manual_remote.dart
+++ b/lib/app/features/escape_manual/data/model/escape_manual_remote.dart
@@ -3,7 +3,6 @@ import 'package:json_annotation/json_annotation.dart';
 
 import '../../../../core/extension/json_serializer.dart';
 import '../../../appstate/data/model/quiz_session_model.dart';
-import 'contact.dart';
 import 'escape_manual_mapper.dart'
     show readUserInputValue, userInputValueFromJson;
 import 'escape_manual_task.dart';
@@ -93,18 +92,12 @@ class EscapeManualTaskRemoteModel extends EscapeManualTaskModel {
     required this.type,
     required this.group,
     this.title,
-    required this.description,
+    this.description = '',
     this.isDone = false,
     this.value,
     required this.updatedAt,
     this.isRemoved = false,
-  })  : assert(type != EscapeManualTaskType.unknown),
-        assert(
-          type == EscapeManualTaskType.contacts
-              ? value is List<ContactEntity>?
-              : true,
-          'Invalid value: $value', // coverage:ignore-line
-        );
+  }) : super(type: type, value: value);
 
   factory EscapeManualTaskRemoteModel.fromJson(Map<String, dynamic> json) =>
       _$EscapeManualTaskRemoteModelFromJson(json);
@@ -114,7 +107,10 @@ class EscapeManualTaskRemoteModel extends EscapeManualTaskModel {
   final String id;
 
   @override
-  @JsonKey(name: 'tipo')
+  @JsonKey(
+    name: 'tipo',
+    unknownEnumValue: EscapeManualTaskType.unknown,
+  )
   final EscapeManualTaskType type;
 
   @JsonKey(name: 'agrupador')

--- a/lib/app/features/escape_manual/data/model/escape_manual_remote.g.dart
+++ b/lib/app/features/escape_manual/data/model/escape_manual_remote.g.dart
@@ -84,6 +84,7 @@ EscapeManualTaskRemoteModel _$EscapeManualTaskRemoteModelFromJson(
           readUserInputValue(json, 'campo_livre') as Map<String, dynamic>),
       updatedAt: const JsonSecondsFromEpochConverter()
           .fromJson(json['atualizado_em'] as int),
+      rawType: readRawType(json, 'rawType') as String?,
     );
 
 Map<String, dynamic> _$EscapeManualTaskRemoteModelToJson(
@@ -91,7 +92,6 @@ Map<String, dynamic> _$EscapeManualTaskRemoteModelToJson(
   final val = <String, dynamic>{
     'id': instance.id,
     'tipo': _$EscapeManualTaskTypeEnumMap[instance.type]!,
-    'agrupador': instance.group,
   };
 
   void writeNotNull(String key, dynamic value) {
@@ -100,6 +100,8 @@ Map<String, dynamic> _$EscapeManualTaskRemoteModelToJson(
     }
   }
 
+  writeNotNull('rawType', instance.rawType);
+  val['agrupador'] = instance.group;
   writeNotNull(
       'titulo', const JsonEmptyStringToNullConverter().toJson(instance.title));
   val['descricao'] = instance.description;

--- a/lib/app/features/escape_manual/data/model/escape_manual_remote.g.dart
+++ b/lib/app/features/escape_manual/data/model/escape_manual_remote.g.dart
@@ -71,11 +71,12 @@ EscapeManualTaskRemoteModel _$EscapeManualTaskRemoteModelFromJson(
         Map<String, dynamic> json) =>
     EscapeManualTaskRemoteModel(
       id: FromJson.parseAsString(json['id']),
-      type: $enumDecode(_$EscapeManualTaskTypeEnumMap, json['tipo']),
+      type: $enumDecode(_$EscapeManualTaskTypeEnumMap, json['tipo'],
+          unknownValue: EscapeManualTaskType.unknown),
       group: json['agrupador'] as String,
       title: const JsonEmptyStringToNullConverter()
           .fromJson(json['titulo'] as String?),
-      description: json['descricao'] as String,
+      description: json['descricao'] as String? ?? '',
       isDone: json['checkbox_feito'] == null
           ? false
           : const JsonBoolConverter().fromJson(json['checkbox_feito']),

--- a/lib/app/features/escape_manual/data/model/escape_manual_task.dart
+++ b/lib/app/features/escape_manual/data/model/escape_manual_task.dart
@@ -1,9 +1,21 @@
 import 'package:equatable/equatable.dart';
 
+import '../../domain/entity/contact.dart';
 import 'escape_manual_task_type.dart';
 
 abstract class EscapeManualTaskModel extends Equatable {
-  const EscapeManualTaskModel();
+  /// Creates a [EscapeManualTaskModel] with the given [type] and [value].
+  /// The constructor is just to assert the type of [value] based on the [type].
+  const EscapeManualTaskModel({
+    required EscapeManualTaskType type,
+    dynamic value,
+  })  : assert(
+          type == EscapeManualTaskType.contacts
+              ? value is List<ContactEntity>?
+              : true,
+          'Invalid value: $value for type $type', // coverage:ignore-line
+        ),
+        assert(type != EscapeManualTaskType.unknown);
 
   String get id;
 

--- a/lib/app/features/escape_manual/data/model/escape_manual_task.dart
+++ b/lib/app/features/escape_manual/data/model/escape_manual_task.dart
@@ -11,10 +11,10 @@ abstract class EscapeManualTaskModel extends Equatable {
     required EscapeManualTaskType type,
     dynamic value,
   })  : assert(
-          type == EscapeManualTaskType.contacts
-              ? value is List<ContactEntity>?
-              : true,
-          'Invalid value: $value for type $type',
+          type != EscapeManualTaskType.contacts ||
+              value is List<ContactEntity>?,
+          'The `value` must be a `List<ContactEntity>` '
+          'when the type is `contacts`',
         ),
         assert(type != EscapeManualTaskType.unknown);
   // coverage:ignore-end

--- a/lib/app/features/escape_manual/data/model/escape_manual_task.dart
+++ b/lib/app/features/escape_manual/data/model/escape_manual_task.dart
@@ -6,6 +6,7 @@ import 'escape_manual_task_type.dart';
 abstract class EscapeManualTaskModel extends Equatable {
   /// Creates a [EscapeManualTaskModel] with the given [type] and [value].
   /// The constructor is just to assert the type of [value] based on the [type].
+  /// coverage:ignore-start
   const EscapeManualTaskModel({
     required EscapeManualTaskType type,
     dynamic value,
@@ -13,9 +14,10 @@ abstract class EscapeManualTaskModel extends Equatable {
           type == EscapeManualTaskType.contacts
               ? value is List<ContactEntity>?
               : true,
-          'Invalid value: $value for type $type', // coverage:ignore-line
+          'Invalid value: $value for type $type',
         ),
         assert(type != EscapeManualTaskType.unknown);
+  // coverage:ignore-end
 
   String get id;
 

--- a/test/app/features/escape_manual/data/datastore/escape_manual_cache_store_test.dart
+++ b/test/app/features/escape_manual/data/datastore/escape_manual_cache_store_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:penhas/app/core/storage/cache_storage.dart';
 import 'package:penhas/app/core/storage/object_store.dart';
+import 'package:penhas/app/core/types/json.dart';
 import 'package:penhas/app/features/escape_manual/data/datastore/escape_manual_cache_store.dart';
 import 'package:penhas/app/features/escape_manual/data/model/escape_manual_remote.dart';
 
@@ -11,7 +12,7 @@ import '../../../../../utils/json_util.dart';
 import '../model/escape_manual_fixtures.dart';
 
 void main() {
-  late IObjectStore<EscapeManualRemoteModel> sut;
+  late IObjectStore<JsonObject> sut;
 
   late ICacheStorage mockCacheStorage;
 
@@ -36,7 +37,11 @@ void main() {
             .thenAnswer((_) async => cached);
 
         // act
-        final actual = await sut.retrieve();
+        final actual = await sut.retrieve().then(
+              (value) => value != null
+                  ? EscapeManualRemoteModel.fromJson(value)
+                  : null,
+            );
 
         // assert
         expect(actual, equals(expected));
@@ -53,10 +58,10 @@ void main() {
             jsonEncode(updatedEscapeManualRemoteModelFixture);
 
         when(() => mockCacheStorage.putString(any(), any()))
-            .thenAnswer((_) async {});
+            .thenAnswer((_) => Future.value());
 
         // act
-        await sut.save(updatedEscapeManualRemoteModelFixture);
+        await sut.save(updatedEscapeManualRemoteModelFixture.asJsonObject);
 
         // assert
         final verificationResult = verify(

--- a/test/utils/json_util.dart
+++ b/test/utils/json_util.dart
@@ -1,6 +1,8 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:penhas/app/core/types/json.dart';
+
 class JsonUtil {
   static Future<Map<String, dynamic>> getJson({required String? from}) {
     return JsonUtil.getString(from: from).then(
@@ -14,4 +16,12 @@ class JsonUtil {
 
   static String getStringSync({required String from}) =>
       File('test/assets/json/$from').readAsStringSync();
+}
+
+extension JsonObjectExtension on Object {
+  /// Convert object to json object
+  /// it is useful to compare json objects in tests
+  /// jsonDecode and jsonEncode are used together to convert object to json object
+  /// including their nested objects
+  JsonObject get asJsonObject => jsonDecode(jsonEncode(this));
 }


### PR DESCRIPTION
Refatoração para otimizar do cache local do MF, demanda para possibilitar o suporte ao tipo de tarefa `button`:

## Problema

Sempre que um novo tipo de tarefa era incluído as versões anteriores do app acabava "quebrando" pois havia validação para não receber tipos "desconhecidos", emitindo assim uma exceção que só poderia ser resolvida com uma nova versão do app. Isso se dá pois os modelos representavam justamente o que se esperava da API até o momento, mas como tudo pode mudar - inclusive teremos um novo tipo - foi necessário melhorar a lógica para garantir uma retrocompatibilidade que não prejudique as usuárias que ainda não atualizaram o app e reduzir a quantidade de controles por versão do app no backend.

## Solução

Armazenar no cache local praticamente em forma bruta - ou seja, um `Map` - com exatamente os dados vindos do servidor, evitando que alguma informação seja perdida no processo de deserialização e serialização, removendo alguns passos do parser. E, ignorar os tipos de tarefas desconhecidos ao transportar esses dados entre as camadas.
Somente em tempo de desenvolvimento a validação do tipo permanece para garantir que o suporte a esses tipos sejam implementados.

