### PR TITLE
Melhorias no fluxo do MF

### DIFF
--- a/lib/app/features/escape_manual/presentation/escape_manual_page.dart
+++ b/lib/app/features/escape_manual/presentation/escape_manual_page.dart
@@ -141,7 +141,10 @@ class _LoadedStateWidget extends StatelessWidget {
               onPressed: () {
                 openAssistantPressed(assistant.action);
               },
-              child: Text(assistant.action.text),
+              child: Text(
+                assistant.action.text,
+                textAlign: TextAlign.center,
+              ),
               style: OutlinedButton.styleFrom(
                 primary: DesignSystemColors.darkIndigoThree,
                 backgroundColor: DesignSystemColors.white,

--- a/lib/app/features/escape_manual/presentation/escape_manual_page.dart
+++ b/lib/app/features/escape_manual/presentation/escape_manual_page.dart
@@ -189,13 +189,16 @@ class _SectionTasksWidget extends StatelessWidget {
       title: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
-          Text(
-            section.title,
-            textAlign: TextAlign.start,
-            style: Theme.of(context).textTheme.subtitle1?.copyWith(
-                  fontWeight: FontWeight.w700,
-                  color: DesignSystemColors.darkIndigoThree,
-                ),
+          Flexible(
+            child: Text(
+              section.title,
+              textAlign: TextAlign.start,
+              softWrap: true,
+              style: Theme.of(context).textTheme.subtitle1?.copyWith(
+                    fontWeight: FontWeight.w700,
+                    color: DesignSystemColors.darkIndigoThree,
+                  ),
+            ),
           ),
           Text(
             '$qtyDoneTasks/${section.tasks.length}',

--- a/lib/app/features/escape_manual/presentation/escape_manual_page.dart
+++ b/lib/app/features/escape_manual/presentation/escape_manual_page.dart
@@ -33,9 +33,15 @@ class EscapeManualPage extends StatefulWidget {
 
 class _EscapeManualPageState
     extends ModularState<EscapeManualPage, EscapeManualController>
-    with SnackBarHandler {
+    with SnackBarHandler, AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true;
+
   ReactionDisposer? _disposer;
-  final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
+
+  final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>(
+    debugLabel: 'escape-manual-scaffold-key',
+  );
 
   @override
   void didChangeDependencies() {
@@ -53,6 +59,7 @@ class _EscapeManualPageState
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     return Scaffold(
       key: _scaffoldKey,
       body: Observer(

--- a/lib/app/features/feed/presentation/feed_page.dart
+++ b/lib/app/features/feed/presentation/feed_page.dart
@@ -32,13 +32,19 @@ class FeedPage extends StatefulWidget {
 }
 
 class _FeedPageState extends ModularState<FeedPage, FeedController>
-    with SnackBarHandler {
+    with SnackBarHandler, AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true;
+
   List<ReactionDisposer>? _disposers;
 
   final _scrollController = ScrollController();
-  final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
-  final GlobalKey<RefreshIndicatorState> _refreshIndicatorKey =
-      GlobalKey<RefreshIndicatorState>();
+  final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>(
+    debugLabel: 'feed-scaffold-key',
+  );
+  final GlobalKey<RefreshIndicatorState> _refreshIndicatorKey = GlobalKey(
+    debugLabel: 'feed-refresh-indicator-key',
+  );
 
   PageProgressState _currentState = PageProgressState.initial;
 
@@ -71,6 +77,7 @@ class _FeedPageState extends ModularState<FeedPage, FeedController>
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     return Scaffold(
       key: _scaffoldKey,
       body: _bodyBuilder(),


### PR DESCRIPTION
- Evita o recarregamento do MF e do feed ao mudar de aba;
- Centraliza o texto do botão que dá acesso ao quiz do MF;
- Adiciona suporte à quebra de linha do texto no título das seções, evitando assim sobreposição quando o texto ocupa mais que uma linha.