### PR TITLE
Adiciona rotas para os tutoriais

### DIFF
--- a/lib/app/features/quiz/quiz_module.dart
+++ b/lib/app/features/quiz/quiz_module.dart
@@ -9,6 +9,7 @@ import '../../core/remoteconfig/i_remote_config.dart';
 import '../../shared/navigation/app_navigator.dart';
 import '../../shared/widgets/dialog_route.dart';
 import '../appstate/domain/usecases/app_state_usecase.dart';
+import '../help_center/presentation/pages/tutorial/guardian/guardian_tutorial_page.dart';
 import 'data/datasources/quiz_data_source.dart';
 import 'data/repositories/quiz_repository.dart';
 import 'domain/quiz_remote_config.dart';
@@ -18,6 +19,7 @@ import 'presentation/quiz/quiz_controller.dart';
 import 'presentation/quiz_bridge/quiz_bridge.dart';
 import 'presentation/quiz_start/quiz_start_controller.dart';
 import 'presentation/quiz_start/quiz_start_page.dart';
+import 'presentation/tutorial/stealth_mode_tutorial_page.dart';
 import 'presentation/tutorial/stealth_mode_tutorial_page_controller.dart';
 
 class QuizModule extends Module {
@@ -77,6 +79,14 @@ class QuizModule extends Module {
           '/start',
           child: (_, args) => const QuizStartPage(),
           routeGenerator: dialogRouteGenerator,
+        ),
+        ChildRoute(
+          '/tutorial/help-center',
+          child: (_, __) => const GuardianTutorialPage(),
+        ),
+        ChildRoute(
+          '/tutorial/stealth',
+          child: (_, __) => const StealthModeTutorialPage(),
         ),
       ];
 }

--- a/lib/app/shared/navigation/app_navigator.dart
+++ b/lib/app/shared/navigation/app_navigator.dart
@@ -6,12 +6,21 @@ import '../logger/log.dart';
 import 'app_route.dart';
 
 class AppNavigator {
+  const AppNavigator();
+
+  static AppNavigator? _instance;
+
+  static AppNavigator get instance => _instance ??= const AppNavigator();
+
   static void popAndPush(AppRoute route) {
     Modular.to.popAndPushNamed(route.path, arguments: route.args);
   }
 
+  Future<T?> navigateTo<T extends Object?>(AppRoute route) =>
+      Modular.to.pushNamed<T>(route.path, arguments: route.args);
+
   static void push(AppRoute route) {
-    Modular.to.pushNamed(route.path, arguments: route.args);
+    instance.navigateTo(route);
   }
 
   static void tryPopOrPushReplacement(AppRoute route) {

--- a/lib/app/shared/navigation/app_route.dart
+++ b/lib/app/shared/navigation/app_route.dart
@@ -1,32 +1,16 @@
-import 'dart:collection';
+import 'package:equatable/equatable.dart';
 
-class AppRoute {
+class AppRoute extends Equatable {
   AppRoute(String uri)
       : assert(uri.trim().isNotEmpty),
-        assert(uri.startsWith('/')) {
-    final List<String> pathAndArgs = uri.split('?');
-    path = pathAndArgs.first;
+        assert(uri.startsWith('/')),
+        uri = Uri.parse(uri);
 
-    if (pathAndArgs.length > 1) {
-      args = HashMap<String, String>();
-      pathAndArgs.last.split('&').forEach((arg) {
-        final List<String> kv = arg.split('=');
-        args![kv.first] = kv.last;
-      });
-    }
-  }
-
-  late String path;
-  Map<String, String>? args;
+  final Uri uri;
+  late final String path = uri.path;
+  late final Map<String, String>? args =
+      uri.queryParameters.isNotEmpty ? uri.queryParameters : null;
 
   @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is AppRoute &&
-          runtimeType == other.runtimeType &&
-          path == other.path &&
-          args == other.args;
-
-  @override
-  int get hashCode => path.hashCode ^ args.hashCode;
+  List<Object?> get props => [uri, path, args];
 }

--- a/test/app/features/quiz/quiz_module_test.dart
+++ b/test/app/features/quiz/quiz_module_test.dart
@@ -9,6 +9,7 @@ import 'package:penhas/app/core/network/network_info.dart';
 import 'package:penhas/app/core/remoteconfig/i_remote_config.dart';
 import 'package:penhas/app/features/appstate/domain/entities/app_state_entity.dart';
 import 'package:penhas/app/features/appstate/domain/usecases/app_state_usecase.dart';
+import 'package:penhas/app/features/help_center/presentation/pages/tutorial/guardian/guardian_tutorial_page.dart';
 import 'package:penhas/app/features/quiz/presentation/quiz_start/quiz_start_page.dart';
 import 'package:penhas/app/features/quiz/presentation/tutorial/stealth_mode_tutorial_page.dart';
 import 'package:penhas/app/features/quiz/quiz_module.dart';
@@ -40,18 +41,34 @@ void main() {
           (_) async => PermissionStatus.granted,
         );
 
+        // act
         await tester.pumpWidget(
           buildTestableApp(
-            home: StealthModeTutorialPage(),
+            initialRoute: '/tutorial/stealth',
             modules: [QuizModule()],
           ),
         );
-
-        // act
-        await tester.pump();
+        await tester.pumpAndSettle();
 
         // assert
         expect(find.byType(StealthModeTutorialPage), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'should start GuardianTutorialPage widget successfully',
+      (tester) async {
+        // act
+        await tester.pumpWidget(
+          buildTestableApp(
+            initialRoute: '/tutorial/help-center',
+            modules: [QuizModule()],
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // assert
+        expect(find.byType(GuardianTutorialPage), findsOneWidget);
       },
     );
 


### PR DESCRIPTION
- Inclusão das rotas `/tutorial/help-center` e `/tutorial/stealth`
- Adiciona método `navigateTo` no `AppNavigator`, que será utilizado em próximos PRs para navegar para essas telas;
- Melhoria na classe `AppRoute`, extendendo de `Equatable` para ajudar nos testes.