### PR TITLE
Define propriedades do Firebase

### DIFF
--- a/lib/app/app_module.dart
+++ b/lib/app/app_module.dart
@@ -3,6 +3,7 @@ import 'package:flutter_modular/flutter_modular.dart';
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'core/analytics/analytics_wrapper.dart';
 import 'core/managers/app_configuration.dart';
 import 'core/managers/app_preferences_store.dart';
 import 'core/managers/audio_sync_manager.dart';
@@ -49,6 +50,7 @@ class AppModule extends Module {
             userProfileStore: i(),
             appConfiguration: i(),
             appModulesServices: i(),
+            analytics: i(),
           ),
         ),
         Bind.factory<IAppStateRepository>(
@@ -147,7 +149,10 @@ class AppModule extends Module {
           (i) => BackgroundTaskManager.instance,
         ),
         Bind.factory<AppNavigator>(
-          (i) => AppNavigator(),
+          (i) => const AppNavigator(),
+        ),
+        Bind.lazySingleton<AnalyticsWrapper>(
+          (i) => AnalyticsWrapper(),
         ),
       ];
 

--- a/lib/app/core/analytics/analytics_wrapper.dart
+++ b/lib/app/core/analytics/analytics_wrapper.dart
@@ -1,0 +1,19 @@
+import 'dart:async';
+
+import 'package:firebase_analytics/firebase_analytics.dart';
+
+class AnalyticsWrapper {
+  AnalyticsWrapper([FirebaseAnalytics? analytics])
+      : _analytics = analytics ?? FirebaseAnalytics.instance;
+
+  final FirebaseAnalytics _analytics;
+
+  FutureOr<void> setProperties(Map<String, dynamic> properties) async {
+    for (var element in properties.entries) {
+      await _analytics.setUserProperty(
+        name: element.key,
+        value: element.value?.toString(),
+      );
+    }
+  }
+}

--- a/lib/app/features/appstate/data/model/app_state_model.dart
+++ b/lib/app/features/appstate/data/model/app_state_model.dart
@@ -12,12 +12,14 @@ class AppStateModel extends AppStateEntity {
     QuizSessionEntity? quizSession,
     UserProfileEntity? userProfile,
     AppStateModeEntity appMode,
-    List<AppStateModuleEntity> modules,
-  ) : super(
+    List<AppStateModuleEntity> modules, [
+    Map<String, dynamic> analyticsProps = const {},
+  ]) : super(
           quizSession: quizSession,
           userProfile: userProfile,
           appMode: appMode,
           modules: modules,
+          analyticsProps: analyticsProps,
         );
 
   factory AppStateModel.fromJson(Map<String, dynamic> jsonData) {
@@ -31,7 +33,13 @@ class AppStateModel extends AppStateEntity {
     final List<AppStateModuleEntity> modules = jsonData.containsKey('modules')
         ? _parseAppModules(jsonData['modules'] as List<dynamic>)
         : [];
-    return AppStateModel(quizSession, userProfile, appMode, modules);
+    return AppStateModel(
+      quizSession,
+      userProfile,
+      appMode,
+      modules,
+      jsonData['analytics_props'] ?? {},
+    );
   }
 
   static QuizSessionEntity? _parseQuizSession(Map<String, dynamic>? session) {

--- a/lib/app/features/appstate/domain/entities/app_state_entity.dart
+++ b/lib/app/features/appstate/domain/entities/app_state_entity.dart
@@ -50,12 +50,14 @@ class AppStateEntity extends Equatable {
     required this.userProfile,
     required this.appMode,
     required this.modules,
+    this.analyticsProps = const {},
   });
 
   final QuizSessionEntity? quizSession;
   final UserProfileEntity? userProfile;
   final AppStateModeEntity appMode;
   final List<AppStateModuleEntity> modules;
+  final Map<String, dynamic> analyticsProps;
 
   @override
   List<Object?> get props => [
@@ -63,6 +65,7 @@ class AppStateEntity extends Equatable {
         userProfile,
         appMode,
         modules,
+        analyticsProps,
       ];
 
   @override

--- a/lib/app/features/appstate/domain/usecases/app_state_usecase.dart
+++ b/lib/app/features/appstate/domain/usecases/app_state_usecase.dart
@@ -1,5 +1,6 @@
 import 'package:dartz/dartz.dart';
 
+import '../../../../core/analytics/analytics_wrapper.dart';
 import '../../../../core/error/failures.dart';
 import '../../../../core/managers/app_configuration.dart';
 import '../../../../core/managers/local_store.dart';
@@ -15,15 +16,18 @@ class AppStateUseCase {
     required LocalStore<UserProfileEntity> userProfileStore,
     required IAppConfiguration appConfiguration,
     required IAppModulesServices appModulesServices,
+    required AnalyticsWrapper analytics,
   })  : _appStateRepository = appStateRepository,
         _appConfiguration = appConfiguration,
         _userProfileStore = userProfileStore,
-        _appModulesServices = appModulesServices;
+        _appModulesServices = appModulesServices,
+        _analytics = analytics;
 
   final IAppStateRepository _appStateRepository;
   final LocalStore<UserProfileEntity> _userProfileStore;
   final IAppConfiguration _appConfiguration;
   final IAppModulesServices _appModulesServices;
+  final AnalyticsWrapper _analytics;
 
   Future<Either<Failure, AppStateEntity>> check() async {
     final currentState = await _appStateRepository.check();
@@ -51,6 +55,7 @@ class AppStateUseCase {
     if (userProfile != null) {
       await _userProfileStore.save(userProfile);
     }
+    _analytics.setProperties(appStateEntity.analyticsProps);
     await _appConfiguration.saveAppModes(appStateEntity.appMode);
     await _appModulesServices.save(appStateEntity.modules);
     return right(appStateEntity);

--- a/lib/app/features/mainboard/presentation/mainboard/mainboard_module.dart
+++ b/lib/app/features/mainboard/presentation/mainboard/mainboard_module.dart
@@ -465,6 +465,7 @@ class MainboardModule extends Module {
             userProfileStore: i.get<LocalStore<UserProfileEntity>>(),
             appConfiguration: i.get<IAppConfiguration>(),
             appModulesServices: i.get<IAppModulesServices>(),
+            analytics: i.get(),
           ),
         ),
         Bind.factory<InactivityLogoutUseCase>(

--- a/test/app/core/analytics/analytics_wrapper_test.dart
+++ b/test/app/core/analytics/analytics_wrapper_test.dart
@@ -1,0 +1,45 @@
+import 'package:firebase_analytics/firebase_analytics.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:penhas/app/core/analytics/analytics_wrapper.dart';
+
+void main() {
+  group(AnalyticsWrapper, () {
+    late AnalyticsWrapper sut;
+
+    late FirebaseAnalytics analytics;
+
+    setUp(() {
+      analytics = _MockFirebaseAnalytics();
+      sut = AnalyticsWrapper(analytics);
+    });
+
+    test(
+      'setProperties should call setUserProperty for each property',
+      () async {
+        // arrange
+        final properties = <String, dynamic>{
+          'key1': 'value1',
+          'key2': 'value2',
+        };
+        when(
+          () => analytics.setUserProperty(
+            name: any(named: 'name'),
+            value: any(named: 'value'),
+          ),
+        ).thenAnswer((_) async => true);
+
+        // act
+        await sut.setProperties(properties);
+
+        // assert
+        verify(() => analytics.setUserProperty(name: 'key1', value: 'value1'))
+            .called(1);
+        verify(() => analytics.setUserProperty(name: 'key2', value: 'value2'))
+            .called(1);
+      },
+    );
+  });
+}
+
+class _MockFirebaseAnalytics extends Mock implements FirebaseAnalytics {}

--- a/test/app/features/appstate/data/models/app_state_model_test.dart
+++ b/test/app/features/appstate/data/models/app_state_model_test.dart
@@ -186,6 +186,9 @@ void main() {
         userProfile,
         appMode,
         modules,
+        {
+          'is_admin': true,
+        },
       );
       // act
       final result = AppStateModel.fromJson(jsonData);

--- a/test/app/features/appstate/domain/usecases/app_state_usecase_test.dart
+++ b/test/app/features/appstate/domain/usecases/app_state_usecase_test.dart
@@ -1,6 +1,7 @@
 import 'package:dartz/dartz.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:penhas/app/core/analytics/analytics_wrapper.dart';
 import 'package:penhas/app/core/error/failures.dart';
 import 'package:penhas/app/core/managers/app_configuration.dart';
 import 'package:penhas/app/core/managers/local_store.dart';
@@ -19,19 +20,23 @@ void main() {
   late IAppModulesServices appModulesServices;
   late IAppStateRepository appStateRepository;
   late LocalStore<UserProfileEntity> profileStore;
+  late AnalyticsWrapper analytics;
+
   late AppStateUseCase sut;
 
   setUp(() {
-    appStateRepository = MockAppStateRepository();
-    appConfiguration = MockAppConfiguration();
-    profileStore = MockUserProfileStore();
-    appModulesServices = MockAppModulesServices();
+    appStateRepository = _MockAppStateRepository();
+    appConfiguration = _MockAppConfiguration();
+    profileStore = _MockUserProfileStore();
+    appModulesServices = _MockAppModulesServices();
+    analytics = _MockAnalyticsWrapper();
 
     sut = AppStateUseCase(
       userProfileStore: profileStore,
       appConfiguration: appConfiguration,
       appStateRepository: appStateRepository,
       appModulesServices: appModulesServices,
+      analytics: analytics,
     );
   });
 
@@ -61,6 +66,8 @@ void main() {
         verify(() => profileStore.save(expectedModel.userProfile!)).called(1);
         verify(() => appModulesServices.save(expectedModel.modules)).called(1);
         verify(() => appConfiguration.saveAppModes(expectedModel.appMode))
+            .called(1);
+        verify(() => analytics.setProperties(expectedModel.analyticsProps))
             .called(1);
       });
       test('return ServerSideSessionFailed for a invalid session', () async {
@@ -103,6 +110,8 @@ void main() {
         verify(() => appModulesServices.save(expectedModel.modules)).called(1);
         verify(() => appConfiguration.saveAppModes(expectedModel.appMode))
             .called(1);
+        verify(() => analytics.setProperties(expectedModel.analyticsProps))
+            .called(1);
       });
       test('return ServerSideSessionFailed for a invalid session', () async {
         // arrange
@@ -121,11 +130,13 @@ void main() {
   });
 }
 
-class MockAppStateRepository extends Mock implements IAppStateRepository {}
+class _MockAppStateRepository extends Mock implements IAppStateRepository {}
 
-class MockAppConfiguration extends Mock implements IAppConfiguration {}
+class _MockAppConfiguration extends Mock implements IAppConfiguration {}
 
-class MockUserProfileStore extends Mock
+class _MockUserProfileStore extends Mock
     implements LocalStore<UserProfileEntity> {}
 
-class MockAppModulesServices extends Mock implements IAppModulesServices {}
+class _MockAppModulesServices extends Mock implements IAppModulesServices {}
+
+class _MockAnalyticsWrapper extends Mock implements AnalyticsWrapper {}

--- a/test/assets/json/profile/about_with_quiz_session.json
+++ b/test/assets/json/profile/about_with_quiz_session.json
@@ -55,5 +55,8 @@
     "raca": "pardo",
     "apelido": "maria",
     "avatar_url": "https:\/\/api.com\/avatar\/padrao.svg"
+  },
+  "analytics_props": {
+    "is_admin": true
   }
 }


### PR DESCRIPTION
Como utilizamos o serviço de remote config do Firebase, para poder definir configurações diferentes para determinados grupos de usuárias é necessário definir propriedades utilizando o `FirebaseAnalytics`.

A proposta é utilizar as propriedades em `analytics_props` contendo informações que não identifique a pessoa em si, mas sim um possível grupo de testes ela estará.

Mais infos: https://firebase.google.com/docs/remote-config/config-analytics