### PR TITLE
Bump mocktail_image_network

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -995,12 +995,10 @@ packages:
   mocktail_image_network:
     dependency: "direct dev"
     description:
-      path: "packages/mocktail_image_network"
-      ref: HEAD
-      resolved-ref: "2fd21e9e7b4447907eb34428fbb8133c5976a90c"
-      url: "https://github.com/pedrox-hs/mocktail.git"
-    source: git
-    version: "1.1.0"
+      name: mocktail_image_network
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.2.0"
   nested:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -98,7 +98,7 @@ dev_dependencies:
   lint: ^1.8.1
   mobx_codegen: ^2.0.4
   mocktail: ^1.0.0
-  mocktail_image_network: ^1.1.0
+  mocktail_image_network: ^1.2.0
   plugin_platform_interface: ^2.0.0
 
 dependency_overrides:
@@ -128,10 +128,6 @@ dependency_overrides:
     git:
       url: https://github.com/pedrox-hs/flutter_tags.git
       ref: null-safety
-  mocktail_image_network:
-    git:
-      url: https://github.com/pedrox-hs/mocktail.git
-      path: packages/mocktail_image_network
   smooth_star_rating:
     git:
       url: https://github.com/bhavin-concetto/smoothratingbar.git


### PR DESCRIPTION
Atualizando a dependencia `mocktail_image_network`, que havia sido utilizado um fork em vez da versão oficial devido a problemas no carregamento de SVG (https://github.com/institutoazmina/penhas-app/pull/180#discussion_r1510106986)