### PR TITLE
Atualiza usos do SnackBar obsoleto

### DIFF
--- a/lib/app/features/authentication/presentation/shared/snack_bar_handler.dart
+++ b/lib/app/features/authentication/presentation/shared/snack_bar_handler.dart
@@ -6,17 +6,29 @@ mixin SnackBarHandler {
   void showSnackBar({
     required GlobalKey<ScaffoldState> scaffoldKey,
     required String? message,
-    Duration? duration,
+    Duration duration = _defaultSnackBarDuration,
   }) {
-    if (message == null || message.isEmpty) {
-      return;
-    }
+    assert(message != null && message.isNotEmpty);
+    if (message == null || message.isEmpty) return;
 
-    scaffoldKey.currentState?.showSnackBar(
+    scaffoldKey.messenger?.showSnackBar(
       SnackBar(
         content: Text(message),
-        duration: duration ?? _defaultSnackBarDuration,
+        duration: duration,
       ),
     );
+  }
+}
+
+extension ScaffoldX on GlobalKey<ScaffoldState> {
+  ScaffoldMessengerState? get messenger {
+    final context = currentContext;
+    assert(context != null);
+    if (context == null) return null;
+    return ScaffoldMessenger.of(context);
+  }
+
+  void hideCurrentSnackBar() {
+    messenger?.hideCurrentSnackBar();
   }
 }

--- a/lib/app/features/authentication/presentation/shared/snack_bar_handler.dart
+++ b/lib/app/features/authentication/presentation/shared/snack_bar_handler.dart
@@ -8,7 +8,6 @@ mixin SnackBarHandler {
     required String? message,
     Duration duration = _defaultSnackBarDuration,
   }) {
-    assert(message != null && message.isNotEmpty);
     if (message == null || message.isEmpty) return;
 
     scaffoldKey.messenger?.showSnackBar(

--- a/lib/app/features/support_center/presentation/support_center_page.dart
+++ b/lib/app/features/support_center/presentation/support_center_page.dart
@@ -194,7 +194,7 @@ extension _SupportCenterPageStateBuilder on _SupportCenterPageState {
   }
 
   void _dismissSnackBarForAction(Function action, {dynamic argument}) {
-    _scaffoldKey.currentState?.hideCurrentSnackBar();
+    _scaffoldKey.hideCurrentSnackBar();
 
     if (argument == null) {
       // ignore: avoid_dynamic_calls


### PR DESCRIPTION
Os métodos `showSnackBar` e `hideCurrentSnackBar` estão obsoletos, esse PR atualiza o uso para o que que é recomendável. 