### PR TITLE
Adiciona definições padrões para botões ao tema do app

### DIFF
--- a/lib/app/shared/design_system/buttons/styles.dart
+++ b/lib/app/shared/design_system/buttons/styles.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/material.dart';
+
+import '../colors.dart';
+
+part 'styles/filled_button.dart';
+part 'styles/outlined_button.dart';
+part 'styles/text_button.dart';

--- a/lib/app/shared/design_system/buttons/styles/filled_button.dart
+++ b/lib/app/shared/design_system/buttons/styles/filled_button.dart
@@ -1,0 +1,34 @@
+part of '../styles.dart';
+
+typedef FilledButton = ElevatedButton;
+
+class FilledButtonStyle extends ButtonStyle {
+  const FilledButtonStyle._();
+
+  static ButtonStyle raised({
+    Color color = DesignSystemColors.ligthPurple,
+    Color? disabledColor = DesignSystemColors.disabledColor,
+    Color textColor = Colors.white,
+    double? elevation = 0.0,
+    Size? minimumSize = const Size(88.0, 36.0),
+    EdgeInsetsGeometry? padding = const EdgeInsets.symmetric(horizontal: 16.0),
+    OutlinedBorder? shape = const RoundedRectangleBorder(
+      borderRadius: BorderRadius.all(Radius.circular(2)),
+    ),
+  }) =>
+      ButtonStyle(
+        foregroundColor: MaterialStateProperty.all<Color>(textColor),
+        backgroundColor: MaterialStateProperty.resolveWith(
+          (states) =>
+              states.contains(MaterialState.disabled) ? disabledColor : color,
+        ),
+        elevation: ButtonStyleButton.allOrNull(elevation),
+        padding: ButtonStyleButton.allOrNull(padding),
+        minimumSize: ButtonStyleButton.allOrNull(minimumSize),
+        shape: ButtonStyleButton.allOrNull(shape),
+      );
+
+  static ElevatedButtonThemeData theme() => ElevatedButtonThemeData(
+        style: ElevatedButton.styleFrom(),
+      );
+}

--- a/lib/app/shared/design_system/buttons/styles/outlined_button.dart
+++ b/lib/app/shared/design_system/buttons/styles/outlined_button.dart
@@ -1,0 +1,24 @@
+part of '../styles.dart';
+
+class OutlinedButtonStyle extends ButtonStyle {
+  const OutlinedButtonStyle._();
+
+  static ButtonStyle outline({
+    Color color = DesignSystemColors.ligthPurple,
+    EdgeInsetsGeometry padding = const EdgeInsets.symmetric(horizontal: 16.0),
+    Size minimumSize = const Size(88.0, 36.0),
+    OutlinedBorder? shape,
+    BorderSide? side,
+  }) =>
+      OutlinedButton.styleFrom(
+        primary: color,
+        padding: padding,
+        minimumSize: minimumSize,
+        shape: shape,
+        side: side ?? shape?.side,
+      );
+
+  static OutlinedButtonThemeData theme() => OutlinedButtonThemeData(
+        style: OutlinedButton.styleFrom(),
+      );
+}

--- a/lib/app/shared/design_system/buttons/styles/text_button.dart
+++ b/lib/app/shared/design_system/buttons/styles/text_button.dart
@@ -1,0 +1,24 @@
+part of '../styles.dart';
+
+class TextButtonStyle extends ButtonStyle {
+  const TextButtonStyle._();
+
+  static ButtonStyle flat({
+    Color? color = Colors.black87,
+    EdgeInsetsGeometry? padding = const EdgeInsets.symmetric(horizontal: 16.0),
+    Size? minimumSize = const Size(88.0, 36.0),
+    OutlinedBorder? shape = const RoundedRectangleBorder(
+      borderRadius: BorderRadius.all(Radius.circular(2)),
+    ),
+  }) =>
+      TextButton.styleFrom(
+        primary: color,
+        padding: padding,
+        minimumSize: minimumSize,
+        shape: shape,
+      );
+
+  static TextButtonThemeData theme() => TextButtonThemeData(
+        style: TextButton.styleFrom(),
+      );
+}

--- a/lib/app/shared/design_system/colors.dart
+++ b/lib/app/shared/design_system/colors.dart
@@ -28,6 +28,7 @@ class DesignSystemColors {
   static const splashColor = Color.fromARGB(16, 0, 0, 0);
   static const shadowColor = Color.fromARGB(25, 0, 0, 0);
   static const dialogBarrierColor = Colors.black54;
+  static const disabledColor = Colors.black38;
 
   static Color hexColor(String value) {
     String hexColor = value.toUpperCase().replaceAll('#', '');

--- a/lib/app/shared/design_system/theme.dart
+++ b/lib/app/shared/design_system/theme.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'buttons/styles.dart';
+
 abstract class AppTheme {
   static ThemeData of(BuildContext context) {
     final base = Theme.of(context);
@@ -8,6 +10,9 @@ abstract class AppTheme {
       bottomSheetTheme: base.bottomSheetTheme.copyWith(
         backgroundColor: Colors.transparent,
       ),
+      textButtonTheme: TextButtonStyle.theme(),
+      elevatedButtonTheme: FilledButtonStyle.theme(),
+      outlinedButtonTheme: OutlinedButtonStyle.theme(),
     );
   }
 }

--- a/test/utils/widget_test_steps.dart
+++ b/test/utils/widget_test_steps.dart
@@ -20,12 +20,14 @@ Future<void> iSeeButton({
     final targetText = find.text(text);
     expect(targetText, findsOneWidget);
 
-    final targetRaisedButton = find.ancestor(
+    final targetButton = find.ancestor(
       of: targetText,
-      matching: find.byType(RaisedButton),
+      matching: find.byWidgetPredicate(
+        (widget) => widget is ButtonStyleButton || widget is MaterialButton,
+      ),
     );
 
-    expect(targetRaisedButton, findsOneWidget);
+    expect(targetButton, findsOneWidget);
 
     return;
   }


### PR DESCRIPTION
Os botões utilizados nessa versão do Flutter estão obsoletos, por isso foi incluso ao tema as definições padrões e estilos para deixar os novos botões com a aparência próxima ao do atual, seguindo o guia [New Buttons and Button Themes](https://docs.flutter.dev/release/breaking-changes/buttons).

Além disso, o PR inclui:
- atualização do helper de testes `iSeeButton`;

Em próximos PRs farei a atualização das utilizações dos botões.