### PR TITLE
 Remoção de Operador Null-Safety Desnecessário guardians_page

### DIFF
--- a/lib/app/features/help_center/presentation/guardians/guardians_page.dart
+++ b/lib/app/features/help_center/presentation/guardians/guardians_page.dart
@@ -37,7 +37,7 @@ class _GuardiansPageState
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance?.addPostFrameCallback((timeStamp) {
+    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
       controller.loadPage();
     });
   }


### PR DESCRIPTION
# [GuardiansPage] Remoção de Operador Null-Safety Desnecessário  

## Descrição  
Este Pull Request ajusta o método `initState` na classe `_GuardiansPageState` para remover o uso desnecessário do operador de null-safety (`?.`) em `WidgetsBinding.instance`.  

### Motivação  
O operador `?.` não é necessário, pois `WidgetsBinding.instance` nunca será nulo. Essa alteração melhora a clareza e a consistência do código.  

## Alterações Realizadas  
### Código Alterado  
Antes:  
```dart
WidgetsBinding.instance?.addPostFrameCallback((timeStamp) {
  controller.loadPage();
});
```
```dart
WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
  controller.loadPage();
});
```

## Testes Realizados
* Verificação Manual: Confirmado que a página GuardiansPage carrega corretamente após a mudança.
* Testes de Regressão: Verificado que nenhuma funcionalidade relacionada ao carregamento da página foi impactada.