### PR TITLE
Substituir flatButton por PenhasButton remover operador null-safety desnecessário help_center_page

### DIFF
--- a/lib/app/features/help_center/presentation/help_center_page.dart
+++ b/lib/app/features/help_center/presentation/help_center_page.dart
@@ -8,6 +8,7 @@ import 'package:mobx/mobx.dart';
 import '../../../core/extension/asuka.dart';
 import '../../../shared/design_system/colors.dart';
 import '../../../shared/design_system/text_styles.dart';
+import '../../../shared/design_system/widgets/buttons/penhas_button.dart';
 import '../../authentication/presentation/shared/page_progress_indicator.dart';
 import '../../authentication/presentation/shared/snack_bar_handler.dart';
 import '../domain/states/guardian_alert_state.dart';
@@ -38,7 +39,7 @@ class _HelpCenterPageState
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance?.addPostFrameCallback((timeStamp) {
+    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
       controller.checkLocalicationRequired();
     });
   }
@@ -240,7 +241,7 @@ class _HelpCenterPageState
             borderRadius: BorderRadius.circular(10.0),
           ),
           actions: <Widget>[
-            FlatButton(
+            PenhasButton.text(
               child: const Text('Fechar'),
               onPressed: () async {
                 Navigator.of(context).pop();


### PR DESCRIPTION
# [HelpCenterPage] Ajustes de Código e Atualização de Botões

## Descrição  
Este Pull Request faz ajustes na página `HelpCenterPage` para melhorar a clareza do código e atualizar o botão de fechamento, substituindo o `FlatButton` por um botão personalizado `PenhasButton.text`.  

### Motivação  
- **Remoção de operador null-safety desnecessário:** O operador `?.` foi removido de `WidgetsBinding.instance` no método `initState`, pois não é necessário, já que `WidgetsBinding.instance` nunca será nulo.
- **Substituição de `FlatButton` por `PenhasButton.text`:** Atualização para utilizar o botão de estilo definido na base de código, garantindo consistência no design do aplicativo.

## Alterações Realizadas  
### Código Alterado  
Antes:
```dart
WidgetsBinding.instance?.addPostFrameCallback((timeStamp) {
  controller.checkLocalicationRequired();
});
```
depois

```dart
WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
  controller.checkLocalicationRequired();
});
```
Além disso, o botão foi alterado de:

```dart
FlatButton(
  child: const Text('Fechar'),
  onPressed: () async {
    Navigator.of(context).pop();
  },
)
```
para

```dart
PenhasButton.text(
  child: const Text('Fechar'),
  onPressed: () async {
    Navigator.of(context).pop();
  },
)
```