### PR TITLE
Remover operador null audio_record_page

### DIFF
--- a/lib/app/features/help_center/presentation/pages/audio/audio_record_page.dart
+++ b/lib/app/features/help_center/presentation/pages/audio/audio_record_page.dart
@@ -26,7 +26,7 @@ class _AudioRecordState
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance?.addPostFrameCallback((timeStamp) async {
+    WidgetsBinding.instance.addPostFrameCallback((timeStamp) async {
       await controller.startAudioRecord();
     });
 


### PR DESCRIPTION
# Pull Request: Remoção de Operador Condicional Redundante no `AudioRecordPage`

## Resumo

Este pull request simplifica o código na página `AudioRecordPage` ao remover o operador condicional (`?.`) desnecessário na chamada de `WidgetsBinding.instance`. Essa alteração garante compatibilidade com as versões mais recentes do Flutter e melhora a legibilidade do código.

---

## Alterações Realizadas

1. **Remoção do Operador Condicional**:
   - Atualizado o método `addPostFrameCallback` para remover o uso do operador `?.` em `WidgetsBinding.instance`.

---

## Diferenças no Código

```diff
diff --git a/lib/app/features/help_center/presentation/pages/audio/audio_record_page.dart b/lib/app/features/help_center/presentation/pages/audio/audio_record_page.dart
index dcd2b59d..d5519d60 100644
--- a/lib/app/features/help_center/presentation/pages/audio/audio_record_page.dart
+++ b/lib/app/features/help_center/presentation/pages/audio/audio_record_page.dart
@@ -26,7 +26,7 @@ class _AudioRecordState
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance?.addPostFrameCallback((timeStamp) async {
+    WidgetsBinding.instance.addPostFrameCallback((timeStamp) async {
       await controller.startAudioRecord();
     });
 
