### PR TITLE
Remoção de Operador de Acesso Condicional em WidgetsBinding.instance mainboard_page

### DIFF
--- a/lib/app/features/mainboard/presentation/mainboard/mainboard_page.dart
+++ b/lib/app/features/mainboard/presentation/mainboard/mainboard_page.dart
@@ -28,7 +28,7 @@ class MainboardPageState
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance?.addObserver(this);
+    WidgetsBinding.instance.addObserver(this);
   }
 
   @override


### PR DESCRIPTION
### Sugestão de Pull Request: Remoção de Operador de Acesso Condicional em WidgetsBinding.instance

#### Descrição
Essa alteração remove o uso obsoleto do operador de acesso condicional (`?.`) ao adicionar um observador a `WidgetsBinding.instance` no método `initState` da classe `MainboardPageState`.

---

#### Alterações Realizadas

- Atualização no método `initState` da seguinte forma:
```dart
  - WidgetsBinding.instance?.addObserver(this);
  + WidgetsBinding.instance.addObserver(this);
```
### Motivação
Simplificação de Código:

1- Em versões recentes do Flutter, WidgetsBinding.instance não retorna null. O uso do operador de acesso condicional (?.) é desnecessário e pode confundir os desenvolvedores.
Melhoria na Leitura:

2- A remoção do operador torna o código mais limpo e legível, alinhando-se às práticas modernas.
Compatibilidade com as Novas Versões:

3- Essa modificação atende aos requisitos das versões mais recentes do Flutter, que não possuem cenários onde WidgetsBinding.instance seja nulo.
