### PR TITLE
Substitui validação de CPF com `cpfcnpj` por implementação própria e remove dependência

### DIFF
--- a/lib/app/features/authentication/domain/usecases/cpf.dart
+++ b/lib/app/features/authentication/domain/usecases/cpf.dart
@@ -62,8 +62,6 @@ class Cpf extends Equatable with MapValidatorFailure {
     // Testar o segundo dígito verificador
     if (digitos[10] != dv2) return left(CpfInvalidFailure());
 
-    // final cleared = input.replaceAll('.', '').replaceAll('-', '');
-
     return right(numeros);
   }
 

--- a/lib/app/features/authentication/domain/usecases/cpf.dart
+++ b/lib/app/features/authentication/domain/usecases/cpf.dart
@@ -1,4 +1,3 @@
-import 'package:cpfcnpj/cpfcnpj.dart';
 import 'package:dartz/dartz.dart';
 import 'package:equatable/equatable.dart';
 import 'package:meta/meta.dart';
@@ -26,13 +25,46 @@ class Cpf extends Equatable with MapValidatorFailure {
   bool get stringify => true;
 
   static Either<Failure, String> _validate(String input) {
-    if (!CPF.isValid(input)) {
+    // Limpa o conteúdo para obter apenas o número
+    var numeros = input.replaceAll(RegExp(r'[^\d]'), '');
+    if (numeros.isEmpty || numeros.length != 11) {
       return left(CpfInvalidFailure());
     }
 
-    final cleared = input.replaceAll('.', '').replaceAll('-', '');
+    // Testar se todos os dígitos do CPF são iguais
+    if (RegExp(r'^(\d)\1*$').hasMatch(numeros)) {
+      return left(CpfInvalidFailure());
+    }
 
-    return right(cleared);
+    // Dividir dígitos
+    List<int> digitos =
+        numeros.split('').map((String d) => int.parse(d)).toList();
+
+    // Calcular o primeiro dígito verificador
+    var calcDv1 = 0;
+    for (var i in Iterable<int>.generate(9, (i) => 10 - i)) {
+      calcDv1 += digitos[10 - i] * i;
+    }
+    calcDv1 %= 11;
+    var dv1 = calcDv1 < 2 ? 0 : 11 - calcDv1;
+
+    // Testar o primeiro dígito verificado
+    if (digitos[9] != dv1) return left(CpfInvalidFailure());
+
+    // Calcular o segundo dígito verificador
+    var calcDv2 = 0;
+    for (var i in Iterable<int>.generate(10, (i) => 11 - i)) {
+      calcDv2 += digitos[11 - i] * i;
+    }
+    calcDv2 %= 11;
+    var dv2 = calcDv2 < 2 ? 0 : 11 - calcDv2;
+
+    // Testar o segundo dígito verificador
+    if (digitos[10] != dv2) return left(CpfInvalidFailure());
+
+    // final cleared = input.replaceAll('.', '').replaceAll('-', '');
+
+    return right(numeros);
   }
 
   @override

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -239,15 +239,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.3"
-  cpfcnpj:
-    dependency: "direct main"
-    description:
-      path: "."
-      ref: "6258774d3de58ee9122f2b6047ebb0c5b833df19"
-      resolved-ref: "6258774d3de58ee9122f2b6047ebb0c5b833df19"
-      url: "https://github.com/erickhaendel/dart-cpfcnpj.git"
-    source: git
-    version: "1.0.3"
   crypt:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,7 +25,6 @@ dependencies:
   asuka: ^2.0.1+3
   badges: ^2.0.2
   collection: ^1.15.0
-  cpfcnpj: ^1.0.3
   crypt: ^4.3.1
   crypto: ^3.0.1
   cupertino_icons: ^1.0.4
@@ -102,10 +101,6 @@ dev_dependencies:
   plugin_platform_interface: ^2.0.0
 
 dependency_overrides:
-  cpfcnpj:
-    git:
-      url: https://github.com/erickhaendel/dart-cpfcnpj.git
-      ref: "6258774d3de58ee9122f2b6047ebb0c5b833df19"
   data_connection_checker:
     git:
       url: https://github.com/uSlashVlad/data_connection_checker.git

--- a/test/app/features/authentication/domain/usecases/cpf_test.dart
+++ b/test/app/features/authentication/domain/usecases/cpf_test.dart
@@ -18,6 +18,19 @@ void main() {
         expect(cpf.mapFailure, '');
       });
       test(
+        'returns invalid Cpf when constructed with invalid value',
+        () {
+          // arrange
+          const cpfString = '52A.A82.247-25';
+          // act
+          final cpf = Cpf(cpfString);
+          // assert
+          expect(cpf.isValid, false);
+          expect(cpf.mapFailure, 'CPF inválido');
+          expect(cpf.value, left(CpfInvalidFailure()));
+        },
+      );
+      test(
         'returns invalid Cpf when constructed with empty value',
         () {
           // arrange

--- a/test/app/features/authentication/domain/usecases/cpf_test.dart
+++ b/test/app/features/authentication/domain/usecases/cpf_test.dart
@@ -18,7 +18,7 @@ void main() {
         expect(cpf.mapFailure, '');
       });
       test(
-        'returns invalid Cpf when constructed with invalid value',
+        'returns an invalid Cpf when initialized with a non-numeric string value',
         () {
           // arrange
           const cpfString = '52A.A82.247-25';
@@ -30,6 +30,21 @@ void main() {
           expect(cpf.value, left(CpfInvalidFailure()));
         },
       );
+
+      test(
+        'returns invalid Cpf when constructed with value containing all the same numbers',
+        () {
+          // arrange
+          const cpfString = '111.111.111-11';
+          // act
+          final cpf = Cpf(cpfString);
+          // assert
+          expect(cpf.isValid, false);
+          expect(cpf.mapFailure, 'CPF inválido');
+          expect(cpf.value, left(CpfInvalidFailure()));
+        },
+      );
+
       test(
         'returns invalid Cpf when constructed with empty value',
         () {


### PR DESCRIPTION
## Descrição:
Esta PR introduz as seguintes mudanças principais:

1. **Remoção da dependência `cpfcnpj`:**  
   - A biblioteca `cpfcnpj` foi removida do projeto (`pubspec.yaml`, `pubspec.lock`) para reduzir dependências externas e aumentar o controle sobre a lógica de validação de CPF.

2. **Implementação própria da validação de CPF:**  
   - Substituição do método de validação baseado na biblioteca `cpfcnpj` por uma nova lógica implementada diretamente no arquivo `cpf.dart`.

3. **Cobertura de testes aprimorada:**  
   - Foram adicionados novos casos de teste no arquivo `cpf_test.dart` para validar:
     - CPFs com caracteres não numéricos.
     - CPFs contendo todos os dígitos iguais.
     - Casos de CPFs vazios ou inválidos, além dos casos já existentes.

## Impacto esperado:
- Redução de dependências externas.
- Maior controle sobre a lógica de validação, permitindo personalizações futuras.
- Garantia de robustez com os novos testes adicionados.

## Teste:
- Todos os testes existentes foram executados com sucesso.
- Novos testes cobrem casos adicionais para validar a funcionalidade implementada.