### PR TITLE
Corrigir erro de digitação 'passord' para 'password'

### DIFF
--- a/lib/app/features/authentication/presentation/reset_password/pages/reset_password_three/reset_password_three_page.dart
+++ b/lib/app/features/authentication/presentation/reset_password/pages/reset_password_three/reset_password_three_page.dart
@@ -126,7 +126,7 @@ class _ResetPasswordThreePageState
   }
 
   Widget _buildPasswordField() {
-    return PassordInputField(
+    return PasswordInputField(
       labelText: 'Senha',
       hintText: 'Digite sua nova senha',
       errorText: controller.warningPassword,
@@ -134,8 +134,8 @@ class _ResetPasswordThreePageState
     );
   }
 
-  PassordInputField _buildConfirmationPasswordField() {
-    return PassordInputField(
+  PasswordInputField _buildConfirmationPasswordField() {
+    return PasswordInputField(
       labelText: 'Confirmação de senha',
       hintText: 'Digite sua senha novamente',
       errorText: controller.warningConfirmationPassword,

--- a/lib/app/features/authentication/presentation/shared/password_text_input.dart
+++ b/lib/app/features/authentication/presentation/shared/password_text_input.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 
 import '../../../../shared/design_system/text_styles.dart';
 
-class PassordInputField extends StatefulWidget {
-  const PassordInputField({
+class PasswordInputField extends StatefulWidget {
+  const PasswordInputField({
     Key? key,
     this.style = kTextStyleDefaultTextFieldLabelStyle,
     this.isAutofocus = false,
@@ -21,11 +21,11 @@ class PassordInputField extends StatefulWidget {
   final bool isAutofocus;
 
   @override
-  _PassordInputFieldState createState() => _PassordInputFieldState();
+  _PasswordInputFieldState createState() => _PasswordInputFieldState();
 }
 
-class _PassordInputFieldState extends State<PassordInputField> {
-  _PassordInputFieldState();
+class _PasswordInputFieldState extends State<PasswordInputField> {
+  _PasswordInputFieldState();
 
   bool _isPasswordVisible = false;
 

--- a/lib/app/features/authentication/presentation/sign_in/sign_in_page.dart
+++ b/lib/app/features/authentication/presentation/sign_in/sign_in_page.dart
@@ -136,7 +136,7 @@ class _SignInPageState extends ModularState<SignInPage, SignInController>
   Widget _buildPasswordField() {
     return Padding(
       padding: const EdgeInsets.only(top: 24),
-      child: PassordInputField(
+      child: PasswordInputField(
         labelText: 'Senha',
         hintText: 'Digite sua senha',
         errorText: controller.warningPassword,

--- a/lib/app/features/authentication/presentation/sign_in/sign_up/pages/sign_up_three/sign_up_three_page.dart
+++ b/lib/app/features/authentication/presentation/sign_in/sign_up/pages/sign_up_three/sign_up_three_page.dart
@@ -126,8 +126,8 @@ class _SignUpThreePageState
     );
   }
 
-  PassordInputField _buildPasswordField() {
-    return PassordInputField(
+  PasswordInputField _buildPasswordField() {
+    return PasswordInputField(
       labelText: 'Senha',
       hintText: 'Digite sua senha',
       errorText: controller.warningPassword,
@@ -135,8 +135,8 @@ class _SignUpThreePageState
     );
   }
 
-  PassordInputField _buildConfirmationPasswordField() {
-    return PassordInputField(
+  PasswordInputField _buildConfirmationPasswordField() {
+    return PasswordInputField(
       labelText: 'Confirmação de senha',
       hintText: 'Digite sua senha novamente',
       errorText: controller.warningConfirmationPassword,

--- a/lib/app/features/authentication/presentation/sign_in_anonymous/sign_in_anonymous_page.dart
+++ b/lib/app/features/authentication/presentation/sign_in_anonymous/sign_in_anonymous_page.dart
@@ -120,8 +120,8 @@ class _SignInAnonymousPage
     );
   }
 
-  PassordInputField _buildPasswordField() {
-    return PassordInputField(
+  PasswordInputField _buildPasswordField() {
+    return PasswordInputField(
       labelText: 'Senha',
       hintText: 'Digite sua senha',
       errorText: controller.warningPassword,

--- a/lib/app/features/authentication/presentation/sign_in_stealth/sign_in_stealth_page.dart
+++ b/lib/app/features/authentication/presentation/sign_in_stealth/sign_in_stealth_page.dart
@@ -139,8 +139,8 @@ class _SignInStealthPage
     );
   }
 
-  PassordInputField _buildPasswordField() {
-    return PassordInputField(
+  PasswordInputField _buildPasswordField() {
+    return PasswordInputField(
       labelText: 'Senha',
       hintText: 'Digite sua senha',
       errorText: controller.warningPassword,

--- a/test/app/features/authentication/presentation/shared/password_text_input_test.dart
+++ b/test/app/features/authentication/presentation/shared/password_text_input_test.dart
@@ -6,12 +6,12 @@ import 'package:penhas/app/features/authentication/presentation/shared/password_
 import '../../../../../utils/golden_tests.dart';
 
 void main() {
-  group(PassordInputField, () {
+  group(PasswordInputField, () {
     testWidgets('widget test', (WidgetTester tester) async {
-      // Build the PassordInputField widget.
+      // Build the PasswordInputField widget.
       await tester.pumpWidget(MaterialApp(
         home: Scaffold(
-          body: PassordInputField(
+          body: PasswordInputField(
             onChanged: (val) {},
             labelText: 'Password',
             errorText: '',
@@ -21,9 +21,9 @@ void main() {
       ));
 
       expect(
-        find.byType(PassordInputField),
+        find.byType(PasswordInputField),
         findsOneWidget,
-        reason: 'PassordInputField should be present',
+        reason: 'PasswordInputField should be present',
       );
 
       var textField = tester.widget<TextField>(find.byType(TextField));
@@ -69,7 +69,7 @@ void main() {
               children: [
                 GoldenTestScenario(
                   name: 'hint',
-                  child: PassordInputField(
+                  child: PasswordInputField(
                     isAutofocus: true,
                     errorText: '',
                     hintText: 'Hint text',
@@ -79,7 +79,7 @@ void main() {
                 ),
                 GoldenTestScenario(
                   name: 'input value',
-                  child: PassordInputField(
+                  child: PasswordInputField(
                     errorText: '',
                     hintText: 'Hint text',
                     labelText: 'P4Ssw0rd',
@@ -88,7 +88,7 @@ void main() {
                 ),
                 GoldenTestScenario(
                   name: 'with error',
-                  child: PassordInputField(
+                  child: PasswordInputField(
                     errorText: 'error',
                     hintText: 'Hint text',
                     labelText: 'Password',

--- a/test/utils/widget_test_steps.dart
+++ b/test/utils/widget_test_steps.dart
@@ -69,14 +69,14 @@ Future<void> iSeePasswordField({
   String? text,
   Key? key,
 }) async {
-  final finder = _getType(PassordInputField, text: text, key: key);
+  final finder = _getType(PasswordInputField, text: text, key: key);
 
   if (finder != null && finder.evaluate().isNotEmpty) {
     expect(finder, findsOneWidget);
     return;
   }
 
-  expect(find.byType(PassordInputField), findsOneWidget);
+  expect(find.byType(PasswordInputField), findsOneWidget);
 }
 
 Future<void> iEnterIntoPasswordField(
@@ -85,7 +85,7 @@ Future<void> iEnterIntoPasswordField(
   Key? key,
   required String password,
 }) async {
-  final finder = _getType(PassordInputField, text: text, key: key);
+  final finder = _getType(PasswordInputField, text: text, key: key);
 
   if (finder == null) {
     fail('did not find the PasswordInputField to enter the value $password');
@@ -133,7 +133,7 @@ Future<void> iSeePasswordFieldErrorMessage(
   Key? key,
   required String message,
 }) async {
-  final finder = _getType(PassordInputField, text: text, key: key);
+  final finder = _getType(PasswordInputField, text: text, key: key);
 
   if (finder == null) {
     fail('did not find the PasswordInputField widget');


### PR DESCRIPTION
# Alteração no Componente PasswordInputField

## Resumo
Este pull request corrige erros de digitação relacionados ao nome do componente de entrada de senha em todo o código base. O componente anteriormente chamado `PassordInputField` foi renomeado para `PasswordInputField`, garantindo consistência e clareza.

---

## Alterações Realizadas
1. **Correção do Nome do Componente:**
   - O nome do componente foi corrigido de `PassordInputField` para `PasswordInputField`.

2. **Arquivos Modificados:**
   - `reset_password_three_page.dart`
   - `password_text_input.dart`
   - `sign_in_page.dart`
   - `sign_up_three_page.dart`
   - `sign_in_anonymous_page.dart`
   - `sign_in_stealth_page.dart`
   - Testes unitários:
     - `password_text_input_test.dart`
     - `widget_test_steps.dart`

3. **Mudanças em Testes:**
   - Atualização de testes unitários para refletir o novo nome do componente.
   - Ajuste de nomes de variáveis e descrições nos testes para evitar confusões.

4. **Benefícios:**
   - Melhoria na legibilidade e clareza do código.
   - Correção de inconsistências e erros de digitação.

---

## Exemplo de Código Modificado

### Antes
```dart
PassordInputField(
  labelText: 'Senha',
  hintText: 'Digite sua nova senha',
);
```

### Depois
```dart
PasswordInputField(
  labelText: 'Senha',
  hintText: 'Digite sua nova senha',
);
```

