### PR TITLE
Substituir webViewJs descontinuado `tweet_body.dart`

### DIFF
--- a/lib/app/features/feed/presentation/tweet/widgets/tweet_body.dart
+++ b/lib/app/features/feed/presentation/tweet/widgets/tweet_body.dart
@@ -16,8 +16,8 @@ class TweetBody extends StatelessWidget {
   Widget build(BuildContext context) {
     final htmlBody = HtmlWidget(
       bodyContent!,
-      webViewJs: false,
       textStyle: kTextStyleFeedTweetBody,
+      factoryBuilder: () => DisabledWebViewJsWidgetFactory(),
     );
 
     return Padding(
@@ -25,4 +25,9 @@ class TweetBody extends StatelessWidget {
       child: htmlBody,
     );
   }
+}
+
+class DisabledWebViewJsWidgetFactory extends WidgetFactory {
+  @override
+  bool get webViewJs => false;
 }


### PR DESCRIPTION
# Refatoração do Componente TweetBody para Desabilitar JavaScript em WebViews

## Resumo
Este pull request introduz uma refatoração na classe `TweetBody`, com a criação de uma fábrica personalizada de widgets chamada `DisabledWebViewJsWidgetFactory` para desativar o suporte a JavaScript em WebViews. Essa mudança melhora a segurança e otimiza o comportamento do conteúdo HTML renderizado no componente.

---

## Alterações Realizadas

1. **Alteração no HtmlWidget:**
   - Substituído o uso do parâmetro `webViewJs: false` pela definição da fábrica de widgets com a configuração específica.

2. **Nova Classe:**
   - Criada a classe `DisabledWebViewJsWidgetFactory`, que herda de `WidgetFactory` e sobrescreve a propriedade `webViewJs` para desativar JavaScript.

3. **Arquivos Modificados:**
   - `tweet_body.dart`

---

## Exemplo de Código Modificado

### Antes
```dart
final htmlBody = HtmlWidget(
  bodyContent!,
  webViewJs: false,
  textStyle: kTextStyleFeedTweetBody,
);
```

### Depois
```dart
final htmlBody = HtmlWidget(
  bodyContent!,
  textStyle: kTextStyleFeedTweetBody,
  factoryBuilder: () => DisabledWebViewJsWidgetFactory(),
);
```

### Nova classe
```dart
class DisabledWebViewJsWidgetFactory extends WidgetFactory {
  @override
  bool get webViewJs => false;
}
```