### PR TITLE
Corrigir acento de Ínicio para Início

### DIFF
--- a/lib/app/features/mainboard/presentation/mainboard/pages/mainboard_button_page.dart
+++ b/lib/app/features/mainboard/presentation/mainboard/pages/mainboard_button_page.dart
@@ -118,7 +118,7 @@ class _BottomBarIcon extends StatelessWidget {
 
 extension MainboardStateExtension on MainboardState {
   String get label => when(
-        feed: () => 'Ínicio',
+        feed: () => 'Início',
         compose: () => 'Publicar',
         escapeManual: () => 'Manual de Fuga',
         helpCenter: () => 'Socorro',


### PR DESCRIPTION
## Resumo
Este pull request corrige um erro de digitação no texto exibido pelo estado `feed` no método de extensão `MainboardStateExtension.label`. A palavra **"Ínicio"** foi corrigida para **"Início"**, atendendo às normas da língua portuguesa.

---

## Alterações Realizadas

1. **Correção do Texto:**
   - No arquivo `mainboard_button_page.dart`, a string retornada pela função `feed` foi corrigida de **"Ínicio"** para **"Início"**.

2. **Arquivo Modificado:**
   - `mainboard_button_page.dart`

---

## Exemplo de Código Modificado

### Antes
```dart
String get label => when(
  feed: () => 'Ínicio',
  compose: () => 'Publicar',
  escapeManual: () => 'Manual de Fuga',
  helpCenter: () => 'Socorro',
);
```

### Depois
```dart
String get label => when(
  feed: () => 'Início',
  compose: () => 'Publicar',
  escapeManual: () => 'Manual de Fuga',
  helpCenter: () => 'Socorro',
);
```