### PR TITLE
refactor(quiz): simplificar _FilledButton removendo a propriedade width

### DIFF
--- a/lib/app/features/quiz/presentation/quiz/messages/horizontal_buttons.dart
+++ b/lib/app/features/quiz/presentation/quiz/messages/horizontal_buttons.dart
@@ -105,13 +105,11 @@ class _FilledButton extends StatelessWidget {
   const _FilledButton(
     this.label, {
     Key? key,
-    this.width = double.infinity,
     this.onPressed,
   }) : super(key: key);
 
   final String label;
   final VoidCallback? onPressed;
-  final double width;
 
   @override
   Widget build(BuildContext context) {
@@ -125,7 +123,7 @@ class _FilledButton extends StatelessWidget {
         primary: DesignSystemColors.ligthPurple,
         elevation: 0,
         shape: kButtonShapeFilled,
-        minimumSize: Size(width, _buttonHeight),
+        minimumSize: const Size(double.infinity, _buttonHeight),
       ),
     );
   }


### PR DESCRIPTION
1. **Remoção da Propriedade `width`:**
   - A propriedade `width` foi removida do construtor do botão, uma vez que o valor padrão (`double.infinity`) já era o único valor utilizado.

2. **Definição Fixa do Tamanho Mínimo:**
   - O tamanho mínimo do botão foi definido diretamente no `ButtonStyle`, utilizando `Size(double.infinity, _buttonHeight)`.
   - Isso garante que o botão ocupe toda a largura disponível por padrão, sem a necessidade de configurar a largura manualmente.

Issues

Fixes #220 