### PR TITLE
refactor(notification): desabilitar JavaScript no HtmlWidget usando u…

### DIFF
--- a/lib/app/features/notification/presentation/pages/notification_card_page.dart
+++ b/lib/app/features/notification/presentation/pages/notification_card_page.dart
@@ -72,7 +72,7 @@ class NotificationCardPage extends StatelessWidget {
       padding: const EdgeInsets.symmetric(vertical: 12.0),
       child: HtmlWidget(
         notification.content!,
-        webViewJs: false,
+        factoryBuilder: () => DisabledWebViewJsWidgetFactory(),
         textStyle: contentTextStyle,
       ),
     );
@@ -100,4 +100,9 @@ extension _TextStyle on NotificationCardPage {
         fontSize: 14.0,
         fontWeight: FontWeight.normal,
       );
+}
+
+class DisabledWebViewJsWidgetFactory extends WidgetFactory {
+  @override
+  bool get webViewJs => false;
 }


### PR DESCRIPTION
**Alterações Realizadas:**

- Substituição da propriedade `webViewJs: false` por uma nova classe `DisabledWebViewJsWidgetFactory` no widget `HtmlWidget` dentro do arquivo `notification_card_page.dart`.
- Adição da classe `DisabledWebViewJsWidgetFactory`, que estende `WidgetFactory` e sobrescreve a propriedade `webViewJs` para retornar `false`.


Fixes #221