### PR TITLE
[Fix] Corrigir texto  de Usuários para Usuárias `profile_edit_page.dart`

### DIFF
--- a/lib/app/features/main_menu/presentation/account/my_profile/profile_edit_page.dart
+++ b/lib/app/features/main_menu/presentation/account/my_profile/profile_edit_page.dart
@@ -172,7 +172,7 @@ extension _ProfileEditPage on _ProfileEditPageState {
           Padding(
             padding: const EdgeInsets.only(top: 16.0),
             child: Text(
-              'Informações exibidas para as usuários do PenhaS.',
+              'Informações exibidas para as usuárias do PenhaS.',
               style: profileHeaderContentTextStyle,
             ),
           ),


### PR DESCRIPTION
# 💡 Sugestão de Pull Request

## 🔍 Resumo das Mudanças
Este Pull Request propõe uma melhoria no texto exibido na página **profile_edit_page.dart**, para corrigir um erro de gênero no termo utilizado, garantindo uma melhor inclusão linguística.

### 🛠️ Modificação
Foi corrigido o texto que antes exibia:  
`"Informações exibidas para as usuários do PenhaS."`  
Agora exibirá:  
`"Informações exibidas para as usuárias do PenhaS."`

**Arquivo Modificado:**
`lib/app/features/main_menu/presentation/account/my_profile/profile_edit_page.dart`

**Alteração no Código:**
```diff
-              'Informações exibidas para as usuários do PenhaS.',
+              'Informações exibidas para as usuárias do PenhaS.',
```

💬 Justificativa
A modificação melhora a linguagem inclusiva do aplicativo, visto que o termo "usuárias" está de acordo com o público feminino principal da plataforma PenhaS. Essa alteração reforça a abordagem sensível e respeitosa ao público-alvo.