### PR TITLE
refactor: remover dependência do Modular na DeletedAccountPage

### DIFF
--- a/lib/app/app_module.dart
+++ b/lib/app/app_module.dart
@@ -164,7 +164,9 @@ class AppModule extends Module {
         ModuleRoute('/quiz', module: QuizModule()),
         ChildRoute(
           '/accountDeleted',
-          child: (context, args) => const DeletedAccountPage(),
+          child: (context, args) => DeletedAccountPage(
+            controller: Modular.get<DeletedAccountController>(),
+          ),
           transition: TransitionType.rightToLeft,
         )
       ];

--- a/lib/app/features/authentication/presentation/deleted_account/deleted_account_page.dart
+++ b/lib/app/features/authentication/presentation/deleted_account/deleted_account_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
-import 'package:flutter_modular/flutter_modular.dart';
 import 'package:mobx/mobx.dart';
 
 import '../../../../shared/design_system/colors.dart';
@@ -10,14 +9,18 @@ import '../shared/snack_bar_handler.dart';
 import 'deleted_account_controller.dart';
 
 class DeletedAccountPage extends StatefulWidget {
-  const DeletedAccountPage({Key? key}) : super(key: key);
+  const DeletedAccountPage({
+    Key? key,
+    required this.controller,
+  }) : super(key: key);
+
+  final DeletedAccountController controller;
 
   @override
   _DeletedAccountPageState createState() => _DeletedAccountPageState();
 }
 
-class _DeletedAccountPageState
-    extends ModularState<DeletedAccountPage, DeletedAccountController>
+class _DeletedAccountPageState extends State<DeletedAccountPage>
     with SnackBarHandler {
   List<ReactionDisposer>? _disposers;
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
@@ -26,7 +29,7 @@ class _DeletedAccountPageState
   void didChangeDependencies() {
     super.didChangeDependencies();
     _disposers ??= [
-      reaction((_) => controller.errorMessage, (String? message) {
+      reaction((_) => widget.controller.errorMessage, (String? message) {
         showSnackBar(scaffoldKey: _scaffoldKey, message: message);
       }),
     ];
@@ -85,7 +88,7 @@ extension _MethodPrivate on _DeletedAccountPageState {
   Widget bodyBuilder() {
     return SafeArea(
       child: PageProgressIndicator(
-        progressState: controller.progressState,
+        progressState: widget.controller.progressState,
         child: Padding(
           padding: const EdgeInsets.all(20.0),
           child: Column(
@@ -109,7 +112,7 @@ extension _MethodPrivate on _DeletedAccountPageState {
                     height: 40,
                     width: 250,
                     child: PenhasButton.roundedFilled(
-                      onPressed: () => controller.reactive(),
+                      onPressed: () => widget.controller.reactive(),
                       child:
                           Text('Reativar Conta', style: activeButtonTextStyle),
                     ),

--- a/test/app/features/authentication/presentation/deleted_account/deleted_account_page_test.dart
+++ b/test/app/features/authentication/presentation/deleted_account/deleted_account_page_test.dart
@@ -1,8 +1,5 @@
-import 'package:flutter_modular/flutter_modular.dart';
-import 'package:flutter_modular_test/flutter_modular_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:penhas/app/app_module.dart';
 import 'package:penhas/app/core/entities/valid_fiel.dart';
 import 'package:penhas/app/core/error/failures.dart';
 import 'package:penhas/app/features/authentication/presentation/deleted_account/deleted_account_controller.dart';
@@ -14,29 +11,26 @@ import '../../../../../utils/widget_test_steps.dart';
 import '../mocks/app_modules_mock.dart';
 
 void main() {
+  late DeletedAccountController controller;
+
   setUp(() {
     AppModulesMock.init();
 
-    initModule(AppModule(), replaceBinds: [
-      Bind<DeletedAccountController>(
-        (i) => DeletedAccountController(
-          profileRepository: AppModulesMock.userProfileRepository,
-          appConfiguration: AppModulesMock.appConfiguration,
-          sessionToken: '',
-        ),
-      ),
-    ]);
-  });
-
-  tearDown(() {
-    Modular.removeModule(AppModule());
+    controller = DeletedAccountController(
+      profileRepository: AppModulesMock.userProfileRepository,
+      appConfiguration: AppModulesMock.appConfiguration,
+      sessionToken: '',
+    );
   });
 
   group(DeletedAccountPage, () {
     testWidgets(
       'shows screen widgets',
       (tester) async {
-        await theAppIsRunning(tester, const DeletedAccountPage());
+        await theAppIsRunning(
+          tester,
+          DeletedAccountPage(controller: controller),
+        );
         await iSeeText('Deseja reativar?');
         await iSeeText(
             'Esta conta está marcada para ser excluída.\n\nVocê pode interromper este processo agora reativando a conta.');
@@ -54,7 +48,10 @@ void main() {
               .reactivate(token: any(named: 'token')),
         ).thenFailure((_) => ServerFailure());
 
-        await theAppIsRunning(tester, const DeletedAccountPage());
+        await theAppIsRunning(
+          tester,
+          DeletedAccountPage(controller: controller),
+        );
         await iTapText(tester, text: 'Reativar Conta');
         await iSeeText(errorMessage);
       },
@@ -76,7 +73,10 @@ void main() {
           () => AppModulesMock.modularNavigator.pushReplacementNamed(any()),
         ).thenAnswer((_) => Future.value());
 
-        await theAppIsRunning(tester, const DeletedAccountPage());
+        await theAppIsRunning(
+          tester,
+          DeletedAccountPage(controller: controller),
+        );
         await iTapText(tester, text: 'Reativar Conta');
 
         verify(() => AppModulesMock.modularNavigator.pushReplacementNamed('/'))
@@ -88,7 +88,7 @@ void main() {
       screenshotTest(
         'looks as expected',
         fileName: 'deleted_account_page',
-        pageBuilder: () => const DeletedAccountPage(),
+        pageBuilder: () => DeletedAccountPage(controller: controller),
       );
     });
   });


### PR DESCRIPTION
**Descrição do Pull Request:**

Este PR introduz alterações na página de conta excluída (`deleted_account_page.dart`) e ajustes nos testes relacionados para melhorar a injeção de dependências e a organização do código.

### Principais Alterações:

1. **Refatoração da Injeção de Dependências:**
   - Remoção da dependência direta do `Modular` na página `DeletedAccountPage`.
   - O controlador (`DeletedAccountController`) agora é injetado diretamente no construtor da página, tornando o código mais explícito e testável.
   - Ajuste no `AppModule` para passar o controlador corretamente ao navegar para a rota `/accountDeleted`.

2. **Simplificação do Estado da Página:**
   - Remoção da herança de `ModularState` e substituição por um `State` comum, já que o controlador é injetado diretamente.
   - Ajuste nas reações do MobX para referenciar o controlador através de `widget.controller`.

3. **Refatoração dos Testes:**
   - Remoção da configuração do `Modular` nos testes, simplificando a inicialização do controlador.
   - O controlador é criado diretamente nos testes, eliminando a necessidade de mocks complexos e inicialização de módulos.
   - Ajuste nos testes para utilizar a nova forma de injeção do controlador.

4. **Testes de Screenshot:**
   - O teste de screenshot foi atualizado para utilizar a nova forma de construção da página, garantindo que a renderização continue consistente.

### Issues:

Fixes #323