### PR TITLE
Refactor Remover dependencias do Modular `AudioRecordPage`

### DIFF
--- a/lib/app/features/help_center/presentation/pages/audio/audio_record_page.dart
+++ b/lib/app/features/help_center/presentation/pages/audio/audio_record_page.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_modular/flutter_modular.dart';
 
 import '../../../../../core/managers/audio_record_services.dart';
 import '../../../../../shared/design_system/colors.dart';
@@ -10,18 +9,22 @@ import 'audio_record_controller.dart';
 import 'sound_record_widget.dart';
 
 class AudioRecordPage extends StatefulWidget {
-  const AudioRecordPage({Key? key}) : super(key: key);
+  const AudioRecordPage({
+    Key? key,
+    required this.controller,
+  }) : super(key: key);
+
+  final AudioRecordController controller;
 
   @override
   _AudioRecordState createState() => _AudioRecordState();
 }
 
-class _AudioRecordState
-    extends ModularState<AudioRecordPage, AudioRecordController>
-    with SnackBarHandler {
+class _AudioRecordState extends State<AudioRecordPage> with SnackBarHandler {
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
   AudioActivity? _audioActivity;
   StreamSubscription? _streamSubscription;
+  AudioRecordController get controller => widget.controller;
 
   @override
   void initState() {

--- a/lib/app/features/mainboard/presentation/mainboard/mainboard_module.dart
+++ b/lib/app/features/mainboard/presentation/mainboard/mainboard_module.dart
@@ -57,6 +57,7 @@ import '../../../help_center/presentation/guardians/guardians_controller.dart';
 import '../../../help_center/presentation/guardians/guardians_page.dart';
 import '../../../help_center/presentation/new_guardian/new_guardian_controller.dart';
 import '../../../help_center/presentation/new_guardian/new_guardian_page.dart';
+import '../../../help_center/presentation/pages/audio/audio_record_controller.dart';
 import '../../../help_center/presentation/pages/audio/audio_record_page.dart';
 import '../../../main_menu/domain/repositories/user_profile_repository.dart';
 import '../../../main_menu/domain/usecases/user_profile.dart';
@@ -191,7 +192,9 @@ class MainboardModule extends Module {
         ),
         ChildRoute(
           '/helpcenter/audioRecord',
-          child: (context, args) => const AudioRecordPage(),
+          child: (context, args) => AudioRecordPage(
+            controller: Modular.get<AudioRecordController>(),
+          ),
           transition: TransitionType.rightToLeft,
         )
       ];


### PR DESCRIPTION
# Melhorias na configuração da página de gravação de áudio (`AudioRecordPage`)

## Descrição

Este pull request refatora o uso do `AudioRecordController` na página `AudioRecordPage`, substituindo a injeção direta via `ModularState` por um padrão de injeção através de construtor. Essa mudança melhora a testabilidade e separação de responsabilidades, alinhando a estrutura com as boas práticas recomendadas para desenvolvimento com Flutter.

## Alterações Realizadas

### `audio_record_page.dart`
1. **Adicionado parâmetro `AudioRecordController` via construtor**:
   - Substitui o acesso ao controlador via `ModularState` pela obtenção através do widget.
2. **Modificado `_AudioRecordState` para acessar o controlador via `widget.controller`**:
   - Facilita o fornecimento de controladores customizados, especialmente durante testes.

**Código Alterado**:
```diff
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_modular/flutter_modular.dart';
 
 import '../../../../../core/managers/audio_record_services.dart';
 import '../../../../../shared/design_system/colors.dart';
@@ -10,18 +9,22 @@ import 'audio_record_controller.dart';
 import 'sound_record_widget.dart';
 
 class AudioRecordPage extends StatefulWidget {
-  const AudioRecordPage({Key? key}) : super(key: key);
+  const AudioRecordPage({
+    Key? key,
+    required this.controller,
+  }) : super(key: key);
+
+  final AudioRecordController controller;
 
   @override
   _AudioRecordState createState() => _AudioRecordState();
 }
 
-class _AudioRecordState
-    extends ModularState<AudioRecordPage, AudioRecordController>
-    with SnackBarHandler {
+class _AudioRecordState extends State<AudioRecordPage> with SnackBarHandler {
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
   AudioActivity? _audioActivity;
   StreamSubscription? _streamSubscription;
+  AudioRecordController get controller => widget.controller;
```

`mainboard_module.dart`

1. Atualização na rota '/helpcenter/audioRecord':

Agora, AudioRecordPage recebe uma instância do controlador AudioRecordController por meio do Modular.

### Código Alterado:
```dart
 import '../../../help_center/presentation/new_guardian/new_guardian_controller.dart';
 import '../../../help_center/presentation/new_guardian/new_guardian_page.dart';
+import '../../../help_center/presentation/pages/audio/audio_record_controller.dart';
 import '../../../help_center/presentation/pages/audio/audio_record_page.dart';
 import '../../../main_menu/domain/repositories/user_profile_repository.dart';
 import '../../../main_menu/domain/usecases/user_profile.dart';
@@ -191,7 +192,9 @@ class MainboardModule extends Module {
         ),
         ChildRoute(
           '/helpcenter/audioRecord',
-          child: (context, args) => const AudioRecordPage(),
+          child: (context, args) => AudioRecordPage(
+            controller: Modular.get<AudioRecordController>(),
+          ),
           transition: TransitionType.rightToLeft,
         )
       ];
```