### PR TITLE
Refactor Remover dependencias do Modular `AudiosPage`

### DIFF
--- a/lib/app/features/help_center/presentation/audios/audios_page.dart
+++ b/lib/app/features/help_center/presentation/audios/audios_page.dart
@@ -20,20 +20,23 @@ import '../pages/guardian_error_page.dart';
 import 'audios_controller.dart';
 
 class AudiosPage extends StatefulWidget {
-  const AudiosPage({Key? key, this.title = 'Audios'}) : super(key: key);
+  const AudiosPage({Key? key, this.title = 'Audios', required this.controller})
+      : super(key: key);
 
   final String title;
+  final AudiosController controller;
 
   @override
   _AudiosPageState createState() => _AudiosPageState();
 }
 
-class _AudiosPageState extends ModularState<AudiosPage, AudiosController>
-    with SnackBarHandler {
+class _AudiosPageState extends State<AudiosPage> with SnackBarHandler {
   List<ReactionDisposer>? _disposers;
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
   final GlobalKey<RefreshIndicatorState> _refreshIndicatorKey =
       GlobalKey<RefreshIndicatorState>();
+
+  AudiosController get controller => widget.controller;
 
   PageProgressState _loadState = PageProgressState.initial;
   AudioEntity? _playingAudio;

--- a/lib/app/features/mainboard/presentation/mainboard/mainboard_module.dart
+++ b/lib/app/features/mainboard/presentation/mainboard/mainboard_module.dart
@@ -187,7 +187,9 @@ class MainboardModule extends Module {
         ),
         ChildRoute(
           '/helpcenter/audios',
-          child: (context, args) => const AudiosPage(),
+          child: (context, args) => AudiosPage(
+            controller: Modular.get<AudiosController>(),
+          ),
           transition: TransitionType.rightToLeft,
         ),
         ChildRoute(

--- a/test/app/features/help_center/presentation/audios/audios_page_test.dart
+++ b/test/app/features/help_center/presentation/audios/audios_page_test.dart
@@ -37,8 +37,8 @@ void main() {
 
     // act
     await tester.pumpWidget(
-      const MaterialApp(
-        home: AudiosPage(),
+       MaterialApp(
+        home: AudiosPage(controller: mockController,),
       ),
     );
 
@@ -83,8 +83,8 @@ void main() {
 
     // act
     await tester.pumpWidget(
-      const MaterialApp(
-        home: AudiosPage(),
+       MaterialApp(
+        home: AudiosPage(controller: mockController,),
       ),
     );
 
@@ -106,8 +106,8 @@ void main() {
 
     //act
     await tester.pumpWidget(
-      const MaterialApp(
-        home: AudiosPage(),
+       MaterialApp(
+        home: AudiosPage(controller: mockController,),
       ),
     );
     // assert

--- a/test/app/features/help_center/presentation/audios/audios_page_test.dart
+++ b/test/app/features/help_center/presentation/audios/audios_page_test.dart
@@ -1,6 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_modular/flutter_modular.dart';
-import 'package:flutter_modular_test/flutter_modular_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:intl/intl.dart';
@@ -11,22 +9,12 @@ import 'package:penhas/app/features/help_center/domain/states/audios_state.dart'
 import 'package:penhas/app/features/help_center/presentation/audios/audios_controller.dart';
 import 'package:penhas/app/features/help_center/presentation/audios/audios_page.dart';
 
-import '../../../../../utils/aditional_bind_module.dart';
-
 void main() {
   late AudiosController mockController;
 
   setUpAll(() {
     mockController = _MockAudiosController();
     when(() => mockController.loadPage()).thenAnswer((_) => Future.value());
-
-    initModule(
-      AditionalBindModule(
-        binds: [
-          Bind.instance<AudiosController>(mockController),
-        ],
-      ),
-    );
   });
 
   testWidgets('Audios Page Initial Load', (tester) async {
@@ -37,8 +25,10 @@ void main() {
 
     // act
     await tester.pumpWidget(
-       MaterialApp(
-        home: AudiosPage(controller: mockController,),
+      MaterialApp(
+        home: AudiosPage(
+          controller: mockController,
+        ),
       ),
     );
 
@@ -83,8 +73,10 @@ void main() {
 
     // act
     await tester.pumpWidget(
-       MaterialApp(
-        home: AudiosPage(controller: mockController,),
+      MaterialApp(
+        home: AudiosPage(
+          controller: mockController,
+        ),
       ),
     );
 
@@ -106,8 +98,10 @@ void main() {
 
     //act
     await tester.pumpWidget(
-       MaterialApp(
-        home: AudiosPage(controller: mockController,),
+      MaterialApp(
+        home: AudiosPage(
+          controller: mockController,
+        ),
       ),
     );
     // assert


### PR DESCRIPTION
# Refatoração de `AudiosPage` para Suporte a Dependência por Construtor

## Descrição

Este pull request implementa uma refatoração no widget `AudiosPage`, adotando a injeção de dependências por construtor em substituição ao uso direto de `ModularState`. Além disso, as alterações atualizam os testes relacionados para refletir as mudanças feitas no componente.

## Alterações Realizadas

### Arquivo: `audios_page.dart`
1. **Adição de `AudiosController` como parâmetro obrigatório no construtor de `AudiosPage`**:
   - Melhora a modularidade e testabilidade ao permitir o fornecimento explícito de instâncias do controlador.
2. **Atualização do `_AudiosPageState`**:
   - Agora, o controlador é obtido via `widget.controller`, eliminando a dependência direta de `Modular`.

**Código Alterado**:
```diff
 class AudiosPage extends StatefulWidget {
-  const AudiosPage({Key? key, this.title = 'Audios'}) : super(key: key);
+  const AudiosPage({Key? key, this.title = 'Audios', required this.controller})
+      : super(key: key);
 
   final String title;
+  final AudiosController controller;
 
   @override
   _AudiosPageState createState() => _AudiosPageState();
 }
 
-class _AudiosPageState extends ModularState<AudiosPage, AudiosController>
-    with SnackBarHandler {
+class _AudiosPageState extends State<AudiosPage> with SnackBarHandler {
   List<ReactionDisposer>? _disposers;
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
   final GlobalKey<RefreshIndicatorState> _refreshIndicatorKey =
       GlobalKey<RefreshIndicatorState>();
 
+  AudiosController get controller => widget.controller;
```
### Arquivo: mainboard_module.dart

1. Atualização na rota /helpcenter/audios:
* Ajuste na instância de AudiosPage para receber um AudiosController obtido pelo Modular.

### Código Alterado:
```dart
 ChildRoute(
   '/helpcenter/audios',
-  child: (context, args) => const AudiosPage(),
+  child: (context, args) => AudiosPage(
+    controller: Modular.get<AudiosController>(),
+  ),
   transition: TransitionType.rightToLeft,
 ),
```

### Arquivo: audios_page_test.dart

1. Atualização dos testes:
* Adicionada a criação de um controlador mockado (mockController) para fornecer à instância de AudiosPage durante os testes.
2. Ajuste nos pumpWidget dos testes para refletir o novo construtor.

### Código Alterado:
```dart
 await tester.pumpWidget(
-  const MaterialApp(
-    home: AudiosPage(),
+   MaterialApp(
+    home: AudiosPage(controller: mockController),
   ),
 );
```