### PR TITLE
[refactor] Remover dependência do Modular `ResetPasswordPage`

### DIFF
--- a/lib/app/features/authentication/presentation/reset_password/reset_password_page.dart
+++ b/lib/app/features/authentication/presentation/reset_password/reset_password_page.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
-import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:mobx/mobx.dart';
 
@@ -15,18 +14,20 @@ import '../shared/snack_bar_handler.dart';
 import 'reset_password_controller.dart';
 
 class ResetPasswordPage extends StatefulWidget {
-  const ResetPasswordPage({Key? key, this.title = 'ResetPassword'})
-      : super(key: key);
+  const ResetPasswordPage({
+    required this.controller,
+    Key? key,
+  }) : super(key: key);
 
-  final String title;
+  final ResetPasswordController controller;
 
   @override
   _ResetPasswordPageState createState() => _ResetPasswordPageState();
 }
 
-class _ResetPasswordPageState
-    extends ModularState<ResetPasswordPage, ResetPasswordController>
+class _ResetPasswordPageState extends State<ResetPasswordPage>
     with SnackBarHandler {
+  ResetPasswordController get controller => widget.controller;
   List<ReactionDisposer>? _disposers;
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
   PageProgressState _currentState = PageProgressState.initial;

--- a/lib/app/features/authentication/presentation/sign_in/sign_in_module.dart
+++ b/lib/app/features/authentication/presentation/sign_in/sign_in_module.dart
@@ -9,6 +9,7 @@ import '../../../../core/managers/location_services.dart';
 import '../../../../core/managers/modules_sevices.dart';
 import '../../../../core/network/api_server_configure.dart';
 import '../../../../core/network/network_info.dart';
+import '../../../../core/remoteconfig/i_remote_config.dart';
 import '../../../appstate/domain/entities/user_profile_entity.dart';
 import '../../../appstate/domain/usecases/app_state_usecase.dart';
 import '../../../help_center/data/datasources/guardian_data_source.dart';
@@ -58,7 +59,7 @@ class SignInModule extends Module {
         ..._resetPassword,
         ..._signInAnonymous,
         ..._signInStealth,
-        ..._logginOfflineToggle
+        ..._loginOfflineToggle
       ];
 
   @override
@@ -80,7 +81,9 @@ class SignInModule extends Module {
         ),
         ChildRoute(
           '/reset_password',
-          child: (_, args) => const ResetPasswordPage(),
+          child: (_, args) => ResetPasswordPage(
+            controller: Modular.get<ResetPasswordController>(),
+          ),
         ),
         ChildRoute(
           '/reset_password/step2',
@@ -224,9 +227,10 @@ class SignInModule extends Module {
                 loginOfflineToggleFeature: i.get()))
       ];
 
-  List<Bind> get _logginOfflineToggle => [
-        Bind.factory<LoginOfflineToggleFeature>(
-            (i) => LoginOfflineToggleFeature(remoteConfig: i.get()))
+  List<Bind> get _loginOfflineToggle => [
+        Bind.factory<LoginOfflineToggleFeature>((_) =>
+            LoginOfflineToggleFeature(
+                remoteConfig: Modular.get<IRemoteConfigService>()))
       ];
 
   List<Bind> get _signInStealth => [

--- a/test/app/features/authentication/presentation/reset_password/reset_password_page_test.dart
+++ b/test/app/features/authentication/presentation/reset_password/reset_password_page_test.dart
@@ -1,12 +1,9 @@
-import 'package:flutter_modular/flutter_modular.dart';
-import 'package:flutter_modular_test/flutter_modular_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:penhas/app/core/error/failures.dart';
 import 'package:penhas/app/features/authentication/domain/entities/reset_password_response_entity.dart';
 import 'package:penhas/app/features/authentication/presentation/reset_password/reset_password_controller.dart';
 import 'package:penhas/app/features/authentication/presentation/reset_password/reset_password_page.dart';
-import 'package:penhas/app/features/authentication/presentation/sign_in/sign_in_module.dart';
 
 import '../../../../../utils/golden_tests.dart';
 import '../../../../../utils/mocktail_extension.dart';
@@ -15,30 +12,22 @@ import '../mocks/app_modules_mock.dart';
 import '../mocks/authentication_modules_mock.dart';
 
 void main() {
+  late ResetPasswordController controller;
+
   setUp(() {
     AppModulesMock.init();
     AuthenticationModulesMock.init();
 
-    initModule(
-      SignInModule(),
-      replaceBinds: [
-        Bind<ResetPasswordController>(
-          (i) => ResetPasswordController(
-              AuthenticationModulesMock.resetPasswordRepository),
-        ),
-      ],
-    );
-  });
-
-  tearDown(() {
-    Modular.removeModule(SignInModule());
+    controller = ResetPasswordController(
+        AuthenticationModulesMock.resetPasswordRepository);
   });
 
   group(ResetPasswordPage, () {
     testWidgets(
       'shows screen widgets',
       (tester) async {
-        await theAppIsRunning(tester, const ResetPasswordPage());
+        await theAppIsRunning(
+            tester, ResetPasswordPage(controller: controller));
         await iSeeText('Esqueceu a senha?');
         await iSeeText(
             'Informe o seu e-mail para receber o código de recuperação de senha.');
@@ -49,7 +38,8 @@ void main() {
     testWidgets(
       'displays error text for invalid email input',
       (tester) async {
-        await theAppIsRunning(tester, const ResetPasswordPage());
+        await theAppIsRunning(
+            tester, ResetPasswordPage(controller: controller));
         await iEnterIntoSingleTextInput(tester,
             text: 'E-mail', value: 'invalidEmail');
         await iSeeSingleTextInputErrorMessage(tester,
@@ -60,7 +50,8 @@ void main() {
     testWidgets(
       'do not forward for invalid email',
       (tester) async {
-        await theAppIsRunning(tester, const ResetPasswordPage());
+        await theAppIsRunning(
+            tester, ResetPasswordPage(controller: controller));
         await iEnterIntoSingleTextInput(tester,
             text: 'E-mail', value: 'invalidEmail');
         await iTapText(tester, text: 'Próximo');
@@ -79,7 +70,8 @@ void main() {
                 .request(emailAddress: any(named: 'emailAddress')))
             .thenFailure((i) => ServerFailure());
 
-        await theAppIsRunning(tester, const ResetPasswordPage());
+        await theAppIsRunning(
+            tester, ResetPasswordPage(controller: controller));
         await iDontSeeText(errorMessage);
         await iEnterIntoSingleTextInput(tester,
             text: 'E-mail', value: 'valid@email.com');
@@ -99,7 +91,8 @@ void main() {
                 .pushNamed(any(), arguments: any(named: 'arguments')))
             .thenAnswer((i) => Future.value());
 
-        await theAppIsRunning(tester, const ResetPasswordPage());
+        await theAppIsRunning(
+            tester, ResetPasswordPage(controller: controller));
         await iEnterIntoSingleTextInput(tester,
             text: 'E-mail', value: 'valid@email.com');
         await iTapText(tester, text: 'Próximo');
@@ -114,7 +107,7 @@ void main() {
       screenshotTest(
         'looks as expected',
         fileName: 'reset_password_page_step_1',
-        pageBuilder: () => const ResetPasswordPage(),
+        pageBuilder: () => ResetPasswordPage(controller: controller),
       );
     });
   });


### PR DESCRIPTION
Este PR introduz alterações na página de redefinição de senha (`reset_password_page.dart`) e ajustes nos testes relacionados, além de melhorias no módulo de autenticação (`sign_in_module.dart`). As mudanças visam simplificar a injeção de dependências, melhorar a organização do código e garantir a consistência dos testes.

### Principais Alterações:

1. **Refatoração da Injeção de Dependências:**
   - Remoção da dependência direta do `Modular` na página `ResetPasswordPage`.
   - O controlador (`ResetPasswordController`) agora é injetado diretamente no construtor da página, tornando o código mais explícito e testável.
   - Ajuste no `SignInModule` para passar o controlador corretamente ao navegar para a rota `/reset_password`.

2. **Simplificação do Estado da Página:**
   - Remoção da herança de `ModularState` e substituição por um `State` comum, já que o controlador é injetado diretamente.
   - Adição de um getter para acessar o controlador (`controller`) de forma mais clara.

3. **Refatoração dos Testes:**
   - Remoção da configuração do `Modular` nos testes, simplificando a inicialização do controlador.
   - O controlador é criado diretamente nos testes, eliminando a necessidade de mocks complexos e inicialização de módulos.
   - Ajuste nos testes para utilizar a nova forma de injeção do controlador.

4. **Correção de Nomenclatura no Módulo de Autenticação:**
   - Correção do nome da variável `_logginOfflineToggle` para `_loginOfflineToggle` no `SignInModule`, mantendo a consistência no código.

5. **Testes de Screenshot:**
   - O teste de screenshot foi atualizado para utilizar a nova forma de construção da página, garantindo que a renderização continue consistente.

### Issues:

Fixes #330
