### PR TITLE
[refactor] Remover dependência do Modular `ZodiacPage`

### DIFF
--- a/lib/app/features/zodiac/presentation/zodiac_module.dart
+++ b/lib/app/features/zodiac/presentation/zodiac_module.dart
@@ -64,5 +64,5 @@ class ZodiacModule extends WidgetModule {
       ];
 
   @override
-  Widget get view => const ZodiacPage();
+  Widget get view => ZodiacPage(controller: Modular.get<ZodiacController>());
 }

--- a/lib/app/features/zodiac/presentation/zodiac_page.dart
+++ b/lib/app/features/zodiac/presentation/zodiac_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
-import 'package:flutter_modular/flutter_modular.dart';
 
 import '../../../shared/design_system/colors.dart';
 import '../../../shared/design_system/logo.dart';
@@ -13,17 +12,19 @@ import 'zodiac_controller.dart';
 
 class ZodiacPage extends StatefulWidget {
   const ZodiacPage({
+    required this.controller,
     Key? key,
-    this.title = 'ZodiacPage',
   }) : super(key: key);
 
-  final String title;
+  final ZodiacController controller;
 
   @override
-  _ZodiacPageState createState() => _ZodiacPageState();
+  State<ZodiacPage> createState() => _ZodiacPageState();
 }
 
-class _ZodiacPageState extends ModularState<ZodiacPage, ZodiacController> {
+class _ZodiacPageState extends State<ZodiacPage> {
+  ZodiacController get controller => widget.controller;
+
   @override
   void dispose() {
     controller.dispose();
@@ -82,7 +83,7 @@ class _ZodiacPageState extends ModularState<ZodiacPage, ZodiacController> {
             ),
             onPressed: () => controller.forwardStealthLogin(),
             child: const Text(
-              'Diário astrólogico',
+              'Diário astrológico',
               style: kTextStyleFeedTweetShowReply,
             ),
           ),

--- a/test/app/features/zodiac/presentation/zodiac_page_test.dart
+++ b/test/app/features/zodiac/presentation/zodiac_page_test.dart
@@ -1,6 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_modular/flutter_modular.dart';
-import 'package:flutter_modular_test/flutter_modular_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:penhas/app/features/appstate/domain/entities/user_profile_entity.dart';
@@ -9,7 +7,6 @@ import 'package:penhas/app/features/zodiac/presentation/pages/zodiac_felling_pag
 import 'package:penhas/app/features/zodiac/presentation/pages/zodiac_ruling_page.dart';
 import 'package:penhas/app/features/zodiac/presentation/pages/zodiac_sign_page.dart';
 import 'package:penhas/app/features/zodiac/presentation/zodiac_controller.dart';
-import 'package:penhas/app/features/zodiac/presentation/zodiac_module.dart';
 import 'package:penhas/app/features/zodiac/presentation/zodiac_page.dart';
 
 import '../../../../utils/golden_tests.dart';
@@ -18,6 +15,8 @@ import '../../authentication/presentation/mocks/app_modules_mock.dart';
 import '../../authentication/presentation/mocks/authentication_modules_mock.dart';
 
 void main() {
+  late ZodiacController controller;
+
   setUp(() {
     AppModulesMock.init();
     AuthenticationModulesMock.init();
@@ -45,25 +44,20 @@ void main() {
 
     when(() => AuthenticationModulesMock.securityAction.dispose())
         .thenAnswer((_) => Future.value());
-    initModule(ZodiacModule(), replaceBinds: [
-      Bind.factory((i) => ZodiacController(
-            userProfileStore: AppModulesMock.userProfileStore,
-            securityAction: AuthenticationModulesMock.securityAction,
-          )),
-    ]);
-  });
 
-  tearDown(() {
-    Modular.removeModule(ZodiacModule());
+    controller = ZodiacController(
+      userProfileStore: AppModulesMock.userProfileStore,
+      securityAction: AuthenticationModulesMock.securityAction,
+    );
   });
 
   group(ZodiacPage, () {
     testWidgets('should render the page', (tester) async {
       // arrange
-      await theAppIsRunning(tester, const ZodiacPage());
+      await theAppIsRunning(tester, ZodiacPage(controller: controller));
       // assert
       iSeeText('Hoje');
-      iSeeText('Diário astrólogico');
+      iSeeText('Diário astrológico');
       iSeeWidget(ZodiacSignPage);
       iSeeWidget(ZodiacRulingPage);
       iSeeWidget(ZodiacFellingPage);
@@ -76,9 +70,9 @@ void main() {
       when(() =>
               AppModulesMock.modularNavigator.pushReplacementNamed(routeName))
           .thenAnswer((_) => Future.value());
-      await theAppIsRunning(tester, const ZodiacPage());
+      await theAppIsRunning(tester, ZodiacPage(controller: controller));
       // act
-      await iTapText(tester, text: 'Diário astrólogico');
+      await iTapText(tester, text: 'Diário astrológico');
       // assert
       verify(() =>
               AppModulesMock.modularNavigator.pushReplacementNamed(routeName))
@@ -93,7 +87,7 @@ void main() {
           .thenAnswer((_) => Future.value());
       when(() => AuthenticationModulesMock.securityAction.stop())
           .thenAnswer((_) => Future.value());
-      await theAppIsRunning(tester, const ZodiacPage());
+      await theAppIsRunning(tester, ZodiacPage(controller: controller));
       await tester.pumpAndSettle();
       // act
       await iSeeWidget(ZodiacActionButton);
@@ -106,7 +100,7 @@ void main() {
     screenshotTest(
       'should render the page',
       fileName: 'zodiac_page',
-      pageBuilder: () => const ZodiacPage(),
+      pageBuilder: () => ZodiacPage(controller: controller),
     );
   });
 }


### PR DESCRIPTION
Este PR introduz alterações na página de zodíaco (`zodiac_page.dart`) e no módulo de zodíaco (`zodiac_module.dart`), além de ajustes nos testes relacionados. As mudanças visam simplificar a injeção de dependências, melhorar a organização do código e garantir a consistência dos testes.

### Principais Alterações:

1. **Refatoração da Injeção de Dependências:**
   - Remoção da dependência direta do `Modular` na página `ZodiacPage`.
   - O controlador (`ZodiacController`) agora é injetado diretamente no construtor da página, tornando o código mais explícito e testável.
   - Ajuste no `ZodiacModule` para passar o controlador corretamente ao construir a página.

2. **Simplificação do Estado da Página:**
   - Remoção da herança de `ModularState` e substituição por um `State` comum, já que o controlador é injetado diretamente.
   - Adição de um getter para acessar o controlador (`controller`) de forma mais clara.

3. **Correção de Texto:**
   - Correção do texto "Diário astrólogico" para "Diário astrológico", mantendo a ortografia correta.

4. **Refatoração dos Testes:**
   - Remoção da configuração do `Modular` nos testes, simplificando a inicialização do controlador.
   - O controlador é criado diretamente nos testes, eliminando a necessidade de mocks complexos e inicialização de módulos.
   - Ajuste nos testes para utilizar a nova forma de injeção do controlador.

5. **Testes de Screenshot:**
   - O teste de screenshot foi atualizado para utilizar a nova forma de construção da página, garantindo que a renderização continue consistente.

### Issues:

Fixes #331