### PR TITLE
[refactor] Remover dependência do Modular `SupportCenterShowPage`

### DIFF
--- a/lib/app/features/mainboard/presentation/mainboard/mainboard_module.dart
+++ b/lib/app/features/mainboard/presentation/mainboard/mainboard_module.dart
@@ -76,6 +76,7 @@ import '../../../notification/presentation/notification_page.dart';
 import '../../../quiz/presentation/tutorial/stealth_mode_tutorial_page_controller.dart';
 import '../../../support_center/presentation/add/support_center_add_page.dart';
 import '../../../support_center/presentation/list/support_center_list_page.dart';
+import '../../../support_center/presentation/show/support_center_show_controller.dart';
 import '../../../support_center/presentation/show/support_center_show_page.dart';
 import '../../../users/data/repositories/users_repository.dart';
 import '../../../users/presentation/user_profile_module.dart';
@@ -218,7 +219,9 @@ class MainboardModule extends Module {
         ),
         ChildRoute(
           '/supportcenter/show',
-          child: (context, args) => const SupportCenterShowPage(),
+          child: (context, args) => SupportCenterShowPage(
+            controller: Modular.get<SupportCenterShowController>(),
+          ),
           transition: TransitionType.rightToLeft,
         )
       ];

--- a/lib/app/features/support_center/presentation/show/support_center_show_controller.dart
+++ b/lib/app/features/support_center/presentation/show/support_center_show_controller.dart
@@ -18,9 +18,7 @@ class SupportCenterShowController extends _SupportCenterShowControllerBase
 }
 
 abstract class _SupportCenterShowControllerBase with Store, MapFailureMessage {
-  _SupportCenterShowControllerBase(this._place, this._useCase) {
-    setup();
-  }
+  _SupportCenterShowControllerBase(this._place, this._useCase);
 
   final SupportCenterUseCase _useCase;
   final SupportCenterPlaceEntity? _place;
@@ -36,6 +34,10 @@ abstract class _SupportCenterShowControllerBase with Store, MapFailureMessage {
   @action
   Future<void> retry() async {
     setup();
+  }
+
+  Future<void> initialize() async {
+    await setup();
   }
 }
 

--- a/lib/app/features/support_center/presentation/show/support_center_show_page.dart
+++ b/lib/app/features/support_center/presentation/show/support_center_show_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
-import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter_widget_from_html/flutter_widget_from_html.dart';
 import 'package:map_launcher/map_launcher.dart';
@@ -17,14 +16,20 @@ import '../pages/widget/support_center_rate_widget.dart';
 import 'support_center_show_controller.dart';
 
 class SupportCenterShowPage extends StatefulWidget {
-  const SupportCenterShowPage({Key? key}) : super(key: key);
+  const SupportCenterShowPage({
+    Key? key,
+    required this.controller,
+  }) : super(key: key);
+
+  final SupportCenterShowController controller;
 
   @override
   _SupportCenterShowPageState createState() => _SupportCenterShowPageState();
 }
 
-class _SupportCenterShowPageState
-    extends ModularState<SupportCenterShowPage, SupportCenterShowController> {
+class _SupportCenterShowPageState extends State<SupportCenterShowPage> {
+  SupportCenterShowController get controller => widget.controller;
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(

--- a/lib/app/features/support_center/presentation/show/support_center_show_page.dart
+++ b/lib/app/features/support_center/presentation/show/support_center_show_page.dart
@@ -31,6 +31,14 @@ class _SupportCenterShowPageState extends State<SupportCenterShowPage> {
   SupportCenterShowController get controller => widget.controller;
 
   @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      controller.initialize();
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(

--- a/lib/app/features/support_center/presentation/show/support_center_show_page.dart
+++ b/lib/app/features/support_center/presentation/show/support_center_show_page.dart
@@ -127,7 +127,7 @@ extension _PageStateBuilder on _SupportCenterShowPageState {
                   const EdgeInsets.symmetric(horizontal: 16.0, vertical: 16.0),
               child: HtmlWidget(
                 detail.place!.htmlContent!,
-                webViewJs: false,
+                factoryBuilder: () => _DisabledWebViewJsWidgetFactory(),
                 textStyle: htmlContentTextStyle,
               ),
             ),
@@ -268,4 +268,9 @@ extension _TextStyle on _SupportCenterShowPageState {
         color: DesignSystemColors.darkIndigoThree,
         fontWeight: FontWeight.normal,
       );
+}
+
+class _DisabledWebViewJsWidgetFactory extends WidgetFactory {
+  @override
+  bool get webViewJs => false;
 }

--- a/test/app/features/support_center/presentation/show/support_center_show_page_test.dart
+++ b/test/app/features/support_center/presentation/show/support_center_show_page_test.dart
@@ -1,20 +1,16 @@
 import 'package:dartz/dartz.dart' as dz;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_modular/flutter_modular.dart';
-import 'package:flutter_modular_test/flutter_modular_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:penhas/app/app_module.dart';
 import 'package:penhas/app/core/error/failures.dart';
-import 'package:penhas/app/features/mainboard/presentation/mainboard/mainboard_module.dart';
 import 'package:penhas/app/features/support_center/domain/entities/support_center_place_detail_entity.dart';
 import 'package:penhas/app/features/support_center/domain/entities/support_center_place_entity.dart';
 import 'package:penhas/app/features/support_center/domain/usecases/support_center_usecase.dart';
 import 'package:penhas/app/features/support_center/presentation/pages/widget/support_center_detail_map_widget.dart';
 import 'package:penhas/app/features/support_center/presentation/pages/widget/support_center_rate_widget.dart';
+import 'package:penhas/app/features/support_center/presentation/show/support_center_show_controller.dart';
 import 'package:penhas/app/features/support_center/presentation/show/support_center_show_page.dart';
-import 'package:penhas/app/features/support_center/presentation/support_center_module.dart';
 import 'package:penhas/app/shared/design_system/widgets/buttons/penhas_button.dart';
 
 import '../../../../../utils/fake_google_map_platform_views_controller.dart';
@@ -22,49 +18,41 @@ import '../../../../../utils/golden_tests.dart';
 
 class MockSupportCenterUseCase extends Mock implements SupportCenterUseCase {}
 
-class MockModularNavigate extends Mock implements IModularNavigator {}
+class FakeSupportCenterPlaceEntity extends Fake
+    implements SupportCenterPlaceEntity {}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   final FakeGoogleMapPlatformViewsController fakePlatformViewsController =
       FakeGoogleMapPlatformViewsController();
 
-  late MockSupportCenterUseCase mockSupportCenterUseCase;
+  late MockSupportCenterUseCase useCase;
+  late SupportCenterPlaceEntity fakePlace;
+  late SupportCenterShowController controller;
 
   setUp(() {
     SystemChannels.platform_views.setMockMethodCallHandler(
         fakePlatformViewsController.fakePlatformViewsMethodHandler);
 
-    mockSupportCenterUseCase = MockSupportCenterUseCase();
+    useCase = MockSupportCenterUseCase();
+    fakePlace = FakeSupportCenterPlaceEntity();
 
-    initModules(
-      [
-        AppModule(),
-        MainboardModule(),
-        SupportCenterModule(),
-      ],
-      replaceBinds: [
-        Bind<SupportCenterUseCase>((i) => mockSupportCenterUseCase),
-      ],
+    controller = SupportCenterShowController(
+      supportCenterUseCase: useCase,
+      place: fakePlace,
     );
-  });
-
-  tearDown(() {
-    Modular.removeModule(AppModule());
-    Modular.removeModule(MainboardModule());
-    Modular.removeModule(SupportCenterModule());
   });
 
   group(SupportCenterShowPage, () {
     testWidgets('should show loading state when initial', (tester) async {
       // arrange
-      when(() => mockSupportCenterUseCase.detail(any())).thenAnswer(
+      when(() => useCase.detail(any())).thenAnswer(
         (_) => Future.value(dz.left(ServerFailure())),
       );
       // act
       await tester.pumpWidget(
         MaterialApp(
-          home: SupportCenterShowPage(),
+          home: SupportCenterShowPage(controller: controller),
         ),
       );
       // assert
@@ -75,22 +63,22 @@ void main() {
       // arrange
       const errorMessage =
           'O servidor está com problema neste momento, tente novamente.';
-      when(() => mockSupportCenterUseCase.detail(any())).thenAnswer(
+      when(() => useCase.detail(any())).thenAnswer(
         (_) => Future.value(dz.left(ServerFailure())),
       );
       // act
       await tester.pumpWidget(
         MaterialApp(
-          home: SupportCenterShowPage(),
+          home: SupportCenterShowPage(controller: controller),
         ),
       );
       await tester.pumpAndSettle();
-      clearInteractions(mockSupportCenterUseCase);
+      clearInteractions(useCase);
       // assert
       expect(find.text(errorMessage), findsOneWidget);
       // test retry button
       await tester.tap(find.byType(PenhasButton));
-      verify(() => mockSupportCenterUseCase.detail(any())).called(1);
+      verify(() => useCase.detail(any())).called(1);
     });
 
     testWidgets('should show loaded state with place details', (tester) async {
@@ -118,13 +106,13 @@ void main() {
         ratedByClient: 0,
       );
 
-      when(() => mockSupportCenterUseCase.detail(any())).thenAnswer(
+      when(() => useCase.detail(any())).thenAnswer(
         (_) => Future.value(dz.right(mockDetail)),
       );
       // act
       await tester.pumpWidget(
         MaterialApp(
-          home: SupportCenterShowPage(),
+          home: SupportCenterShowPage(controller: controller),
         ),
       );
       await tester.pumpAndSettle();
@@ -136,50 +124,50 @@ void main() {
       expect(find.byType(SupportCenterDetailMapWidget), findsOneWidget);
       expect(find.byType(SupportCenterRateWidget), findsOneWidget);
     });
-  });
 
-  screenshotTest(
-    'error state looks as expected',
-    fileName: 'support_center_show_page_error',
-    pageBuilder: () => SupportCenterShowPage(),
-    setUp: () {
-      when(() => mockSupportCenterUseCase.detail(any())).thenAnswer(
-        (_) => Future.value(dz.left(ServerFailure())),
-      );
-    },
-  );
+    screenshotTest(
+      'error state looks as expected',
+      fileName: 'support_center_show_page_error',
+      pageBuilder: () => SupportCenterShowPage(controller: controller),
+      setUp: () {
+        when(() => useCase.detail(any())).thenAnswer(
+          (_) => Future.value(dz.left(ServerFailure())),
+        );
+      },
+    );
 
-  screenshotTest(
-    'loaded state looks as expected',
-    fileName: 'support_center_show_page_loaded',
-    pageBuilder: () => SupportCenterShowPage(),
-    setUp: () {
-      final mockDetail = SupportCenterPlaceDetailEntity(
-        place: SupportCenterPlaceEntity(
-          ratedByClient: 0,
-          rate: '0',
-          id: '1',
-          name: 'Test Place',
-          distance: '0',
-          fullStreet: 'Test Street',
-          uf: 'SP',
-          category: SupportCenterPlaceCategoryEntity(
-            id: 1,
-            name: 'Test Category',
-            color: '#000000',
+    screenshotTest(
+      'loaded state looks as expected',
+      fileName: 'support_center_show_page_loaded',
+      pageBuilder: () => SupportCenterShowPage(controller: controller),
+      setUp: () {
+        final mockDetail = SupportCenterPlaceDetailEntity(
+          place: SupportCenterPlaceEntity(
+            ratedByClient: 0,
+            rate: '0',
+            id: '1',
+            name: 'Test Place',
+            distance: '0',
+            fullStreet: 'Test Street',
+            uf: 'SP',
+            category: SupportCenterPlaceCategoryEntity(
+              id: 1,
+              name: 'Test Category',
+              color: '#000000',
+            ),
+            typeOfPlace: 'Test Type',
+            htmlContent: 'Test Content',
+            latitude: -23.123,
+            longitude: -46.123,
           ),
-          typeOfPlace: 'Test Type',
-          htmlContent: 'Test Content',
-          latitude: -23.123,
-          longitude: -46.123,
-        ),
-        maximumRate: 5,
-        ratedByClient: 0,
-      );
+          maximumRate: 5,
+          ratedByClient: 0,
+        );
 
-      when(() => mockSupportCenterUseCase.detail(any())).thenAnswer(
-        (_) => Future.value(dz.right(mockDetail)),
-      );
-    },
-  );
+        when(() => useCase.detail(any())).thenAnswer(
+          (_) => Future.value(dz.right(mockDetail)),
+        );
+      },
+    );
+  });
 }


### PR DESCRIPTION
Este PR introduz alterações na página de exibição do centro de suporte (`support_center_show_page.dart`), no controlador (`support_center_show_controller.dart`) e no módulo principal (`mainboard_module.dart`), além de ajustes nos testes relacionados. As mudanças visam melhorar a injeção de dependências, corrigir problemas de inicialização e garantir a consistência dos testes.

### Principais Alterações:

1. **Refatoração da Injeção de Dependências:**
   - Remoção da dependência direta do `Modular` na página `SupportCenterShowPage`.
   - O controlador (`SupportCenterShowController`) agora é injetado diretamente no construtor da página, tornando o código mais explícito e testável.
   - Ajuste no `MainboardModule` para passar o controlador corretamente ao navegar para a rota `/supportcenter/show`.

2. **Correção de Inicialização do Controlador:**
   - Adição de um método `initialize` no controlador para garantir que a configuração inicial seja feita de forma assíncrona.
   - Chamada do método `initialize` no `initState` da página, utilizando `WidgetsBinding.instance.addPostFrameCallback` para garantir que a inicialização ocorra após o primeiro frame.

3. **Desabilitação do JavaScript no WebView:**
   - Criação de uma classe `_DisabledWebViewJsWidgetFactory` para desabilitar o JavaScript no `HtmlWidget`, melhorando a segurança e o desempenho.

4. **Refatoração dos Testes:**
   - Remoção da configuração do `Modular` nos testes, simplificando a inicialização do controlador.
   - O controlador é criado diretamente nos testes, eliminando a necessidade de mocks complexos e inicialização de módulos.
   - Ajuste nos testes para utilizar a nova forma de injeção do controlador.

5. **Testes de Screenshot:**
   - Os testes de screenshot foram atualizados para utilizar a nova forma de construção da página, garantindo que a renderização continue consistente.

### Issues:

Fixes #333