### PR TITLE
[refactor] Remover dependência do Modular `SupportCenterAddPage`

### DIFF
--- a/lib/app/features/mainboard/presentation/mainboard/mainboard_module.dart
+++ b/lib/app/features/mainboard/presentation/mainboard/mainboard_module.dart
@@ -74,6 +74,7 @@ import '../../../notification/data/repositories/notification_repository.dart';
 import '../../../notification/presentation/notification_controller.dart';
 import '../../../notification/presentation/notification_page.dart';
 import '../../../quiz/presentation/tutorial/stealth_mode_tutorial_page_controller.dart';
+import '../../../support_center/presentation/add/support_center_add_controller.dart';
 import '../../../support_center/presentation/add/support_center_add_page.dart';
 import '../../../support_center/presentation/list/support_center_list_page.dart';
 import '../../../support_center/presentation/show/support_center_show_controller.dart';
@@ -209,7 +210,9 @@ class MainboardModule extends Module {
   List<ModularRoute> get supportCenter => [
         ChildRoute(
           '/supportcenter/add',
-          child: (context, args) => const SupportCenterAddPage(),
+          child: (context, args) => SupportCenterAddPage(
+            controller: Modular.get<SupportCenterAddController>(),
+          ),
           transition: TransitionType.rightToLeft,
         ),
         ChildRoute(

--- a/lib/app/features/support_center/presentation/add/support_center_add_controller.dart
+++ b/lib/app/features/support_center/presentation/add/support_center_add_controller.dart
@@ -21,9 +21,7 @@ class SupportCenterAddController extends _SupportCenterAddControllerBase
 }
 
 abstract class _SupportCenterAddControllerBase with Store, MapFailureMessage {
-  _SupportCenterAddControllerBase(this._supportCenterUseCase) {
-    setup();
-  }
+  _SupportCenterAddControllerBase(this._supportCenterUseCase);
 
   String? _address;
   String _cep = '';
@@ -118,6 +116,10 @@ abstract class _SupportCenterAddControllerBase with Store, MapFailureMessage {
 
   @observable
   SupportCenterAddState state = const SupportCenterAddState.initial();
+
+  Future<void> initialize() async {
+    await setup();
+  }
 
   @computed
   PageProgressState get progressState {

--- a/lib/app/features/support_center/presentation/add/support_center_add_page.dart
+++ b/lib/app/features/support_center/presentation/add/support_center_add_page.dart
@@ -4,11 +4,11 @@ import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:mask_text_input_formatter/mask_text_input_formatter.dart';
 import 'package:mobx/mobx.dart';
-import 'package:penhas/app/shared/design_system/widgets/buttons/penhas_button.dart';
 
 import '../../../../core/extension/asuka.dart';
 import '../../../../shared/design_system/colors.dart';
 import '../../../../shared/design_system/text_styles.dart';
+import '../../../../shared/design_system/widgets/buttons/penhas_button.dart';
 import '../../../authentication/presentation/shared/page_progress_indicator.dart';
 import '../../../authentication/presentation/shared/snack_bar_handler.dart';
 import '../../../filters/domain/entities/filter_tag_entity.dart';
@@ -22,19 +22,25 @@ import '../pages/support_center_input_phone.dart';
 import 'support_center_add_controller.dart';
 
 class SupportCenterAddPage extends StatefulWidget {
-  const SupportCenterAddPage({Key? key}) : super(key: key);
+  const SupportCenterAddPage({
+    Key? key,
+    required this.controller,
+  }) : super(key: key);
+
+  final SupportCenterAddController controller;
 
   @override
   _SupportCenterAddPageState createState() => _SupportCenterAddPageState();
 }
 
-class _SupportCenterAddPageState
-    extends ModularState<SupportCenterAddPage, SupportCenterAddController>
+class _SupportCenterAddPageState extends State<SupportCenterAddPage>
     with SnackBarHandler {
   List<ReactionDisposer>? _disposers;
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
 
   final _scrollController = ScrollController();
+
+  SupportCenterAddController get controller => widget.controller;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/app/features/support_center/presentation/add/support_center_add_page.dart
+++ b/lib/app/features/support_center/presentation/add/support_center_add_page.dart
@@ -43,6 +43,14 @@ class _SupportCenterAddPageState extends State<SupportCenterAddPage>
   SupportCenterAddController get controller => widget.controller;
 
   @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      controller.initialize();
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
         key: _scaffoldKey,


### PR DESCRIPTION
Este PR introduz alterações na página de adição de pontos de apoio (`support_center_add_page.dart`), no controlador (`support_center_add_controller.dart`) e no módulo principal (`mainboard_module.dart`), além de ajustes nos testes relacionados. As mudanças visam melhorar a injeção de dependências, corrigir problemas de inicialização e garantir a consistência dos testes.

### Principais Alterações:

1. **Refatoração da Injeção de Dependências:**
   - Remoção da dependência direta do `Modular` na página `SupportCenterAddPage`.
   - O controlador (`SupportCenterAddController`) agora é injetado diretamente no construtor da página, tornando o código mais explícito e testável.
   - Ajuste no `MainboardModule` para passar o controlador corretamente ao navegar para a rota `/supportcenter/add`.

2. **Correção de Inicialização do Controlador:**
   - Adição de um método `initialize` no controlador para garantir que a configuração inicial seja feita de forma assíncrona.
   - Chamada do método `initialize` no `initState` da página, utilizando `WidgetsBinding.instance.addPostFrameCallback` para garantir que a inicialização ocorra após o primeiro frame.

3. **Reorganização de Importações:**
   - Movimentação da importação do `PenhasButton` para o local correto, mantendo a organização do código.

4. **Refatoração dos Testes:**
   - Remoção da configuração do `Modular` nos testes, simplificando a inicialização do controlador.
   - O controlador é criado diretamente nos testes, eliminando a necessidade de mocks complexos e inicialização de módulos.
   - Ajuste nos testes para utilizar a nova forma de injeção do controlador.

5. **Testes de Screenshot:**
   - Os testes de screenshot foram atualizados para utilizar a nova forma de construção da página, garantindo que a renderização continue consistente.

### Issues:

Fixes #336
