### PR TITLE
[refactor] Remover dependência do Modular `SupportCenterPage`

### DIFF
--- a/lib/app/features/support_center/presentation/support_center_controller.dart
+++ b/lib/app/features/support_center/presentation/support_center_controller.dart
@@ -29,9 +29,7 @@ class SupportCenterController extends _SupportCenterControllerBase
 }
 
 abstract class _SupportCenterControllerBase with Store, MapFailureMessage {
-  _SupportCenterControllerBase(this._supportCenterUseCase) {
-    setup();
-  }
+  _SupportCenterControllerBase(this._supportCenterUseCase);
 
   List<FilterTagEntity> _tags = [];
   late SupportCenterPlaceSessionEntity currentPlaceSession;
@@ -71,6 +69,10 @@ abstract class _SupportCenterControllerBase with Store, MapFailureMessage {
 
   @observable
   String currentKeywords = '';
+
+  Future<void> initialize() async {
+    await setup();
+  }
 
   @computed
   PageProgressState get progressState {
@@ -271,7 +273,7 @@ extension _SupportCenterControllerBasePrivate on _SupportCenterControllerBase {
     placeMarkers = Set<Marker>.from(places).asObservable();
 
     var markersPosition = placeMarkers.map((e) => e.position).toList();
-    latLngBounds = boundfromLatLng(markersPosition);
+    latLngBounds = boundFromLatLng(markersPosition);
   }
 
   void handleStateError(Failure f) {
@@ -283,7 +285,7 @@ extension _SupportCenterControllerBasePrivate on _SupportCenterControllerBase {
     state = SupportCenterState.error(mapFailureMessage(f));
   }
 
-  boundfromLatLng(List<LatLng> markersLatLngList) {
+  LatLngBounds boundFromLatLng(List<LatLng> markersLatLngList) {
     LatLngBounds brasilBounds = LatLngBounds(
         northeast: const LatLng(5.24448639569, -34.7299934555),
         southwest: const LatLng(-33.7683777809, -73.9872354804));

--- a/lib/app/features/support_center/presentation/support_center_module.dart
+++ b/lib/app/features/support_center/presentation/support_center_module.dart
@@ -49,5 +49,7 @@ class SupportCenterModule extends WidgetModule {
       ];
 
   @override
-  Widget get view => const SupportCenterPage();
+  Widget get view => SupportCenterPage(
+        controller: Modular.get<SupportCenterController>(),
+      );
 }

--- a/lib/app/features/support_center/presentation/support_center_page.dart
+++ b/lib/app/features/support_center/presentation/support_center_page.dart
@@ -27,12 +27,20 @@ class SupportCenterPage extends StatefulWidget {
 
 class _SupportCenterPageState extends State<SupportCenterPage>
     with SnackBarHandler {
+  GoogleMapController? mapController;
   List<ReactionDisposer>? _disposers;
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
-  GoogleMapController? mapController;
 
   // Getter para acessar o controller
   SupportCenterController get controller => widget.controller;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      controller.initialize();
+    });
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/app/features/support_center/presentation/support_center_page.dart
+++ b/lib/app/features/support_center/presentation/support_center_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
-import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:mobx/mobx.dart';
@@ -15,18 +14,25 @@ import 'pages/support_center_input_filter.dart';
 import 'support_center_controller.dart';
 
 class SupportCenterPage extends StatefulWidget {
-  const SupportCenterPage({Key? key}) : super(key: key);
+  const SupportCenterPage({
+    Key? key,
+    required this.controller,
+  }) : super(key: key);
+
+  final SupportCenterController controller;
 
   @override
   _SupportCenterPageState createState() => _SupportCenterPageState();
 }
 
-class _SupportCenterPageState
-    extends ModularState<SupportCenterPage, SupportCenterController>
+class _SupportCenterPageState extends State<SupportCenterPage>
     with SnackBarHandler {
   List<ReactionDisposer>? _disposers;
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
   GoogleMapController? mapController;
+
+  // Getter para acessar o controller
+  SupportCenterController get controller => widget.controller;
 
   @override
   Widget build(BuildContext context) {

--- a/test/app/features/support_center/presentation/support_center_page_test.dart
+++ b/test/app/features/support_center/presentation/support_center_page_test.dart
@@ -1,7 +1,5 @@
 import 'package:dartz/dartz.dart' as dartz;
 import 'package:flutter/services.dart';
-import 'package:flutter_modular/flutter_modular.dart';
-import 'package:flutter_modular_test/flutter_modular_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:penhas/app/core/error/failures.dart';
@@ -10,7 +8,6 @@ import 'package:penhas/app/features/support_center/domain/entities/support_cente
 import 'package:penhas/app/features/support_center/domain/entities/support_center_place_session_entity.dart';
 import 'package:penhas/app/features/support_center/domain/usecases/support_center_usecase.dart';
 import 'package:penhas/app/features/support_center/presentation/support_center_controller.dart';
-import 'package:penhas/app/features/support_center/presentation/support_center_module.dart';
 import 'package:penhas/app/features/support_center/presentation/support_center_page.dart';
 
 import '../../../../utils/fake_google_map_platform_views_controller.dart';
@@ -22,22 +19,15 @@ void main() {
       FakeGoogleMapPlatformViewsController();
 
   late SupportCenterUseCase supportCenterUseCase;
+  late SupportCenterController controller;
 
   setUp(() {
     SystemChannels.platform_views.setMockMethodCallHandler(
         fakePlatformViewsController.fakePlatformViewsMethodHandler);
 
     supportCenterUseCase = MockSupportCenterUseCase();
-
-    initModule(
-      SupportCenterModule(),
-      replaceBinds: [
-        Bind.factory(
-          (i) => SupportCenterController(
-            supportCenterUseCase: supportCenterUseCase,
-          ),
-        ),
-      ],
+    controller = SupportCenterController(
+      supportCenterUseCase: supportCenterUseCase,
     );
   });
 
@@ -52,7 +42,7 @@ void main() {
     screenshotTest(
       'should render error state when server fails',
       fileName: 'support_center_page_error_state',
-      pageBuilder: () => const SupportCenterPage(),
+      pageBuilder: () => SupportCenterPage(controller: controller),
       setUp: () {
         when(() => supportCenterUseCase.fetch(any())).thenAnswer(
           (_) => Future.value(dartz.Left(ServerFailure())),
@@ -63,7 +53,7 @@ void main() {
     screenshotTest(
       'should render success state with map and markers',
       fileName: 'support_center_page_success_state',
-      pageBuilder: () => const SupportCenterPage(),
+      pageBuilder: () => SupportCenterPage(controller: controller),
       setUp: () {
         when(() => supportCenterUseCase.fetch(any())).thenAnswer(
           (_) => Future.value(dartz.Right(centerPlace)),


### PR DESCRIPTION
Este PR introduz alterações no controlador (`support_center_controller.dart`), no módulo (`support_center_module.dart`) e na página do centro de suporte (`support_center_page.dart`), além de ajustes nos testes relacionados. As mudanças visam melhorar a injeção de dependências, corrigir problemas de inicialização e garantir a consistência dos testes.

### Principais Alterações:

1. **Refatoração da Injeção de Dependências:**
   - Remoção da dependência direta do `Modular` na página `SupportCenterPage`.
   - O controlador (`SupportCenterController`) agora é injetado diretamente no construtor da página, tornando o código mais explícito e testável.
   - Ajuste no `SupportCenterModule` para passar o controlador corretamente ao construir a página.

2. **Correção de Inicialização do Controlador:**
   - Adição de um método `initialize` no controlador para garantir que a configuração inicial seja feita de forma assíncrona.
   - Chamada do método `initialize` no `initState` da página, utilizando `WidgetsBinding.instance.addPostFrameCallback` para garantir que a inicialização ocorra após o primeiro frame.

3. **Correção de Nomenclatura:**
   - Renomeação do método `boundfromLatLng` para `boundFromLatLng`, seguindo as convenções de nomenclatura do Dart.

4. **Refatoração dos Testes:**
   - Remoção da configuração do `Modular` nos testes, simplificando a inicialização do controlador.
   - O controlador é criado diretamente nos testes, eliminando a necessidade de mocks complexos e inicialização de módulos.
   - Ajuste nos testes para utilizar a nova forma de injeção do controlador.

5. **Testes de Screenshot:**
   - Os testes de screenshot foram atualizados para utilizar a nova forma de construção da página, garantindo que a renderização continue consistente.

### Issues:

Fixes #334
