### PR TITLE
[refactor] Remover dependência do Modular `MainboardPage`

### DIFF
--- a/lib/app/features/mainboard/presentation/mainboard/mainboard_controller.dart
+++ b/lib/app/features/mainboard/presentation/mainboard/mainboard_controller.dart
@@ -22,9 +22,7 @@ abstract class _MainboardControllerBase with Store {
     Timer? notificationTimer,
   })  : _inactivityLogoutUseCase = inactivityLogoutUseCase,
         _notification = notification,
-        _syncTimer = notificationTimer {
-    setup();
-  }
+        _syncTimer = notificationTimer;
 
   final MainboardStore mainboardStore;
 
@@ -41,7 +39,7 @@ abstract class _MainboardControllerBase with Store {
   int notificationCounter = 0;
 
   @action
-  void resetNotificatinCounter() {
+  void resetNotificationCounter() {
     notificationCounter = 0;
   }
 
@@ -64,10 +62,13 @@ abstract class _MainboardControllerBase with Store {
         break;
     }
   }
-}
 
-extension _PrivateMethod on _MainboardControllerBase {
-  void setupUploadTimer() {
+  Future<void> initialize() async {
+    _setupUploadTimer();
+    _checkUnRead();
+  }
+
+  void _setupUploadTimer() {
     if (_syncTimer != null) {
       return;
     }
@@ -75,17 +76,12 @@ extension _PrivateMethod on _MainboardControllerBase {
     _syncTimer = Timer.periodic(
       Duration(seconds: notificationInterval),
       (timer) async {
-        checkUnRead();
+        _checkUnRead();
       },
     );
   }
 
-  Future<void> setup() async {
-    setupUploadTimer();
-    checkUnRead();
-  }
-
-  Future<void> checkUnRead() async {
+  Future<void> _checkUnRead() async {
     final result = await _notification.unread();
     final validField = result.getOrElse(() => const ValidField(message: '0'));
     notificationCounter = int.tryParse(validField.message!) ?? 0;

--- a/lib/app/features/mainboard/presentation/mainboard/mainboard_controller.g.dart
+++ b/lib/app/features/mainboard/presentation/mainboard/mainboard_controller.g.dart
@@ -53,11 +53,11 @@ mixin _$MainboardController on _MainboardControllerBase, Store {
       ActionController(name: '_MainboardControllerBase');
 
   @override
-  void resetNotificatinCounter() {
+  void resetNotificationCounter() {
     final _$actionInfo = _$_MainboardControllerBaseActionController.startAction(
-        name: '_MainboardControllerBase.resetNotificatinCounter');
+        name: '_MainboardControllerBase.resetNotificationCounter');
     try {
-      return super.resetNotificatinCounter();
+      return super.resetNotificationCounter();
     } finally {
       _$_MainboardControllerBaseActionController.endAction(_$actionInfo);
     }

--- a/lib/app/features/mainboard/presentation/mainboard/mainboard_module.dart
+++ b/lib/app/features/mainboard/presentation/mainboard/mainboard_module.dart
@@ -127,7 +127,9 @@ class MainboardModule extends Module {
   List<ModularRoute> get routes => [
         ChildRoute(
           Modular.initialRoute,
-          child: (_, args) => const MainboardPage(),
+          child: (_, args) => MainboardPage(
+            controller: Modular.get<MainboardController>(),
+          ),
         ),
         ...tweetRoutes,
         ...helpCenter,

--- a/lib/app/features/mainboard/presentation/mainboard/mainboard_page.dart
+++ b/lib/app/features/mainboard/presentation/mainboard/mainboard_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
-import 'package:flutter_modular/flutter_modular.dart';
 
 import '../../../main_menu/presentation/penhas_drawer_page.dart';
 import 'mainboard_controller.dart';
@@ -9,7 +8,12 @@ import 'pages/mainboard_body_page.dart';
 import 'pages/mainboard_bottom_navigation_page.dart';
 
 class MainboardPage extends StatefulWidget {
-  const MainboardPage({Key? key}) : super(key: key);
+  const MainboardPage({
+    Key? key,
+    required this.controller,
+  }) : super(key: key);
+
+  final MainboardController controller;
 
   static final mainBoardKey = GlobalKey<ScaffoldState>(
     debugLabel: 'main-board-scaffold-key',
@@ -22,9 +26,10 @@ class MainboardPage extends StatefulWidget {
   MainboardPageState createState() => MainboardPageState();
 }
 
-class MainboardPageState
-    extends ModularState<MainboardPage, MainboardController>
+class MainboardPageState extends State<MainboardPage>
     with WidgetsBindingObserver {
+  MainboardController get controller => widget.controller;
+
   @override
   void initState() {
     super.initState();

--- a/lib/app/features/mainboard/presentation/mainboard/mainboard_page.dart
+++ b/lib/app/features/mainboard/presentation/mainboard/mainboard_page.dart
@@ -34,6 +34,9 @@ class MainboardPageState extends State<MainboardPage>
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      controller.initialize();
+    });
   }
 
   @override
@@ -48,7 +51,7 @@ class MainboardPageState extends State<MainboardPage>
       builder: (context) => Scaffold(
         appBar: MainBoardAppBarPage(
           counter: controller.notificationCounter,
-          resetCounter: controller.resetNotificatinCounter,
+          resetCounter: controller.resetNotificationCounter,
           currentPage: controller.mainboardStore.selectedPage,
         ),
         drawer: const PenhasDrawerPage(),


### PR DESCRIPTION
Este PR introduz alterações na página principal do aplicativo (`mainboard_page.dart`), no controlador (`mainboard_controller.dart`), no módulo principal (`mainboard_module.dart`) e nos testes relacionados. As mudanças visam melhorar a injeção de dependências, corrigir problemas de inicialização, renomear métodos para maior clareza e garantir a consistência dos testes.

### Principais Alterações:

1. **Refatoração da Injeção de Dependências:**
   - Remoção da dependência direta do `Modular` na página `MainboardPage`.
   - O controlador (`MainboardController`) agora é injetado diretamente no construtor da página, tornando o código mais explícito e testável.
   - Ajuste no `MainboardModule` para passar o controlador corretamente ao construir a página.

2. **Correção de Inicialização do Controlador:**
   - Adição de um método `initialize` no controlador para garantir que a configuração inicial seja feita de forma assíncrona.
   - Chamada do método `initialize` no `initState` da página, utilizando `WidgetsBinding.instance.addPostFrameCallback` para garantir que a inicialização ocorra após o primeiro frame.

3. **Renomeação de Métodos:**
   - Renomeação do método `resetNotificatinCounter` para `resetNotificationCounter`, corrigindo um erro de digitação e seguindo as convenções de nomenclatura do Dart.
   - Renomeação de métodos privados para seguir as convenções de nomenclatura do Dart (`_setupUploadTimer`, `_checkUnRead`).

4. **Refatoração dos Testes:**
   - Remoção da configuração do `Modular` nos testes, simplificando a inicialização do controlador.
   - O controlador é criado diretamente nos testes, eliminando a necessidade de mocks complexos e inicialização de módulos.
   - Adição de um teste de screenshot para a página principal, embora este teste esteja marcado como `skip` devido à complexidade da tela.

### Issues:

Fixes #355
