### PR TITLE
[refactor] Remover dependência do Modular `ChatPage`

### DIFF
--- a/lib/app/features/chat/presentation/chat/chat_channel_page.dart
+++ b/lib/app/features/chat/presentation/chat/chat_channel_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
-import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_svg/svg.dart';
 
 import '../../../../shared/design_system/colors.dart';
@@ -15,13 +14,17 @@ import '../pages/channel/chat_channel_message_page.dart';
 import 'chat_channel_controller.dart';
 
 class ChatPage extends StatefulWidget {
-  const ChatPage({Key? key}) : super(key: key);
+  const ChatPage({Key? key, required this.controller}) : super(key: key);
+
+  final ChatChannelController controller;
 
   @override
   _ChatPageState createState() => _ChatPageState();
 }
 
-class _ChatPageState extends ModularState<ChatPage, ChatChannelController> {
+class _ChatPageState extends State<ChatPage> {
+  ChatChannelController get controller => widget.controller;
+
   @override
   Widget build(BuildContext context) {
     return Observer(

--- a/lib/app/features/mainboard/presentation/mainboard/mainboard_module.dart
+++ b/lib/app/features/mainboard/presentation/mainboard/mainboard_module.dart
@@ -329,12 +329,16 @@ class MainboardModule extends Module {
   List<ModularRoute> get chat => [
         ChildRoute(
           '/chat/:token',
-          child: (context, args) => const ChatPage(),
+          child: (context, args) => ChatPage(
+            controller: Modular.get<ChatChannelController>(),
+          ),
           transition: TransitionType.rightToLeft,
         ),
         ChildRoute(
           '/chat_from_feed',
-          child: (context, args) => const ChatPage(),
+          child: (context, args) => ChatPage(
+            controller: Modular.get<ChatChannelController>(),
+          ),
           transition: TransitionType.noTransition,
         ),
       ];


### PR DESCRIPTION
## Alterações Propostas

Este Pull Request introduz uma refatoração no gerenciamento do `ChatChannelController` dentro da página `ChatPage`. A principal alteração é a transição de dependências via `ModularState` para o recebimento explícito do controlador como parâmetro de construtor. Isso torna a injeção de dependência mais clara e alinhada às melhores práticas de desenvolvimento.

### Alterações Realizadas

#### 1. **Refatoração em `ChatPage`**

- A `ChatPage` agora recebe o controlador `ChatChannelController` como parâmetro obrigatório no construtor, removendo a necessidade de herdar de `ModularState`.
- A propriedade `controller` é acessada diretamente a partir do widget usando `widget.controller`.

##### Antes:

```dart
class ChatPage extends StatefulWidget {
  const ChatPage({Key? key}) : super(key: key);

  @override
  _ChatPageState createState() => _ChatPageState();
}

class _ChatPageState extends ModularState<ChatPage, ChatChannelController> {
  @override
  Widget build(BuildContext context) {
    return Observer(
      builder: (_) {
        // Código omitido...
      },
    );
  }
}
```
### Depois
```dart
class ChatPage extends StatefulWidget {
  const ChatPage({Key? key, required this.controller}) : super(key: key);

  final ChatChannelController controller;

  @override
  _ChatPageState createState() => _ChatPageState();
}

class _ChatPageState extends State<ChatPage> {
  ChatChannelController get controller => widget.controller;

  @override
  Widget build(BuildContext context) {
    return Observer(
      builder: (_) {
        // Código omitido...
      },
    );
  }
}
```
2. Atualização no MainboardModule

* A injeção do ChatChannelController foi explicitada nas rotas '/chat/:token' e '/chat_from_feed' do MainboardModule. O controlador é obtido diretamente pelo Modular.get<ChatChannelController>() e passado para a ChatPage.

### Antes
```dart
ChildRoute(
  '/chat/:token',
  child: (context, args) => const ChatPage(),
  transition: TransitionType.rightToLeft,
),
ChildRoute(
  '/chat_from_feed',
  child: (context, args) => const ChatPage(),
  transition: TransitionType.noTransition,
),
```
### Depois
```dart
ChildRoute(
  '/chat/:token',
  child: (context, args) => ChatPage(
    controller: Modular.get<ChatChannelController>(),
  ),
  transition: TransitionType.rightToLeft,
),
ChildRoute(
  '/chat_from_feed',
  child: (context, args) => ChatPage(
    controller: Modular.get<ChatChannelController>(),
  ),
  transition: TransitionType.noTransition,
),
```