### PR TITLE
[Refactor] Remover dependência do Modular `ChatMainPage`

### DIFF
--- a/lib/app/features/chat/presentation/chat_main_module.dart
+++ b/lib/app/features/chat/presentation/chat_main_module.dart
@@ -51,5 +51,7 @@ class ChatMainModule extends WidgetModule {
       ];
 
   @override
-  Widget get view => const ChatMainPage();
+  Widget get view => ChatMainPage(
+        controller: Modular.get<ChatMainController>(),
+      );
 }

--- a/lib/app/features/chat/presentation/chat_main_page.dart
+++ b/lib/app/features/chat/presentation/chat_main_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
-import 'package:flutter_modular/flutter_modular.dart';
 
 import '../../../shared/design_system/colors.dart';
 import '../domain/entities/chat_tab_item.dart';
@@ -9,14 +8,16 @@ import 'people/chat_main_people_page.dart';
 import 'talk/chat_main_talks_page.dart';
 
 class ChatMainPage extends StatefulWidget {
-  const ChatMainPage({Key? key}) : super(key: key);
+  const ChatMainPage({Key? key, required this.controller}) : super(key: key);
+
+  final ChatMainController controller;
 
   @override
   _ChatMainPageState createState() => _ChatMainPageState();
 }
 
-class _ChatMainPageState
-    extends ModularState<ChatMainPage, ChatMainController> {
+class _ChatMainPageState extends State<ChatMainPage> {
+  ChatMainController get controller => widget.controller;
   @override
   Widget build(BuildContext context) {
     return Observer(


### PR DESCRIPTION
# Sugestão de Pull Request: Refatoração da Injeção de Dependências no `ChatMainPage`

## Descrição

Este pull request tem como objetivo refatorar o uso do controlador `ChatMainController` na página `ChatMainPage`. A principal mudança é a remoção da dependência direta do `ModularState` e a introdução de injeção de dependência explícita via construtor. Essa abordagem torna o código mais claro, testável e modular.

---

## Alterações Realizadas

### 1. Modificação no `ChatMainPage`

- Foi adicionado o parâmetro obrigatório `controller` ao construtor da classe `ChatMainPage`.
- A instância do `ChatMainController` agora é acessada explicitamente via `widget.controller`.

**Antes:**

```dart
class ChatMainPage extends StatefulWidget {
  const ChatMainPage({Key? key}) : super(key: key);

  @override
  _ChatMainPageState createState() => _ChatMainPageState();
}

class _ChatMainPageState
    extends ModularState<ChatMainPage, ChatMainController> {
  @override
  Widget build(BuildContext context) {
    return Observer(
      ...
    );
  }
}
```
### Depois
```dart
class ChatMainPage extends StatefulWidget {
  const ChatMainPage({Key? key, required this.controller}) : super(key: key);

  final ChatMainController controller;

  @override
  _ChatMainPageState createState() => _ChatMainPageState();
}

class _ChatMainPageState extends State<ChatMainPage> {
  ChatMainController get controller => widget.controller;

  @override
  Widget build(BuildContext context) {
    return Observer(
      ...
    );
  }
}
```

2. Atualização no ChatMainModule

* Foi alterada a criação da página ChatMainPage para receber explicitamente o ChatMainController através do método Modular.get.

### Antes
```dart
class ChatMainModule extends WidgetModule {
  @override
  Widget get view => const ChatMainPage();
}
```

### Depois
```dart
class ChatMainModule extends WidgetModule {
  @override
  Widget get view => ChatMainPage(
        controller: Modular.get<ChatMainController>(),
      );
}
```
