### PR TITLE
[Refactor]  Alteração para Injeção Explícita no `DetailTweetPage`

### DIFF
--- a/lib/app/features/feed/presentation/detail_tweet/detail_tweet_page.dart
+++ b/lib/app/features/feed/presentation/detail_tweet/detail_tweet_page.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
-import 'package:flutter_modular/flutter_modular.dart';
 import 'package:mobx/mobx.dart';
 import 'package:scroll_to_index/scroll_to_index.dart';
 
@@ -23,19 +22,21 @@ class DetailTweetPage extends StatefulWidget {
   const DetailTweetPage({
     Key? key,
     this.title = 'DetailTweet',
-    required this.tweetController,
+    required this.tweetController, required this.detailTweetController,
   }) : super(key: key);
 
   final String title;
   final ITweetController tweetController;
+  final DetailTweetController detailTweetController;
 
   @override
   _DetailTweetPageState createState() => _DetailTweetPageState();
 }
 
 class _DetailTweetPageState
-    extends ModularState<DetailTweetPage, DetailTweetController>
+    extends State<DetailTweetPage>
     with SnackBarHandler {
+      DetailTweetController get _controller => widget.detailTweetController;
   List<ReactionDisposer>? _disposers;
   final _scrollController = AutoScrollController();
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
@@ -65,7 +66,7 @@ class _DetailTweetPageState
       d();
     }
     _scrollController.dispose();
-    controller.dispose();
+    _controller.dispose();
   }
 
   @override
@@ -96,8 +97,8 @@ class _DetailTweetPageState
   }
 
   Widget _buildTweetListWithParentButton() {
-    final String? parentId = controller.tweet?.parentId;
-    if (parentId == null || controller.isWithoutGoToParentAction) {
+    final String? parentId = _controller.tweet?.parentId;
+    if (parentId == null || _controller.isWithoutGoToParentAction) {
       return _buildTweetList();
     }
     return Column(
@@ -114,7 +115,7 @@ class _DetailTweetPageState
         horizontal: 12,
         vertical: 8,
       ),
-      itemCount: controller.listTweets.length,
+      itemCount: _controller.listTweets.length,
       controller: _scrollController,
       itemBuilder: _buildTweetItem,
       separatorBuilder: (_, __) => SizedBox(
@@ -125,7 +126,7 @@ class _DetailTweetPageState
   }
 
   Widget _buildReplyFab() {
-    if (!controller.allowReply) return Container();
+    if (!_controller.allowReply) return Container();
     return FloatingActionButton(
       heroTag: 'comment',
       backgroundColor: DesignSystemColors.ligthPurple,
@@ -145,12 +146,12 @@ class _DetailTweetPageState
   Future<void> _onRefresh() async {
     final bool isEndOfListView = _scrollController.position.extentAfter == 0;
     if (isEndOfListView) {
-      return controller.fetchNextPage();
+      return _controller.fetchNextPage();
     }
   }
 
   Widget _buildTweetItem(BuildContext context, int index) {
-    final TweetEntity tweet = controller.listTweets[index];
+    final TweetEntity tweet = _controller.listTweets[index];
     return AutoScrollTag(
       key: ValueKey(index),
       index: index,
@@ -159,15 +160,15 @@ class _DetailTweetPageState
         tweet: tweet,
         controller: widget.tweetController,
         isComment: index > 0,
-        isHighlighted: index == controller.selectedPosition,
-        onHighlightFinish: controller.highlightDone,
+        isHighlighted: index == _controller.selectedPosition,
+        onHighlightFinish: _controller.highlightDone,
       ),
     );
   }
 
   bool _handleScrollNotification(ScrollNotification notification) {
     final bool isEndOfListView = _scrollController.position.extentAfter == 0;
-    final bool isRefreshVisible = isEndOfListView && !controller.isFullyLoaded;
+    final bool isRefreshVisible = isEndOfListView && !_controller.isFullyLoaded;
 
     if (isRefreshVisible) {
       _refreshIndicatorKey.currentState?.show(atTop: false);
@@ -177,19 +178,19 @@ class _DetailTweetPageState
   }
 
   ReactionDisposer _showErrorMessage() {
-    return reaction((_) => controller.errorMessage, (String? message) {
+    return reaction((_) => _controller.errorMessage, (String? message) {
       showSnackBar(scaffoldKey: _scaffoldKey, message: message);
     });
   }
 
   void _navigateToComment() {
-    controller.reply();
+    _controller.reply();
   }
 
   void _scrollToSelectedPosition() {
-    if (controller.selectedPosition != invalidPosition) {
+    if (_controller.selectedPosition != invalidPosition) {
       _scrollController.scrollToIndex(
-        controller.selectedPosition,
+        _controller.selectedPosition,
         duration: const Duration(milliseconds: 100),
       );
     }

--- a/lib/app/features/feed/presentation/detail_tweet/detail_tweet_page.dart
+++ b/lib/app/features/feed/presentation/detail_tweet/detail_tweet_page.dart
@@ -22,7 +22,8 @@ class DetailTweetPage extends StatefulWidget {
   const DetailTweetPage({
     Key? key,
     this.title = 'DetailTweet',
-    required this.tweetController, required this.detailTweetController,
+    required this.tweetController,
+    required this.detailTweetController,
   }) : super(key: key);
 
   final String title;
@@ -33,10 +34,9 @@ class DetailTweetPage extends StatefulWidget {
   _DetailTweetPageState createState() => _DetailTweetPageState();
 }
 
-class _DetailTweetPageState
-    extends State<DetailTweetPage>
+class _DetailTweetPageState extends State<DetailTweetPage>
     with SnackBarHandler {
-      DetailTweetController get _controller => widget.detailTweetController;
+  DetailTweetController get _controller => widget.detailTweetController;
   List<ReactionDisposer>? _disposers;
   final _scrollController = AutoScrollController();
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();

--- a/lib/app/features/mainboard/presentation/mainboard/mainboard_module.dart
+++ b/lib/app/features/mainboard/presentation/mainboard/mainboard_module.dart
@@ -161,7 +161,8 @@ class MainboardModule extends Module {
         ChildRoute(
           '/tweet/:id',
           child: (context, args) => DetailTweetPage(
-            tweetController: Modular.get<ITweetController>(), detailTweetController: Modular.get<DetailTweetController>(),
+            tweetController: Modular.get<ITweetController>(),
+            detailTweetController: Modular.get<DetailTweetController>(),
           ),
           transition: TransitionType.rightToLeft,
         ),

--- a/lib/app/features/mainboard/presentation/mainboard/mainboard_module.dart
+++ b/lib/app/features/mainboard/presentation/mainboard/mainboard_module.dart
@@ -161,7 +161,7 @@ class MainboardModule extends Module {
         ChildRoute(
           '/tweet/:id',
           child: (context, args) => DetailTweetPage(
-            tweetController: Modular.get<ITweetController>(),
+            tweetController: Modular.get<ITweetController>(), detailTweetController: Modular.get<DetailTweetController>(),
           ),
           transition: TransitionType.rightToLeft,
         ),


### PR DESCRIPTION
# Refatoração: Alteração para Injeção Explícita no `DetailTweetPage`

## Descrição

Este Pull Request refatora o componente `DetailTweetPage` para adotar injeção explícita de dependências, eliminando o uso de `ModularState`. Essa abordagem promove um código mais desacoplado do framework Modular, aumenta a testabilidade e melhora a clareza geral do componente.

---

## Alterações Realizadas

### 1. Substituição do `ModularState`
- O uso do `ModularState<DetailTweetPage, DetailTweetController>` foi substituído por uma extensão direta de `State<DetailTweetPage>`.
- As dependências são acessadas diretamente através de propriedades do widget: `widget.detailTweetController` e `widget.tweetController`.

### 2. Atualização dos Métodos e Propriedades
- Todas as referências a `controller` foram substituídas por `_controller`, que é obtido diretamente da propriedade `widget.detailTweetController`.
- Os métodos e propriedades dependentes do controlador (`fetchNextPage`, `listTweets`, etc.) foram ajustados para utilizar `_controller`.

### 3. Controle de Rolagem
- A manipulação de notificações de scroll foi ajustada para utilizar `_controller` ao invés de `controller`.
- A rolagem para posição selecionada agora usa `_controller.selectedPosition`.

---

## Benefícios da Refatoração
- **Desacoplamento:** Reduz dependências explícitas do framework Modular.
- **Testabilidade:** Permite passar controladores simulados em testes unitários.
- **Clareza:** Facilita o entendimento de onde as dependências estão sendo injetadas e como são utilizadas.

---

## Alterações no Código

```diff
@@ -23,19 +22,21 @@ class DetailTweetPage extends StatefulWidget {
    required this.tweetController,
    required this.tweetController, required this.detailTweetController,
  }) : super(key: key);

  final String title;
  final ITweetController tweetController;
  final DetailTweetController detailTweetController;

  @override
  _DetailTweetPageState createState() => _DetailTweetPageState();
}

-class _DetailTweetPageState
-    extends ModularState<DetailTweetPage, DetailTweetController>
+class _DetailTweetPageState
+    extends State<DetailTweetPage>
     with SnackBarHandler {
+  DetailTweetController get _controller => widget.detailTweetController;

  Widget _buildTweetListWithParentButton() {
    final String? parentId = controller.tweet?.parentId;
    if (parentId == null || controller.isWithoutGoToParentAction) {
    final String? parentId = _controller.tweet?.parentId;
    if (parentId == null || _controller.isWithoutGoToParentAction) {

  Widget _buildReplyFab() {
    if (!controller.allowReply) return Container();
    if (!_controller.allowReply) return Container();

  void _navigateToComment() {
    controller.reply();
    _controller.reply();

  ReactionDisposer _showErrorMessage() {
    return reaction((_) => controller.errorMessage, (String? message) {
    return reaction((_) => _controller.errorMessage, (String? message) {
