### PR TITLE
Bump JDK version

### DIFF
--- a/.github/workflows/distribute-flutter-android.yml
+++ b/.github/workflows/distribute-flutter-android.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
           distribution: "zulu"
 
       - name: Setup Android SDK


### PR DESCRIPTION
Por razões de compatibilidade com Build Tools do Android, é necessário subir a versão do JDK nas actions.