### PR TITLE
[Refactor] Refatoração do `EditTrustedContactsPage` para Injeção de Dependências via Construtor

### DIFF
--- a/lib/app/features/escape_manual/escape_manual_module.dart
+++ b/lib/app/features/escape_manual/escape_manual_module.dart
@@ -27,7 +27,9 @@ class EscapeManualModule extends WidgetModule {
   List<ModularRoute> get routes => [
         ChildRoute(
           '/edit/trusted_contacts',
-          child: (_, __) => const EditTrustedContactsPage(),
+          child: (_, __) => EditTrustedContactsPage(
+            controller: Modular.get<EditTrustedContactsController>(),
+          ),
         )
       ];
 
@@ -46,7 +48,7 @@ class EscapeManualModule extends WidgetModule {
       (i) => EditTrustedContactsController(
         contacts: i.args?.data,
         escapeManualToggleFeature: EscapeManualToggleFeature(
-          modulesServices: i(),
+          modulesServices: i.get(),
         ),
       ),
     ),

--- a/lib/app/features/escape_manual/presentation/edit/edit_trusted_contacts_page.dart
+++ b/lib/app/features/escape_manual/presentation/edit/edit_trusted_contacts_page.dart
@@ -15,16 +15,20 @@ import 'edit_trusted_contacts_state.dart';
 typedef OnContactActionPressed = void Function(ContactEntity contact);
 
 class EditTrustedContactsPage extends StatefulWidget {
-  const EditTrustedContactsPage({Key? key}) : super(key: key);
+  const EditTrustedContactsPage({Key? key, required this.controller})
+      : super(key: key);
+
+  final EditTrustedContactsController controller;
 
   @override
   State<EditTrustedContactsPage> createState() =>
       _EditTrustedContactsPageState();
 }
 
-class _EditTrustedContactsPageState extends ModularState<
-    EditTrustedContactsPage, EditTrustedContactsController> {
+class _EditTrustedContactsPageState extends State<EditTrustedContactsPage> {
   ReactionDisposer? _disposer;
+
+  EditTrustedContactsController get controller => widget.controller;
 
   @override
   void didChangeDependencies() {

--- a/test/app/features/escape_manual/presentation/edit/edit_trusted_contacts_page_test.dart
+++ b/test/app/features/escape_manual/presentation/edit/edit_trusted_contacts_page_test.dart
@@ -10,7 +10,6 @@ import 'package:penhas/app/features/escape_manual/domain/escape_manual_toggle.da
 import 'package:penhas/app/features/escape_manual/presentation/edit/edit_trusted_contacts_controller.dart';
 import 'package:penhas/app/features/escape_manual/presentation/edit/edit_trusted_contacts_page.dart';
 
-import '../../../../../utils/aditional_bind_module.dart';
 import '../../../../../utils/golden_tests.dart';
 import '../../../../../utils/widget_tester_ext.dart';
 
@@ -25,6 +24,7 @@ final _contactPhone = '123456789';
 void main() {
   late IModularNavigator mockNavigator;
   late EscapeManualToggleFeature mockToggleFeature;
+  late EditTrustedContactsController controller;
   final contacts = <ContactEntity>[
     ContactEntity(
       id: _filledContactId,
@@ -32,17 +32,6 @@ void main() {
       phone: _contactPhone,
     ),
   ];
-
-  late Module module = AditionalBindModule(
-    binds: [
-      Bind.lazySingleton<EditTrustedContactsController>(
-        (_) => EditTrustedContactsController(
-          contacts: contacts,
-          escapeManualToggleFeature: mockToggleFeature,
-        ),
-      ),
-    ],
-  );
 
   setUp(() {
     mockToggleFeature = _MockEscapeManualToggleFeature();
@@ -53,11 +42,8 @@ void main() {
     when(() => mockToggleFeature.maxTrustedContacts)
         .thenAnswer((_) async => _maxTrustedContacts);
 
-    initModule(module);
-  });
-
-  tearDown(() {
-    Modular.removeModule(module);
+    controller = EditTrustedContactsController(
+        contacts: contacts, escapeManualToggleFeature: mockToggleFeature);
   });
 
   group(EditTrustedContactsPage, () {
@@ -66,7 +52,9 @@ void main() {
       (tester) async {
         // arrange
         await tester.pumpWidget(
-          buildTestableWidget(const EditTrustedContactsPage()),
+          buildTestableWidget(EditTrustedContactsPage(
+            controller: controller,
+          )),
         );
         await tester.pumpAndSettle();
 
@@ -87,7 +75,9 @@ void main() {
         // arrange
         final contactId = _nonFilledContactId;
         await tester.pumpWidget(
-          buildTestableWidget(const EditTrustedContactsPage()),
+          buildTestableWidget(EditTrustedContactsPage(
+            controller: controller,
+          )),
         );
         await tester.pumpAndSettle();
 
@@ -126,7 +116,9 @@ void main() {
         // arrange
         final contactId = _filledContactId;
         await tester.pumpWidget(
-          buildTestableWidget(const EditTrustedContactsPage()),
+          buildTestableWidget(EditTrustedContactsPage(
+            controller: controller,
+          )),
         );
         await tester.pumpAndSettle();
 
@@ -167,7 +159,7 @@ void main() {
         final newName = 'Mary';
         final newPhone = '987654321';
         await tester.pumpWidget(
-          buildTestableWidget(const EditTrustedContactsPage()),
+          buildTestableWidget(EditTrustedContactsPage(controller: controller)),
         );
         await tester.pumpAndSettle();
 
@@ -197,7 +189,7 @@ void main() {
         // arrange
         final contactId = _randomContactId;
         await tester.pumpWidget(
-          buildTestableWidget(const EditTrustedContactsPage()),
+          buildTestableWidget(EditTrustedContactsPage(controller: controller)),
         );
         await tester.pumpAndSettle();
 
@@ -228,7 +220,7 @@ void main() {
         final newName = 'Mary';
         final newPhone = '987654321';
         await tester.pumpWidget(
-          buildTestableWidget(const EditTrustedContactsPage()),
+          buildTestableWidget(EditTrustedContactsPage(controller: controller)),
         );
         await tester.pumpAndSettle();
 
@@ -258,7 +250,7 @@ void main() {
         // arrange
         final contactId = _filledContactId;
         await tester.pumpWidget(
-          buildTestableWidget(const EditTrustedContactsPage()),
+          buildTestableWidget(EditTrustedContactsPage(controller: controller)),
         );
         await tester.pumpAndSettle();
 
@@ -282,7 +274,7 @@ void main() {
         // arrange
         final contactId = _nonFilledContactId;
         await tester.pumpWidget(
-          buildTestableWidget(const EditTrustedContactsPage()),
+          buildTestableWidget(EditTrustedContactsPage(controller: controller)),
         );
         await tester.pumpAndSettle();
 
@@ -306,7 +298,7 @@ void main() {
         // arrange
         final contactId = _filledContactId;
         await tester.pumpWidget(
-          buildTestableWidget(const EditTrustedContactsPage()),
+          buildTestableWidget(EditTrustedContactsPage(controller: controller)),
         );
         await tester.pumpAndSettle();
 
@@ -334,7 +326,7 @@ void main() {
         // arrange
         final contactId = _filledContactId;
         await tester.pumpWidget(
-          buildTestableWidget(const EditTrustedContactsPage()),
+          buildTestableWidget(EditTrustedContactsPage(controller: controller)),
         );
         await tester.pumpAndSettle();
 
@@ -360,13 +352,13 @@ void main() {
       screenshotTest(
         'should render correctly',
         fileName: 'edit_trusted_contacts_page',
-        pageBuilder: () => const EditTrustedContactsPage(),
+        pageBuilder: () => EditTrustedContactsPage(controller: controller),
       );
 
       screenshotTest(
         'should show remove contact confirmation dialog',
         fileName: 'edit_trusted_contacts_page_with_remove_contact_dialog',
-        pageBuilder: () => EditTrustedContactsPage(),
+        pageBuilder: () => EditTrustedContactsPage(controller: controller),
         pumpBeforeTest: (tester) async {
           await tester.pumpAndSettle();
           await tester.tapAll(
@@ -382,7 +374,7 @@ void main() {
       screenshotTest(
         'should show update contact dialog',
         fileName: 'edit_trusted_contacts_page_with_update_contact_dialog',
-        pageBuilder: () => EditTrustedContactsPage(),
+        pageBuilder: () => EditTrustedContactsPage(controller: controller),
         pumpBeforeTest: (tester) async {
           await tester.pumpAndSettle();
           await tester.tapAll(


### PR DESCRIPTION
# 📌 [PR] Refatoração do EditTrustedContactsPage para Injeção de Dependências via Construtor

## 📋 Descrição
Este PR refatora o `EditTrustedContactsPage` para permitir a injeção de dependências via construtor, facilitando testes e modularização. Além disso, corrige a forma como o `modulesServices` é recuperado em `EscapeManualToggleFeature`.

## 🔄 Alterações Principais
- Modificação do `EditTrustedContactsPage` para receber um `EditTrustedContactsController` via construtor.
- Remoção da herança de `ModularState` na `EditTrustedContactsPage`, utilizando `widget.controller` diretamente.
- Ajuste na recuperação de `modulesServices` em `EscapeManualToggleFeature`, utilizando `i.get()` em vez de `i()`.
- Refatoração dos testes para criar a instância do `EditTrustedContactsController` diretamente, sem necessidade de módulos extras.

## 🛠 Arquivos Modificados
- `lib/app/features/escape_manual/escape_manual_module.dart`
- `lib/app/features/escape_manual/presentation/edit/edit_trusted_contacts_page.dart`
- `test/app/features/escape_manual/presentation/edit/edit_trusted_contacts_page_test.dart`

## ✅ Benefícios
- Facilita a testabilidade da `EditTrustedContactsPage`, removendo a necessidade de inicializar módulos extras nos testes.
- Melhora a organização do código, tornando a injeção de dependências mais explícita.
- Evita problemas de inicialização ao garantir que o controlador é passado corretamente.

## 🔄 Como Testar
1. Rodar os testes unitários:
   ```sh
   flutter test
