### PR TITLE
[Refactor] Refatoração do `FeedModule` e `FeedPage` para Melhor Injeção de Dependências

### DIFF
--- a/lib/app/features/feed/presentation/feed_module.dart
+++ b/lib/app/features/feed/presentation/feed_module.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 
+import '../../../core/managers/modules_sevices.dart';
 import '../../escape_manual/domain/escape_manual_toggle.dart';
+import '../../help_center/domain/usecases/security_mode_action_feature.dart';
 import '../domain/usecases/compose_tweet_fab_toggle.dart';
+import '../domain/usecases/feed_use_cases.dart';
 import '../domain/usecases/tweet_toggle_feature.dart';
 import 'feed_controller.dart';
 import 'feed_page.dart';
@@ -27,5 +30,15 @@ class FeedModule extends WidgetModule {
       ];
 
   @override
-  Widget get view => FeedPage(tweetController: Modular.get<ITweetController>());
+  Widget get view => FeedPage(
+        tweetController: Modular.get<ITweetController>(),
+        feedController: FeedController(
+            composeTweetFabToggleFeature: ComposeTweetFabToggleFeature(
+                escapeManualToggleFeature: EscapeManualToggleFeature(
+                    modulesServices: Modular.get<IAppModulesServices>()),
+                tweetToggleFeature: TweetToggleFeature(
+                    modulesServices: Modular.get<IAppModulesServices>())),
+            securityModeActionFeature: Modular.get<SecurityModeActionFeature>(),
+            useCase: Modular.get<FeedUseCases>()),
+      );
 }

--- a/lib/app/features/feed/presentation/feed_page.dart
+++ b/lib/app/features/feed/presentation/feed_page.dart
@@ -24,19 +24,22 @@ class FeedPage extends StatefulWidget {
     Key? key,
     this.title = 'Feed',
     required this.tweetController,
+    required this.feedController,
   }) : super(key: key);
 
   final String title;
   final ITweetController tweetController;
+  final FeedController feedController;
 
   @override
   _FeedPageState createState() => _FeedPageState();
 }
 
-class _FeedPageState extends ModularState<FeedPage, FeedController>
+class _FeedPageState extends State<FeedPage>
     with SnackBarHandler, AutomaticKeepAliveClientMixin {
   @override
   bool get wantKeepAlive => true;
+  FeedController get controller => widget.feedController;
 
   List<ReactionDisposer>? _disposers;
 


### PR DESCRIPTION
# 📌 [PR] Refatoração do FeedModule e FeedPage para Melhor Injeção de Dependências

## 📋 Descrição
Este PR refatora o `FeedModule` e o `FeedPage` para aprimorar a injeção de dependências e facilitar a testabilidade e manutenção do código. A mudança principal envolve a injeção explícita do `FeedController` no `FeedPage`, garantindo maior clareza e modularização.

## 🔄 Alterações Principais
- Adicionada a injeção explícita do `FeedController` no `FeedPage`.
- Removida a herança de `ModularState` no `_FeedPageState`, acessando o `FeedController` via `widget.feedController`.
- Ajustada a inicialização do `FeedController` dentro do `FeedModule`, garantindo que suas dependências (`ComposeTweetFabToggleFeature`, `SecurityModeActionFeature` e `FeedUseCases`) sejam corretamente instanciadas via `Modular.get()`.
- Importações organizadas para incluir `SecurityModeActionFeature` e `FeedUseCases`.

## 🛠 Arquivos Modificados
- `lib/app/features/feed/presentation/feed_module.dart`
- `lib/app/features/feed/presentation/feed_page.dart`

## ✅ Benefícios
- Torna a injeção de dependências mais explícita, facilitando a legibilidade e manutenção do código.
- Evita problemas com `ModularState`, promovendo uma abordagem mais flexível e modular.
- Melhora a testabilidade do `FeedPage`, permitindo a injeção de um `FeedController` mock nos testes.

## 🔄 Como Testar
1. Rodar os testes unitários para garantir que a refatoração não quebrou nenhuma funcionalidade:
   ```sh
   flutter test
