### PR TITLE
[Refactor] Refatoração do `FeedRoutingProfileChatPage` para Melhor Injeção de Dependências

### DIFF
--- a/lib/app/features/feed/presentation/routing_profile_chat/feed_routing_profile_chat_page.dart
+++ b/lib/app/features/feed/presentation/routing_profile_chat/feed_routing_profile_chat_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
-import 'package:flutter_modular/flutter_modular.dart';
 
 import '../../../../shared/design_system/colors.dart';
 import '../../../authentication/presentation/shared/page_progress_indicator.dart';
@@ -9,18 +8,24 @@ import '../../domain/states/feed_routing_state.dart';
 import 'feed_routing_profile_chat_controller.dart';
 
 class FeedRoutingProfileChatPage extends StatefulWidget {
-  const FeedRoutingProfileChatPage({Key? key}) : super(key: key);
+  const FeedRoutingProfileChatPage({Key? key, required this.controller})
+      : super(key: key);
+
+  final FeedRoutingProfileChatController controller;
 
   @override
   _FeedRoutingProfileChatPageState createState() =>
       _FeedRoutingProfileChatPageState();
 }
 
-class _FeedRoutingProfileChatPageState extends ModularState<
-    FeedRoutingProfileChatPage, FeedRoutingProfileChatController> {
+class _FeedRoutingProfileChatPageState
+    extends State<FeedRoutingProfileChatPage> {
+  FeedRoutingProfileChatController get _controller => widget.controller;
+
   @override
   Widget build(BuildContext context) {
-    return Observer(builder: (context) => pageBuilder(controller.routingState));
+    return Observer(
+        builder: (context) => pageBuilder(_controller.routingState));
   }
 }
 
@@ -59,7 +64,7 @@ extension _Bodybuilder on _FeedRoutingProfileChatPageState {
       body: SafeArea(
         child: SupportCenterGeneralError(
           message: message,
-          onPressed: controller.retry,
+          onPressed: _controller.retry,
         ),
       ),
     );

--- a/lib/app/features/mainboard/presentation/mainboard/mainboard_module.dart
+++ b/lib/app/features/mainboard/presentation/mainboard/mainboard_module.dart
@@ -180,7 +180,9 @@ class MainboardModule extends Module {
         ),
         ChildRoute(
           '/tweet/perfil_chat',
-          child: (context, args) => const FeedRoutingProfileChatPage(),
+          child: (context, args) => FeedRoutingProfileChatPage(
+            controller: Modular.get<FeedRoutingProfileChatController>(),
+          ),
           transition: TransitionType.rightToLeft,
         ),
       ];


### PR DESCRIPTION
# 📌 [PR] Refatoração do FeedRoutingProfileChatPage para Melhor Injeção de Dependências

## 📋 Descrição
Este PR refatora o `FeedRoutingProfileChatPage` para tornar a injeção de dependências mais explícita, eliminando a dependência direta do `ModularState` e permitindo a injeção manual do `FeedRoutingProfileChatController`.

## 🔄 Alterações Principais
- Adicionada a injeção explícita do `FeedRoutingProfileChatController` no `FeedRoutingProfileChatPage`.
- Removida a herança de `ModularState`, acessando o controller via `widget.controller`.
- Ajustado o `MainboardModule` para fornecer corretamente o `FeedRoutingProfileChatController` ao criar `FeedRoutingProfileChatPage`.
- Pequenas melhorias na organização do código.

## 🛠 Arquivos Modificados
- `lib/app/features/feed/presentation/routing_profile_chat/feed_routing_profile_chat_page.dart`
- `lib/app/features/mainboard/presentation/mainboard/mainboard_module.dart`

## ✅ Benefícios
- Melhora a clareza e modularização da injeção de dependências.
- Remove a necessidade de `ModularState`, permitindo maior flexibilidade na utilização do controller.
- Facilita a testabilidade do `FeedRoutingProfileChatPage`, permitindo a injeção de um controller mock para testes.

## 🔄 Como Testar
1. Rodar os testes unitários para garantir que a refatoração não quebrou nenhuma funcionalidade:
   ```sh
   flutter test
