### PR TITLE
[Refactor] Refatoração do FilterPage para Melhor Injeção de Dependências

### DIFF
--- a/lib/app/features/filters/presentation/filter_module.dart
+++ b/lib/app/features/filters/presentation/filter_module.dart
@@ -18,7 +18,9 @@ class FilterModule extends Module {
   List<ModularRoute> get routes => [
         ChildRoute(
           '/',
-          child: (context, args) => const FilterPage(),
+          child: (context, args) => FilterPage(
+            controller: Modular.get<FilterController>(),
+          ),
         )
       ];
 }

--- a/lib/app/features/filters/presentation/filter_page.dart
+++ b/lib/app/features/filters/presentation/filter_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
-import 'package:flutter_modular/flutter_modular.dart';
 
 import '../../authentication/presentation/shared/snack_bar_handler.dart';
 import '../states/filter_state.dart';
@@ -9,19 +8,21 @@ import 'pages/filter_initial_state_page.dart';
 import 'pages/filter_loaded_state_page.dart';
 
 class FilterPage extends StatefulWidget {
-  const FilterPage({Key? key}) : super(key: key);
+  const FilterPage({Key? key, required this.controller}) : super(key: key);
+
+  final FilterController controller;
 
   @override
   _FilterPageState createState() => _FilterPageState();
 }
 
-class _FilterPageState extends ModularState<FilterPage, FilterController>
-    with SnackBarHandler {
+class _FilterPageState extends State<FilterPage> with SnackBarHandler {
+  FilterController get _controller => widget.controller;
   @override
   Widget build(BuildContext context) {
     return Observer(
       builder: (context) {
-        return pageBuilder(controller.currentState);
+        return pageBuilder(_controller.currentState);
       },
     );
   }
@@ -33,8 +34,8 @@ extension _FilterPageStateMethods on _FilterPageState {
       initial: () => const FilterInitialStatePage(),
       loaded: (skill) => FilterLoadedStatePage(
         tags: skill,
-        onResetAction: controller.reset,
-        onApplyFilterAction: controller.setTags,
+        onResetAction: _controller.reset,
+        onApplyFilterAction: _controller.setTags,
       ),
     );
   }


### PR DESCRIPTION
# 📌 [PR] Refatoração do FilterPage para Melhor Injeção de Dependências

## 📋 Descrição
Este PR refatora o `FilterPage` para remover a dependência de `ModularState`, tornando a injeção do `FilterController` mais explícita e modular.

## 🔄 Alterações Principais
- Adicionada a injeção explícita do `FilterController` via construtor do `FilterPage`.
- Removida a herança de `ModularState`, acessando o controller via `widget.controller`.
- Ajustado o `FilterModule` para fornecer corretamente o `FilterController` ao criar `FilterPage`.
- Refatoração da classe `_FilterPageState` para acessar `_controller` de forma direta.

## 🛠 Arquivos Modificados
- `lib/app/features/filters/presentation/filter_module.dart`
- `lib/app/features/filters/presentation/filter_page.dart`

## ✅ Benefícios
- Torna a injeção de dependências mais explícita, facilitando a compreensão e manutenção do código.
- Melhora a testabilidade do `FilterPage`, permitindo a injeção de um controller mock para testes.
- Remove a necessidade de `ModularState`, aumentando a modularização e desacoplamento.

## 🔄 Como Testar
1. Rodar os testes unitários para garantir que a refatoração não quebrou nenhuma funcionalidade:
   ```sh
   flutter test
