### PR TITLE
[Refactor] Refatoração do `PenhasDrawerPage` para Injeção Explícita de Dependências  

### DIFF
--- a/lib/app/features/main_menu/presentation/penhas_drawer_controller.dart
+++ b/lib/app/features/main_menu/presentation/penhas_drawer_controller.dart
@@ -23,15 +23,13 @@ abstract class _PenhasDrawerControllerBase with Store {
     this._appConfigure,
     this._userProfile,
     this._modulesServices,
-  ) {
-    _init();
-  }
+  );
 
   final UserProfile _userProfile;
   final IAppConfiguration _appConfigure;
   final IAppModulesServices _modulesServices;
 
-  Future<void> _init() async {
+  Future<void> init() async {
     showSecurityOptions = await _showSecurityModeToggle();
     await _updateProfileInformation();
   }

--- a/lib/app/features/main_menu/presentation/penhas_drawer_page.dart
+++ b/lib/app/features/main_menu/presentation/penhas_drawer_page.dart
@@ -4,7 +4,6 @@ import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_svg/svg.dart';
 
 import '../../../core/pages/tutorial_scale_route.dart';
-import '../../../core/states/security_toggle_state.dart';
 import '../../../shared/design_system/colors.dart';
 import '../../../shared/design_system/text_styles.dart';
 import '../../../shared/design_system/widgets/buttons/penhas_button.dart';
@@ -14,19 +13,29 @@ import 'pages/penhas_drawer_toggle_page.dart';
 import 'penhas_drawer_controller.dart';
 
 class PenhasDrawerPage extends StatefulWidget {
-  const PenhasDrawerPage({Key? key, this.title = 'Penhas Drawer'})
+  const PenhasDrawerPage(
+      {Key? key, this.title = 'Penhas Drawer', required this.controller})
       : super(key: key);
 
   final String title;
+  final PenhasDrawerController controller;
 
   @override
   _PenhasDrawerPageState createState() => _PenhasDrawerPageState();
 }
 
-class _PenhasDrawerPageState
-    extends ModularState<PenhasDrawerPage, PenhasDrawerController> {
+class _PenhasDrawerPageState extends State<PenhasDrawerPage> {
   final double listHeight = 80;
   final Color drawerGrey = const Color.fromRGBO(239, 239, 239, 1.0);
+  PenhasDrawerController get _controller => widget.controller;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _controller.init();
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -43,15 +52,15 @@ class _PenhasDrawerPageState
               return ListView(
                 children: <Widget>[
                   PenhasDrawerHeaderPage(
-                    userName: controller.userName,
-                    userAvatar: _buildAvatar(controller.userAvatar),
+                    userName: _controller.userName,
+                    userAvatar: _buildAvatar(_controller.userAvatar),
                   ),
-                  if (controller.showSecurityOptions)
+                  if (_controller.showSecurityOptions)
                     PenhasDrawerTogglePage(
-                        state: controller.anonymousModeState),
-                  if (controller.showSecurityOptions)
-                    PenhasDrawerTogglePage(state: controller.stealthModeState),
-                  _buildStealthModeNotice(controller.showSecurityOptions),
+                        state: _controller.anonymousModeState),
+                  if (_controller.showSecurityOptions)
+                    PenhasDrawerTogglePage(state: _controller.stealthModeState),
+                  _buildStealthModeNotice(_controller.showSecurityOptions),
                   _buildItemList(
                     title: 'Informações pessoais',
                     icon: SvgPicture.asset(
@@ -97,7 +106,7 @@ class _PenhasDrawerPageState
                     constraints: const BoxConstraints(minHeight: 126.0),
                     alignment: Alignment.bottomCenter,
                     child: PenhasButton.text(
-                      onPressed: () => controller.logoutPressed(),
+                      onPressed: () => _controller.logoutPressed(),
                       child: Row(
                         mainAxisAlignment: MainAxisAlignment.center,
                         children: const <Widget>[
@@ -192,11 +201,6 @@ class _PenhasDrawerPageState
         ),
       ),
     );
-  }
-
-  Widget _buildSecurityToggle(bool isVisible, SecurityToggleState state) {
-    if (!isVisible) return Container();
-    return PenhasDrawerTogglePage(state: state);
   }
 }
 

--- a/lib/app/features/mainboard/presentation/mainboard/mainboard_module.dart
+++ b/lib/app/features/mainboard/presentation/mainboard/mainboard_module.dart
@@ -132,6 +132,7 @@ class MainboardModule extends Module {
           child: (_, args) => MainboardPage(
             controller: Modular.get<MainboardController>(),
             composeTweetController: Modular.get<ComposeTweetController>(),
+            penhasDrawerController: Modular.get<PenhasDrawerController>(),
           ),
         ),
         ...tweetRoutes,

--- a/lib/app/features/mainboard/presentation/mainboard/mainboard_page.dart
+++ b/lib/app/features/mainboard/presentation/mainboard/mainboard_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 
 import '../../../feed/presentation/compose_tweet/compose_tweet_controller.dart';
+import '../../../main_menu/presentation/penhas_drawer_controller.dart';
 import '../../../main_menu/presentation/penhas_drawer_page.dart';
 import 'mainboard_controller.dart';
 import 'pages/mainboard_app_bar_page.dart';
@@ -13,10 +14,12 @@ class MainboardPage extends StatefulWidget {
     Key? key,
     required this.controller,
     required this.composeTweetController,
+    required this.penhasDrawerController,
   }) : super(key: key);
 
   final MainboardController controller;
   final ComposeTweetController composeTweetController;
+  final PenhasDrawerController penhasDrawerController;
 
   static final mainBoardKey = GlobalKey<ScaffoldState>(
     debugLabel: 'main-board-scaffold-key',
@@ -32,6 +35,8 @@ class MainboardPage extends StatefulWidget {
 class MainboardPageState extends State<MainboardPage>
     with WidgetsBindingObserver {
   MainboardController get controller => widget.controller;
+  PenhasDrawerController get _penhasDrawerController =>
+      widget.penhasDrawerController;
   ComposeTweetController get composeTweetController =>
       widget.composeTweetController;
 
@@ -59,7 +64,9 @@ class MainboardPageState extends State<MainboardPage>
           resetCounter: controller.resetNotificationCounter,
           currentPage: controller.mainboardStore.selectedPage,
         ),
-        drawer: const PenhasDrawerPage(),
+        drawer: PenhasDrawerPage(
+          controller: _penhasDrawerController,
+        ),
         backgroundColor: Colors.white,
         body: Scaffold(
           key: MainboardPage.mainBoardKey,

--- a/test/app/features/main_menu/presentation/penhas_drawer_page_test.dart
+++ b/test/app/features/main_menu/presentation/penhas_drawer_page_test.dart
@@ -1,6 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_modular/flutter_modular.dart';
-import 'package:flutter_modular_test/flutter_modular_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:penhas/app/core/managers/app_configuration.dart';
@@ -11,7 +9,6 @@ import 'package:penhas/app/features/help_center/domain/usecases/security_mode_ac
 import 'package:penhas/app/features/main_menu/domain/usecases/user_profile.dart';
 import 'package:penhas/app/features/main_menu/presentation/penhas_drawer_controller.dart';
 import 'package:penhas/app/features/main_menu/presentation/penhas_drawer_page.dart';
-import 'package:penhas/app/features/mainboard/presentation/mainboard/mainboard_module.dart';
 
 import '../../../../utils/golden_tests.dart';
 import '../../../../utils/widget_test_steps.dart';
@@ -28,6 +25,7 @@ void main() {
   late MockAppConfiguration appConfiguration;
   late MockUserProfile userProfile;
   late MockAppModulesServices modulesServices;
+  late PenhasDrawerController penhasDrawerController;
 
   final userProfileEntity = UserProfileEntity(
     fullName: 'Penhas',
@@ -48,19 +46,10 @@ void main() {
     appConfiguration = MockAppConfiguration();
     userProfile = MockUserProfile();
     modulesServices = MockAppModulesServices();
-
-    initModule(
-      MainboardModule(),
-      replaceBinds: [
-        Bind.factory(
-          (i) => PenhasDrawerController(
-            appConfigure: appConfiguration,
-            userProfile: userProfile,
-            modulesServices: modulesServices,
-          ),
-        ),
-      ],
-    );
+    penhasDrawerController = PenhasDrawerController(
+        appConfigure: appConfiguration,
+        modulesServices: modulesServices,
+        userProfile: userProfile);
   });
 
   group(PenhasDrawerPage, () {
@@ -68,12 +57,15 @@ void main() {
       // arrange
       when(() => modulesServices.feature(
               name: SecurityModeActionFeature.featureCode))
-          .thenAnswer((_) => Future.value(null));
+          .thenAnswer((_) async => null);
+
       when(() => userProfile.currentProfile()).thenAnswer(
         (_) => Future.value(userProfileEntity),
       );
       // act
-      tester.theAppIsRunning(PenhasDrawerPage());
+      tester.theAppIsRunning(PenhasDrawerPage(
+        controller: penhasDrawerController,
+      ));
       // assert
     });
   });
@@ -81,7 +73,10 @@ void main() {
   screenshotTest(
     'should load penhas drawer page',
     fileName: 'penhas_drawer_page',
-    pageBuilder: () => Scaffold(body: PenhasDrawerPage()),
+    pageBuilder: () => Scaffold(
+        body: PenhasDrawerPage(
+      controller: penhasDrawerController,
+    )),
     setUp: () {
       when(() => modulesServices.feature(
               name: SecurityModeActionFeature.featureCode))
@@ -98,7 +93,10 @@ void main() {
   screenshotTest(
     'should show security mode toggle',
     fileName: 'penhas_drawer_page_security_mode_toggle',
-    pageBuilder: () => Scaffold(body: PenhasDrawerPage()),
+    pageBuilder: () => Scaffold(
+        body: PenhasDrawerPage(
+      controller: penhasDrawerController,
+    )),
     setUp: () {
       when(() => modulesServices.feature(
               name: SecurityModeActionFeature.featureCode))

--- a/test/app/features/mainboard/presentation/mainboard/mainboard_page_test.dart
+++ b/test/app/features/mainboard/presentation/mainboard/mainboard_page_test.dart
@@ -6,6 +6,7 @@ import 'package:mobx/mobx.dart' as mobx;
 import 'package:mocktail/mocktail.dart';
 import 'package:penhas/app/features/appstate/domain/usecases/app_preferences_use_case.dart';
 import 'package:penhas/app/features/feed/presentation/compose_tweet/compose_tweet_controller.dart';
+import 'package:penhas/app/features/main_menu/presentation/penhas_drawer_controller.dart';
 import 'package:penhas/app/features/mainboard/domain/states/mainboard_state.dart';
 import 'package:penhas/app/features/mainboard/domain/states/mainboard_store.dart';
 import 'package:penhas/app/features/mainboard/presentation/mainboard/mainboard_controller.dart';
@@ -29,6 +30,9 @@ class FakeTimer extends Fake implements Timer {}
 class MockComposeTweetController extends Mock
     implements ComposeTweetController {}
 
+class MockPenhasDrawerController extends Mock
+    implements PenhasDrawerController {}
+
 void main() {
   late MainboardController controller;
   late ComposeTweetController composeTweetController;
@@ -37,6 +41,7 @@ void main() {
   late INotificationRepository notification;
   late Timer notificationTimer;
   late PageController pageController;
+  late PenhasDrawerController penhasDrawerController;
 
   setUp(() {
     mainboardStore = MockMainboardStore();
@@ -44,6 +49,7 @@ void main() {
     notification = MockNotificationRepository();
     notificationTimer = FakeTimer();
     pageController = FakePageController();
+    penhasDrawerController = MockPenhasDrawerController();
     when(() => mainboardStore.selectedPage).thenReturn(MainboardState.feed());
     when(() => mainboardStore.pages).thenReturn(([
       MainboardState.feed(),
@@ -71,6 +77,7 @@ void main() {
       pageBuilder: () => MainboardPage(
         controller: controller,
         composeTweetController: composeTweetController,
+        penhasDrawerController: penhasDrawerController,
       ),
       skip: true,
       reason:


### PR DESCRIPTION
# 🚀 Melhorias na Inicialização do `PenhasDrawerController` e Integração com `MainboardPage`

## 📝 Descrição  

Este PR refatora a inicialização do `PenhasDrawerController`, removendo a chamada `_init()` do construtor e tornando o método público (`init()`), permitindo melhor controle sobre o ciclo de vida da inicialização.  

Além disso, a `MainboardPage` agora recebe explicitamente uma instância do `PenhasDrawerController`, garantindo que a injeção de dependências seja mais previsível e testável.  

## 🔧 Alterações Principais  

- ✅ **Refatoração**: Removida a chamada `_init()` no construtor do `PenhasDrawerController`.  
- ✅ **Novo método público**: Criado `init()` para inicialização controlada.  
- ✅ **Ajustes na `PenhasDrawerPage`**: Agora recebe `controller` como parâmetro obrigatório.  
- ✅ **Correções em testes**: Atualizados os testes para injetar corretamente o `PenhasDrawerController`.  

## 📌 Motivação  

Essa mudança melhora a testabilidade e previsibilidade do código, além de evitar que o `PenhasDrawerController` seja inicializado automaticamente sem controle explícito.  

## 🛠 Como Testar  

1. Execute os testes unitários com:  
   ```sh
   flutter test
