### PR TITLE
[Refactor] Refatoração do `ProfileSkillPage` para receber `ProfileSkillController` via construtor 

### DIFF
--- a/lib/app/features/main_menu/presentation/account/my_profile/skill/profile_skill_module.dart
+++ b/lib/app/features/main_menu/presentation/account/my_profile/skill/profile_skill_module.dart
@@ -15,7 +15,9 @@ class ProfileSkillModule extends Module {
   List<ModularRoute> get routes => [
         ChildRoute(
           '/',
-          child: (context, args) => const ProfileSkillPage(),
+          child: (context, args) => ProfileSkillPage(
+            controller: Modular.get<ProfileSkillController>(),
+          ),
         )
       ];
 }

--- a/lib/app/features/main_menu/presentation/account/my_profile/skill/profile_skill_page.dart
+++ b/lib/app/features/main_menu/presentation/account/my_profile/skill/profile_skill_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
-import 'package:flutter_modular/flutter_modular.dart';
 
 import '../../../../../authentication/presentation/shared/snack_bar_handler.dart';
 import '../../../../../filters/states/filter_state.dart';
@@ -9,20 +8,22 @@ import 'pages/profile_skill_loaded_widget.dart';
 import 'profile_skill_controller.dart';
 
 class ProfileSkillPage extends StatefulWidget {
-  const ProfileSkillPage({Key? key}) : super(key: key);
+  const ProfileSkillPage({Key? key, required this.controller})
+      : super(key: key);
+
+  final ProfileSkillController controller;
 
   @override
   _FilterPageState createState() => _FilterPageState();
 }
 
-class _FilterPageState
-    extends ModularState<ProfileSkillPage, ProfileSkillController>
-    with SnackBarHandler {
+class _FilterPageState extends State<ProfileSkillPage> with SnackBarHandler {
+  ProfileSkillController get _controller => widget.controller;
   @override
   Widget build(BuildContext context) {
     return Observer(
       builder: (context) {
-        return pageBuilder(controller.currentState);
+        return pageBuilder(_controller.currentState);
       },
     );
   }
@@ -34,8 +35,8 @@ extension _FilterPageStateMethods on _FilterPageState {
       initial: () => const ProfileSkillInitialWidget(),
       loaded: (skill) => ProfileSkillLoadedWidget(
         tags: skill,
-        onResetAction: controller.reset,
-        onApplyFilterAction: controller.setTags,
+        onResetAction: _controller.reset,
+        onApplyFilterAction: _controller.setTags,
       ),
     );
   }


### PR DESCRIPTION
## Melhorias na Injeção de Dependência para `ProfileSkillPage`

### Descrição
Este PR modifica a forma como o `ProfileSkillController` é injetado na `ProfileSkillPage`, removendo a dependência de `flutter_modular` diretamente na classe de estado e passando o controller como um parâmetro do widget.

### Mudanças Principais
- Removida a herança de `ModularState` em `_FilterPageState`.
- Adicionada a injeção do `ProfileSkillController` via construtor na `ProfileSkillPage`.
- Ajuste nos usos do `controller` para `_controller`, referenciando a instância do widget.
- Alterada a definição da rota em `ProfileSkillModule` para garantir que o `ProfileSkillController` seja fornecido corretamente.

### Motivação
- Seguir o princípio de injeção de dependências explícita, evitando dependência direta do `flutter_modular` dentro do estado do widget.
- Melhorar a testabilidade do componente, permitindo que o controller seja mockado mais facilmente.

### Alterações no Código
```diff
 diff --git a/lib/app/features/main_menu/presentation/account/my_profile/skill/profile_skill_module.dart b/lib/app/features/main_menu/presentation/account/my_profile/skill/profile_skill_module.dart
index f3e621da..334e5fe9 100644
--- a/lib/app/features/main_menu/presentation/account/my_profile/skill/profile_skill_module.dart
+++ b/lib/app/features/main_menu/presentation/account/my_profile/skill/profile_skill_module.dart
@@ -15,7 +15,7 @@ class ProfileSkillModule extends Module {
   List<ModularRoute> get routes => [
         ChildRoute(
           '/',
-          child: (context, args) => const ProfileSkillPage(),
+          child: (context, args) =>  ProfileSkillPage(controller: Modular.get<ProfileSkillController>(),),
         )
       ];
 }
 diff --git a/lib/app/features/main_menu/presentation/account/my_profile/skill/profile_skill_page.dart b/lib/app/features/main_menu/presentation/account/my_profile/skill/profile_skill_page.dart
index d5e8058c..70d200da 100644
--- a/lib/app/features/main_menu/presentation/account/my_profile/skill/profile_skill_page.dart
+++ b/lib/app/features/main_menu/presentation/account/my_profile/skill/profile_skill_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
-import 'package:flutter_modular/flutter_modular.dart';

 import '../../../../../authentication/presentation/shared/snack_bar_handler.dart';
 import '../../../../../filters/states/filter_state.dart';
@@ -9,20 +8,24 @@ import 'pages/profile_skill_loaded_widget.dart';
 import 'profile_skill_controller.dart';

 class ProfileSkillPage extends StatefulWidget {
-  const ProfileSkillPage({Key? key}) : super(key: key);
+  const ProfileSkillPage({Key? key, required this.controller}) : super(key: key);
+
+  final ProfileSkillController controller;

   @override
   _FilterPageState createState() => _FilterPageState();
 }

 class _FilterPageState
-    extends ModularState<ProfileSkillPage, ProfileSkillController>
+    extends State<ProfileSkillPage>
     with SnackBarHandler {
+
+      ProfileSkillController get _controller => widget.controller;
   @override
   Widget build(BuildContext context) {
     return Observer(
       builder: (context) {
-        return pageBuilder(controller.currentState);
+        return pageBuilder(_controller.currentState);
       },
     );
   }
@@ -34,8 +37,8 @@ extension _FilterPageStateMethods on _FilterPageState {
       initial: () => const ProfileSkillInitialWidget(),
       loaded: (skill) => ProfileSkillLoadedWidget(
         tags: skill,
-        onResetAction: controller.reset,
-        onApplyFilterAction: controller.setTags,
+        onResetAction: _controller.reset,
+        onApplyFilterAction: _controller.setTags,
       ),
     );
   }
```

### Impacto Esperado
- Melhoria na modularidade e desacoplamento do `flutter_modular` dentro do estado do widget.
- Melhor suporte para testes unitários e maior flexibilidade na inicialização da página.

### Testes
- Testes existentes devem continuar passando sem alterações.
- Testes unitários podem ser ajustados para utilizar um mock do `ProfileSkillController` ao instanciar a `ProfileSkillPage`.

### Checklist
- [x] Código segue as boas práticas do projeto
- [x] Testes foram executados e passaram
- [x] Alteração foi documentada no código quando necessário

### Revisores
@time-de-mobile, por favor, revisem e testem esta alteração. 🙌

