### PR TITLE
[Refactor] Refatoração do`ResetPasswordThreePage` para receber `ResetPasswordThreeController` via construtor 

### DIFF
--- a/lib/app/features/authentication/presentation/reset_password/pages/reset_password_three/reset_password_three_page.dart
+++ b/lib/app/features/authentication/presentation/reset_password/pages/reset_password_three/reset_password_three_page.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
-import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:mobx/mobx.dart';
 
@@ -14,21 +13,23 @@ import '../../../shared/snack_bar_handler.dart';
 import 'reset_password_three_controller.dart';
 
 class ResetPasswordThreePage extends StatefulWidget {
-  const ResetPasswordThreePage({Key? key, this.title = 'ResetPasswordThree'})
+  const ResetPasswordThreePage(
+      {Key? key, this.title = 'ResetPasswordThree', required this.controller})
       : super(key: key);
 
   final String title;
+  final ResetPasswordThreeController controller;
 
   @override
   _ResetPasswordThreePageState createState() => _ResetPasswordThreePageState();
 }
 
-class _ResetPasswordThreePageState
-    extends ModularState<ResetPasswordThreePage, ResetPasswordThreeController>
+class _ResetPasswordThreePageState extends State<ResetPasswordThreePage>
     with SnackBarHandler {
   List<ReactionDisposer>? _disposers;
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
   PageProgressState _currentState = PageProgressState.initial;
+  ResetPasswordThreeController get _controller => widget.controller;
 
   @override
   void didChangeDependencies() {
@@ -129,8 +130,8 @@ class _ResetPasswordThreePageState
     return PasswordInputField(
       labelText: 'Senha',
       hintText: 'Digite sua nova senha',
-      errorText: controller.warningPassword,
-      onChanged: controller.setPassword,
+      errorText: _controller.warningPassword,
+      onChanged: _controller.setPassword,
     );
   }
 
@@ -138,14 +139,14 @@ class _ResetPasswordThreePageState
     return PasswordInputField(
       labelText: 'Confirmação de senha',
       hintText: 'Digite sua senha novamente',
-      errorText: controller.warningConfirmationPassword,
-      onChanged: controller.setConfirmationPassword,
+      errorText: _controller.warningConfirmationPassword,
+      onChanged: _controller.setConfirmationPassword,
     );
   }
 
   Widget _buildNextButton() {
     return PenhasButton.roundedFilled(
-      onPressed: controller.nextStepPressed,
+      onPressed: _controller.nextStepPressed,
       child: const Text(
         'Salvar',
         style: kTextStyleDefaultFilledButtonLabel,
@@ -161,13 +162,14 @@ class _ResetPasswordThreePageState
   }
 
   ReactionDisposer _showErrorMessage() {
-    return reaction((_) => controller.errorMessage, (String? message) {
+    return reaction((_) => _controller.errorMessage, (String? message) {
       showSnackBar(scaffoldKey: _scaffoldKey, message: message);
     });
   }
 
   ReactionDisposer _showProgress() {
-    return reaction((_) => controller.currentState, (PageProgressState status) {
+    return reaction((_) => _controller.currentState,
+        (PageProgressState status) {
       setState(() {
         _currentState = status;
       });

--- a/lib/app/features/authentication/presentation/sign_in/sign_in_module.dart
+++ b/lib/app/features/authentication/presentation/sign_in/sign_in_module.dart
@@ -91,7 +91,9 @@ class SignInModule extends Module {
         ),
         ChildRoute(
           '/reset_password/step3',
-          child: (_, args) => const ResetPasswordThreePage(),
+          child: (_, args) => ResetPasswordThreePage(
+            controller: Modular.get<ResetPasswordThreeController>(),
+          ),
         ),
         ChildRoute(
           '/sign_in_anonymous',

--- a/test/app/features/authentication/presentation/reset_password/pages/reset_password_three/reset_password_three_page_test.dart
+++ b/test/app/features/authentication/presentation/reset_password/pages/reset_password_three/reset_password_three_page_test.dart
@@ -18,22 +18,25 @@ import '../../../../../../../utils/widget_test_steps.dart';
 import '../../../mocks/app_modules_mock.dart';
 import '../../../mocks/authentication_modules_mock.dart';
 
-class MockIChangePasswordRepository extends Mock implements IChangePasswordRepository{
+class MockIChangePasswordRepository extends Mock
+    implements IChangePasswordRepository {
   @override
-  Future<Either<Failure, ValidField>> reset({EmailAddress? emailAddress,
-    SignUpPassword? password,
-    String? resetToken}) async {
-    return Future.value(Right(ValidField())); 
+  Future<Either<Failure, ValidField>> reset(
+      {EmailAddress? emailAddress,
+      SignUpPassword? password,
+      String? resetToken}) async {
+    return Future.value(Right(ValidField()));
   }
 }
 
-
-class MockIChangePasswordRepositoryWithError extends Mock implements IChangePasswordRepository{
+class MockIChangePasswordRepositoryWithError extends Mock
+    implements IChangePasswordRepository {
   @override
-  Future<Either<Failure, ValidField>> reset({EmailAddress? emailAddress,
-    SignUpPassword? password,
-    String? resetToken}) async {
-    return Future.value(Left(ServerFailure())); 
+  Future<Either<Failure, ValidField>> reset(
+      {EmailAddress? emailAddress,
+      SignUpPassword? password,
+      String? resetToken}) async {
+    return Future.value(Left(ServerFailure()));
   }
 }
 
@@ -50,14 +53,21 @@ void main() {
     userRegisterFormField.token = 'token';
     iChangePasswordRepository = MockIChangePasswordRepository();
     userRegisterFormFieldModel = UserRegisterFormFieldModel();
-    controller = ResetPasswordThreeController(iChangePasswordRepository, userRegisterFormFieldModel, AuthenticationModulesMock.passwordValidator);
+    controller = ResetPasswordThreeController(
+        iChangePasswordRepository,
+        userRegisterFormFieldModel,
+        AuthenticationModulesMock.passwordValidator);
   });
 
   group(ResetPasswordThreePage, () {
     testWidgets(
       'shows screen widgets',
       (tester) async {
-        await theAppIsRunning(tester,  ResetPasswordThreePage(controller: controller,));
+        await theAppIsRunning(
+            tester,
+            ResetPasswordThreePage(
+              controller: controller,
+            ));
 
         // check that required widgets are present
         await iSeeText('Configure uma nova senha');
@@ -75,7 +85,11 @@ void main() {
             any(), any())).thenAnswer((i) => failure(MinLengthRule()));
 
         // Input a invalid password
-        await theAppIsRunning(tester,  ResetPasswordThreePage(controller: controller,));
+        await theAppIsRunning(
+            tester,
+            ResetPasswordThreePage(
+              controller: controller,
+            ));
         await iEnterIntoPasswordField(tester, text: 'Senha', password: '1');
         await iSeePasswordFieldErrorMessage(tester,
             text: 'Senha', message: 'Senha precisa ter no mínimo 8 caracteres');
@@ -89,7 +103,11 @@ void main() {
             .validate(any(), any())).thenAnswer((i) => success('password'));
 
         // Input a invalid password
-        await theAppIsRunning(tester,  ResetPasswordThreePage(controller: controller,));
+        await theAppIsRunning(
+            tester,
+            ResetPasswordThreePage(
+              controller: controller,
+            ));
         await iEnterIntoPasswordField(tester,
             text: 'Senha', password: 'password');
         await iEnterIntoPasswordField(tester,
@@ -104,14 +122,18 @@ void main() {
       (tester) async {
         late IChangePasswordRepository iChangePasswordRepositoryError;
 
-         iChangePasswordRepositoryError = MockIChangePasswordRepositoryWithError();
+        iChangePasswordRepositoryError =
+            MockIChangePasswordRepositoryWithError();
 
-         final controllerError =  ResetPasswordThreeController(iChangePasswordRepositoryError, userRegisterFormFieldModel, AuthenticationModulesMock.passwordValidator);
+        final controllerError = ResetPasswordThreeController(
+            iChangePasswordRepositoryError,
+            userRegisterFormFieldModel,
+            AuthenticationModulesMock.passwordValidator);
 
         when(() => AppModulesMock.modularNavigator.pushNamedAndRemoveUntil(
-  any(), any(), forRoot: any(named: 'forRoot')
-)).thenAnswer((_) async => Future.value()); 
-    
+                any(), any(), forRoot: any(named: 'forRoot')))
+            .thenAnswer((_) async => Future.value());
+
         when(() => AuthenticationModulesMock.passwordValidator
             .validate(any(), any())).thenAnswer((i) => success('password'));
 
@@ -122,7 +144,11 @@ void main() {
             )).thenFailure((_) => ServerFailure());
 
         // Capture server side error message
-        await theAppIsRunning(tester,  ResetPasswordThreePage(controller: controllerError,));
+        await theAppIsRunning(
+            tester,
+            ResetPasswordThreePage(
+              controller: controllerError,
+            ));
         await iEnterIntoPasswordField(tester,
             text: 'Senha', password: 'password');
         await iEnterIntoPasswordField(tester,
@@ -150,7 +176,11 @@ void main() {
             any(), any())).thenAnswer((i) => Future.value());
 
         // Capture server side error message
-        await theAppIsRunning(tester,  ResetPasswordThreePage(controller: controller,));
+        await theAppIsRunning(
+            tester,
+            ResetPasswordThreePage(
+              controller: controller,
+            ));
         await iEnterIntoPasswordField(tester,
             text: 'Senha', password: 'password');
         await iEnterIntoPasswordField(tester,
@@ -166,7 +196,9 @@ void main() {
       screenshotTest(
         'looks as expected',
         fileName: 'reset_password_page_step_3',
-        pageBuilder: () =>  ResetPasswordThreePage(controller: controller,),
+        pageBuilder: () => ResetPasswordThreePage(
+          controller: controller,
+        ),
       );
     });
   });

--- a/test/app/features/authentication/presentation/reset_password/pages/reset_password_three/reset_password_three_page_test.dart
+++ b/test/app/features/authentication/presentation/reset_password/pages/reset_password_three/reset_password_three_page_test.dart
@@ -1,15 +1,16 @@
-import 'package:flutter_modular/flutter_modular.dart';
-import 'package:flutter_modular_test/flutter_modular_test.dart';
+import 'package:dartz/dartz.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:penhas/app/core/entities/valid_fiel.dart';
 import 'package:penhas/app/core/error/failures.dart';
 import 'package:penhas/app/core/extension/either.dart';
+import 'package:penhas/app/features/authentication/domain/repositories/i_reset_password_repository.dart';
+import 'package:penhas/app/features/authentication/domain/usecases/email_address.dart';
 import 'package:penhas/app/features/authentication/domain/usecases/password_validator.dart';
+import 'package:penhas/app/features/authentication/domain/usecases/sign_up_password.dart';
 import 'package:penhas/app/features/authentication/presentation/reset_password/pages/reset_password_three/reset_password_three_controller.dart';
 import 'package:penhas/app/features/authentication/presentation/reset_password/pages/reset_password_three/reset_password_three_page.dart';
 import 'package:penhas/app/features/authentication/presentation/shared/user_register_form_field_model.dart';
-import 'package:penhas/app/features/authentication/presentation/sign_in/sign_in_module.dart';
 
 import '../../../../../../../utils/golden_tests.dart';
 import '../../../../../../../utils/mocktail_extension.dart';
@@ -17,38 +18,46 @@ import '../../../../../../../utils/widget_test_steps.dart';
 import '../../../mocks/app_modules_mock.dart';
 import '../../../mocks/authentication_modules_mock.dart';
 
+class MockIChangePasswordRepository extends Mock implements IChangePasswordRepository{
+  @override
+  Future<Either<Failure, ValidField>> reset({EmailAddress? emailAddress,
+    SignUpPassword? password,
+    String? resetToken}) async {
+    return Future.value(Right(ValidField())); 
+  }
+}
+
+
+class MockIChangePasswordRepositoryWithError extends Mock implements IChangePasswordRepository{
+  @override
+  Future<Either<Failure, ValidField>> reset({EmailAddress? emailAddress,
+    SignUpPassword? password,
+    String? resetToken}) async {
+    return Future.value(Left(ServerFailure())); 
+  }
+}
+
 void main() {
   late UserRegisterFormFieldModel userRegisterFormField;
+  late IChangePasswordRepository iChangePasswordRepository;
+  late ResetPasswordThreeController controller;
+  late UserRegisterFormFieldModel userRegisterFormFieldModel;
 
   setUp(() {
     AppModulesMock.init();
     AuthenticationModulesMock.init();
     userRegisterFormField = UserRegisterFormFieldModel();
     userRegisterFormField.token = 'token';
-
-    initModule(
-      SignInModule(),
-      replaceBinds: [
-        Bind<ResetPasswordThreeController>(
-          (i) => ResetPasswordThreeController(
-            AuthenticationModulesMock.changePasswordRepository,
-            userRegisterFormField,
-            AuthenticationModulesMock.passwordValidator,
-          ),
-        ),
-      ],
-    );
-  });
-
-  tearDown(() {
-    Modular.removeModule(SignInModule());
+    iChangePasswordRepository = MockIChangePasswordRepository();
+    userRegisterFormFieldModel = UserRegisterFormFieldModel();
+    controller = ResetPasswordThreeController(iChangePasswordRepository, userRegisterFormFieldModel, AuthenticationModulesMock.passwordValidator);
   });
 
   group(ResetPasswordThreePage, () {
     testWidgets(
       'shows screen widgets',
       (tester) async {
-        await theAppIsRunning(tester, const ResetPasswordThreePage());
+        await theAppIsRunning(tester,  ResetPasswordThreePage(controller: controller,));
 
         // check that required widgets are present
         await iSeeText('Configure uma nova senha');
@@ -66,7 +75,7 @@ void main() {
             any(), any())).thenAnswer((i) => failure(MinLengthRule()));
 
         // Input a invalid password
-        await theAppIsRunning(tester, const ResetPasswordThreePage());
+        await theAppIsRunning(tester,  ResetPasswordThreePage(controller: controller,));
         await iEnterIntoPasswordField(tester, text: 'Senha', password: '1');
         await iSeePasswordFieldErrorMessage(tester,
             text: 'Senha', message: 'Senha precisa ter no mínimo 8 caracteres');
@@ -80,7 +89,7 @@ void main() {
             .validate(any(), any())).thenAnswer((i) => success('password'));
 
         // Input a invalid password
-        await theAppIsRunning(tester, const ResetPasswordThreePage());
+        await theAppIsRunning(tester,  ResetPasswordThreePage(controller: controller,));
         await iEnterIntoPasswordField(tester,
             text: 'Senha', password: 'password');
         await iEnterIntoPasswordField(tester,
@@ -93,6 +102,16 @@ void main() {
     testWidgets(
       'shows an error message from server side error when resetting the password',
       (tester) async {
+        late IChangePasswordRepository iChangePasswordRepositoryError;
+
+         iChangePasswordRepositoryError = MockIChangePasswordRepositoryWithError();
+
+         final controllerError =  ResetPasswordThreeController(iChangePasswordRepositoryError, userRegisterFormFieldModel, AuthenticationModulesMock.passwordValidator);
+
+        when(() => AppModulesMock.modularNavigator.pushNamedAndRemoveUntil(
+  any(), any(), forRoot: any(named: 'forRoot')
+)).thenAnswer((_) async => Future.value()); 
+    
         when(() => AuthenticationModulesMock.passwordValidator
             .validate(any(), any())).thenAnswer((i) => success('password'));
 
@@ -103,12 +122,13 @@ void main() {
             )).thenFailure((_) => ServerFailure());
 
         // Capture server side error message
-        await theAppIsRunning(tester, const ResetPasswordThreePage());
+        await theAppIsRunning(tester,  ResetPasswordThreePage(controller: controllerError,));
         await iEnterIntoPasswordField(tester,
             text: 'Senha', password: 'password');
         await iEnterIntoPasswordField(tester,
             text: 'Confirmação de senha', password: 'password');
         await iTapText(tester, text: 'Salvar');
+        await tester.pumpAndSettle();
         await iSeeText(
             'O servidor está com problema neste momento, tente novamente.');
       },
@@ -130,7 +150,7 @@ void main() {
             any(), any())).thenAnswer((i) => Future.value());
 
         // Capture server side error message
-        await theAppIsRunning(tester, const ResetPasswordThreePage());
+        await theAppIsRunning(tester,  ResetPasswordThreePage(controller: controller,));
         await iEnterIntoPasswordField(tester,
             text: 'Senha', password: 'password');
         await iEnterIntoPasswordField(tester,
@@ -146,7 +166,7 @@ void main() {
       screenshotTest(
         'looks as expected',
         fileName: 'reset_password_page_step_3',
-        pageBuilder: () => const ResetPasswordThreePage(),
+        pageBuilder: () =>  ResetPasswordThreePage(controller: controller,),
       );
     });
   });


### PR DESCRIPTION
# 🛠️ Refatoração: Injeção de Dependência em `ResetPasswordThreePage`

## 📌 Descrição  

Este PR remove a dependência do `flutter_modular` na `ResetPasswordThreePage`, tornando o `ResetPasswordThreeController` uma injeção explícita via construtor. Além disso, foram feitas alterações para refletir essa mudança em módulos de navegação e testes.

## 🔄 Alterações Principais  

1. **Remoção de `flutter_modular` na `ResetPasswordThreePage`**  
   - O controller agora é passado via construtor (`required this.controller`).  
   - Métodos e acessos a propriedades do controller foram ajustados.  

2. **Atualização do `SignInModule`**  
   - Agora passa explicitamente o `ResetPasswordThreeController` ao instanciar a `ResetPasswordThreePage`.  

3. **Ajustes nos testes**  
   - Removida a dependência do `flutter_modular_test`.  
   - Criados mocks para `IChangePasswordRepository`.  
   - Testes foram atualizados para injetar manualmente o `ResetPasswordThreeController`.  

## 🧩 Motivação  

A injeção direta melhora a testabilidade e reduz o acoplamento com `flutter_modular`, permitindo maior flexibilidade no gerenciamento de dependências.

## ✅ Como testar  

1. Rodar os testes unitários para garantir que a funcionalidade continua intacta:  
   ```sh
   flutter test
