### PR TITLE
[Refactor] Refatoracao: Injecao de Dependencia em `SignInAnonymousPage` 

### DIFF
--- a/lib/app/features/authentication/presentation/sign_in/sign_in_module.dart
+++ b/lib/app/features/authentication/presentation/sign_in/sign_in_module.dart
@@ -99,7 +99,9 @@ class SignInModule extends Module {
         ),
         ChildRoute(
           '/sign_in_anonymous',
-          child: (_, args) => const SignInAnonymousPage(),
+          child: (_, args) => SignInAnonymousPage(
+            controller: Modular.get<SignInAnonymousController>(),
+          ),
         ),
         ChildRoute(
           '/sign_in_stealth',

--- a/lib/app/features/authentication/presentation/sign_in_anonymous/sign_in_anonymous_page.dart
+++ b/lib/app/features/authentication/presentation/sign_in_anonymous/sign_in_anonymous_page.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
-import 'package:flutter_modular/flutter_modular.dart';
 import 'package:mobx/mobx.dart';
 
 import '../../../../shared/design_system/linear_gradient_design_system.dart';
@@ -15,30 +14,32 @@ import '../shared/snack_bar_handler.dart';
 import 'sign_in_anonymous_controller.dart';
 
 class SignInAnonymousPage extends StatefulWidget {
-  const SignInAnonymousPage({Key? key, this.title = 'Authentication'})
+  const SignInAnonymousPage(
+      {Key? key, this.title = 'Authentication', required this.controller})
       : super(key: key);
 
   final String title;
+  final SignInAnonymousController controller;
 
   @override
   _SignInAnonymousPage createState() => _SignInAnonymousPage();
 }
 
-class _SignInAnonymousPage
-    extends ModularState<SignInAnonymousPage, SignInAnonymousController>
+class _SignInAnonymousPage extends State<SignInAnonymousPage>
     with SnackBarHandler {
   List<ReactionDisposer>? _disposers;
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
   PageProgressState _currentState = PageProgressState.initial;
+  SignInAnonymousController get _controller => widget.controller;
 
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
     _disposers ??= [
-      reaction((_) => controller.errorMessage, (String? message) {
+      reaction((_) => _controller.errorMessage, (String? message) {
         showSnackBar(scaffoldKey: _scaffoldKey, message: message);
       }),
-      reaction((_) => controller.currentState, (PageProgressState status) {
+      reaction((_) => _controller.currentState, (PageProgressState status) {
         setState(() {
           _currentState = status;
         });
@@ -105,14 +106,14 @@ class _SignInAnonymousPage
         Padding(
           padding: const EdgeInsets.only(top: 52.0),
           child: Text(
-            controller.userGreetings,
+            _controller.userGreetings,
             style: kTextStyleRegisterHeaderLabelStyle,
           ),
         ),
         Padding(
           padding: const EdgeInsets.only(bottom: 30, top: 30),
           child: Text(
-            controller.userEmail!,
+            _controller.userEmail!,
             style: kTextStyleRegisterSubtitleLabelStyle,
           ),
         )
@@ -124,8 +125,8 @@ class _SignInAnonymousPage
     return PasswordInputField(
       labelText: 'Senha',
       hintText: 'Digite sua senha',
-      errorText: controller.warningPassword,
-      onChanged: controller.setPassword,
+      errorText: _controller.warningPassword,
+      onChanged: _controller.setPassword,
     );
   }
 
@@ -133,7 +134,7 @@ class _SignInAnonymousPage
     return Padding(
       padding: const EdgeInsets.only(top: 32.0),
       child: LoginButton(
-        onChanged: () async => controller.signInWithEmailAndPasswordPressed(),
+        onChanged: () async => _controller.signInWithEmailAndPasswordPressed(),
       ),
     );
   }
@@ -144,7 +145,7 @@ class _SignInAnonymousPage
       child: SizedBox(
         height: 44.0,
         child: PenhasButton.text(
-          onPressed: () => controller.resetPasswordPressed(),
+          onPressed: () => _controller.resetPasswordPressed(),
           child: const Text(
             'Esqueci minha senha',
             style: kTextStyleFeedTweetShowReply,
@@ -160,7 +161,7 @@ class _SignInAnonymousPage
       child: SizedBox(
         height: 44.0,
         child: PenhasButton.text(
-          onPressed: () => controller.changeAccount(),
+          onPressed: () => _controller.changeAccount(),
           child: const Text(
             'Acessar outra conta',
             style: kTextStyleFeedTweetShowReply,

--- a/lib/app/features/zodiac/presentation/zodiac_module.dart
+++ b/lib/app/features/zodiac/presentation/zodiac_module.dart
@@ -64,5 +64,8 @@ class ZodiacModule extends WidgetModule {
       ];
 
   @override
-  Widget get view => ZodiacPage(controller: Modular.get<ZodiacController>());
+  Widget get view => ZodiacPage(
+      controller: ZodiacController(
+          securityAction: Modular.get<StealthSecurityAction>(),
+          userProfileStore: Modular.get<LocalStore<UserProfileEntity>>()));
 }

--- a/test/app/features/authentication/presentation/sign_in_anonymous/sign_in_anonymous_page_test.dart
+++ b/test/app/features/authentication/presentation/sign_in_anonymous/sign_in_anonymous_page_test.dart
@@ -41,10 +41,10 @@ void main() {
     );
 
     controller = SignInAnonymousController(
-          authenticateAnonymousUserUseCase:
-              AuthenticationModulesMock.authenticateAnonymousUserUseCase,
-          passwordValidator: AuthenticationModulesMock.passwordValidator,
-          userProfileStore: AppModulesMock.userProfileStore,
+      authenticateAnonymousUserUseCase:
+          AuthenticationModulesMock.authenticateAnonymousUserUseCase,
+      passwordValidator: AuthenticationModulesMock.passwordValidator,
+      userProfileStore: AppModulesMock.userProfileStore,
     );
   });
 
@@ -56,7 +56,11 @@ void main() {
     testWidgets(
       'shows screen widgets',
       (tester) async {
-        await theAppIsRunning(tester,  SignInAnonymousPage(controller: controller,));
+        await theAppIsRunning(
+            tester,
+            SignInAnonymousPage(
+              controller: controller,
+            ));
 
         // check if necessary widgets are present
         await iSeePasswordField(text: 'Senha');
@@ -76,7 +80,11 @@ void main() {
         when(() => AuthenticationModulesMock.passwordValidator
             .validate(any(), any())).thenAnswer((i) => failure(EmptyRule()));
 
-        await theAppIsRunning(tester,  SignInAnonymousPage(controller: controller,));
+        await theAppIsRunning(
+            tester,
+            SignInAnonymousPage(
+              controller: controller,
+            ));
         await iDontSeeText(errorMessage);
         await iEnterIntoPasswordField(tester,
             text: 'Senha', password: validPassword);
@@ -115,7 +123,11 @@ void main() {
               .pushReplacementNamed(any(), arguments: any(named: 'arguments')),
         ).thenAnswer((_) => Future.value());
 
-        await theAppIsRunning(tester,  SignInAnonymousPage(controller: controller,));
+        await theAppIsRunning(
+            tester,
+            SignInAnonymousPage(
+              controller: controller,
+            ));
         await iEnterIntoPasswordField(tester,
             text: 'Senha', password: validPassword);
         await iTapText(tester, text: 'Entrar');
@@ -133,7 +145,11 @@ void main() {
               .pushNamed(any(), arguments: any(named: 'arguments')),
         ).thenAnswer((_) => Future.value());
 
-        await theAppIsRunning(tester,  SignInAnonymousPage(controller: controller,));
+        await theAppIsRunning(
+            tester,
+            SignInAnonymousPage(
+              controller: controller,
+            ));
         await iTapText(tester, text: 'Esqueci minha senha');
 
         verify(() => AppModulesMock.modularNavigator
@@ -149,7 +165,11 @@ void main() {
               .pushNamed(any(), arguments: any(named: 'arguments')),
         ).thenAnswer((_) => Future.value());
 
-        await theAppIsRunning(tester,  SignInAnonymousPage(controller: controller,));
+        await theAppIsRunning(
+            tester,
+            SignInAnonymousPage(
+              controller: controller,
+            ));
         await iTapText(tester, text: 'Acessar outra conta');
 
         verify(() =>
@@ -162,7 +182,9 @@ void main() {
       screenshotTest(
         'looks as expected',
         fileName: 'sign_in_anonymous_page',
-        pageBuilder: () =>  SignInAnonymousPage(controller: controller,),
+        pageBuilder: () => SignInAnonymousPage(
+          controller: controller,
+        ),
       );
     });
   });

--- a/test/app/features/authentication/presentation/sign_in_anonymous/sign_in_anonymous_page_test.dart
+++ b/test/app/features/authentication/presentation/sign_in_anonymous/sign_in_anonymous_page_test.dart
@@ -1,11 +1,9 @@
 import 'package:flutter_modular/flutter_modular.dart';
-import 'package:flutter_modular_test/flutter_modular_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:penhas/app/core/extension/either.dart';
 import 'package:penhas/app/features/appstate/domain/entities/user_profile_entity.dart';
 import 'package:penhas/app/features/authentication/domain/entities/session_entity.dart';
-import 'package:penhas/app/features/authentication/domain/usecases/authenticate_user.dart';
 import 'package:penhas/app/features/authentication/domain/usecases/password_validator.dart';
 import 'package:penhas/app/features/authentication/presentation/sign_in/sign_in_module.dart';
 import 'package:penhas/app/features/authentication/presentation/sign_in_anonymous/sign_in_anonymous_controller.dart';
@@ -18,6 +16,7 @@ import '../mocks/app_modules_mock.dart';
 import '../mocks/authentication_modules_mock.dart';
 
 void main() {
+  late SignInAnonymousController controller;
   setUp(() {
     AppModulesMock.init();
     AuthenticationModulesMock.init();
@@ -41,20 +40,12 @@ void main() {
       (i) async => userProfileEntity,
     );
 
-    initModule(SignInModule(), replaceBinds: [
-      Bind<SignInAnonymousController>(
-        (i) => SignInAnonymousController(
+    controller = SignInAnonymousController(
           authenticateAnonymousUserUseCase:
               AuthenticationModulesMock.authenticateAnonymousUserUseCase,
           passwordValidator: AuthenticationModulesMock.passwordValidator,
           userProfileStore: AppModulesMock.userProfileStore,
-        ),
-      ),
-      Bind<AuthenticateAnonymousUserUseCase>((i) =>
-          AuthenticateAnonymousUserUseCase(
-              authenticationRepository: i.get(),
-              loginOfflineToggleFeature: i.get())),
-    ]);
+    );
   });
 
   tearDown(() {
@@ -65,7 +56,7 @@ void main() {
     testWidgets(
       'shows screen widgets',
       (tester) async {
-        await theAppIsRunning(tester, const SignInAnonymousPage());
+        await theAppIsRunning(tester,  SignInAnonymousPage(controller: controller,));
 
         // check if necessary widgets are present
         await iSeePasswordField(text: 'Senha');
@@ -85,7 +76,7 @@ void main() {
         when(() => AuthenticationModulesMock.passwordValidator
             .validate(any(), any())).thenAnswer((i) => failure(EmptyRule()));
 
-        await theAppIsRunning(tester, const SignInAnonymousPage());
+        await theAppIsRunning(tester,  SignInAnonymousPage(controller: controller,));
         await iDontSeeText(errorMessage);
         await iEnterIntoPasswordField(tester,
             text: 'Senha', password: validPassword);
@@ -124,7 +115,7 @@ void main() {
               .pushReplacementNamed(any(), arguments: any(named: 'arguments')),
         ).thenAnswer((_) => Future.value());
 
-        await theAppIsRunning(tester, const SignInAnonymousPage());
+        await theAppIsRunning(tester,  SignInAnonymousPage(controller: controller,));
         await iEnterIntoPasswordField(tester,
             text: 'Senha', password: validPassword);
         await iTapText(tester, text: 'Entrar');
@@ -142,7 +133,7 @@ void main() {
               .pushNamed(any(), arguments: any(named: 'arguments')),
         ).thenAnswer((_) => Future.value());
 
-        await theAppIsRunning(tester, const SignInAnonymousPage());
+        await theAppIsRunning(tester,  SignInAnonymousPage(controller: controller,));
         await iTapText(tester, text: 'Esqueci minha senha');
 
         verify(() => AppModulesMock.modularNavigator
@@ -158,7 +149,7 @@ void main() {
               .pushNamed(any(), arguments: any(named: 'arguments')),
         ).thenAnswer((_) => Future.value());
 
-        await theAppIsRunning(tester, const SignInAnonymousPage());
+        await theAppIsRunning(tester,  SignInAnonymousPage(controller: controller,));
         await iTapText(tester, text: 'Acessar outra conta');
 
         verify(() =>
@@ -171,7 +162,7 @@ void main() {
       screenshotTest(
         'looks as expected',
         fileName: 'sign_in_anonymous_page',
-        pageBuilder: () => const SignInAnonymousPage(),
+        pageBuilder: () =>  SignInAnonymousPage(controller: controller,),
       );
     });
   });


### PR DESCRIPTION
# 📌 Sugestão de Pull Request

## 📝 Descrição  

Esta PR refatora a `SignInAnonymousPage` para remover a dependência direta do `Modular` e passar o `SignInAnonymousController` via injeção de dependência. Além disso, ajusta os testes para refletirem essa mudança.  

## 🔄 Alterações realizadas  

- **`SignInModule`**:  
  - Adicionada a injeção do `SignInAnonymousController` no `ChildRoute` da `SignInAnonymousPage`.  

- **`SignInAnonymousPage`**:  
  - Agora recebe o `SignInAnonymousController` como um parâmetro obrigatório no construtor.  
  - Remove o mixin `ModularState`, substituindo as referências diretas ao `controller` por `_controller`, que é injetado via `widget.controller`.  

- **Testes (`sign_in_anonymous_page_test.dart`)**:  
  - Ajustado o `setUp()` para inicializar e injetar o `SignInAnonymousController` corretamente.  
  - Atualizadas chamadas de `SignInAnonymousPage()` nos testes para garantir que o `controller` seja passado corretamente.  

## ✅ Como testar  

1. Rodar os testes unitários:  

   ```sh
   flutter test test/app/features/authentication/presentation/sign_in_anonymous/sign_in_anonymous_page_test.dart
