### PR TITLE
[Refactor] Refatoração da Página `SignUp` pare receber `SignUpController` por construtor

### DIFF
--- a/lib/app/features/authentication/presentation/sign_in/sign_in_module.dart
+++ b/lib/app/features/authentication/presentation/sign_in/sign_in_module.dart
@@ -70,7 +70,9 @@ class SignInModule extends Module {
                 )),
         ChildRoute(
           '/signup',
-          child: (_, args) => const SignUpPage(),
+          child: (_, args) => SignUpPage(
+            controller: Modular.get<SignUpController>(),
+          ),
           transition: TransitionType.rightToLeft,
         ),
         ChildRoute(

--- a/lib/app/features/authentication/presentation/sign_in/sign_up/sign_up_page.dart
+++ b/lib/app/features/authentication/presentation/sign_in/sign_up/sign_up_page.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
-import 'package:flutter_modular/flutter_modular.dart';
 import 'package:intl/intl.dart';
 import 'package:mask_text_input_formatter/mask_text_input_formatter.dart';
 import 'package:mobx/mobx.dart';
@@ -17,19 +16,21 @@ import '../../shared/snack_bar_handler.dart';
 import 'sign_up_controller.dart';
 
 class SignUpPage extends StatefulWidget {
-  const SignUpPage({Key? key, this.title = 'SignUp'}) : super(key: key);
+  const SignUpPage({Key? key, this.title = 'SignUp', required this.controller})
+      : super(key: key);
 
   final String title;
+  final SignUpController controller;
 
   @override
   _SignUpPageState createState() => _SignUpPageState();
 }
 
-class _SignUpPageState extends ModularState<SignUpPage, SignUpController>
-    with SnackBarHandler {
+class _SignUpPageState extends State<SignUpPage> with SnackBarHandler {
   List<ReactionDisposer>? _disposers;
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
   PageProgressState _currentState = PageProgressState.initial;
+  SignUpController get _controller => widget.controller;
 
   final format = DateFormat('dd/MM/yyyy');
 
@@ -126,12 +127,12 @@ class _SignUpPageState extends ModularState<SignUpPage, SignUpController>
     return SingleTextInput(
       key: const Key('sign_up_cep'),
       inputFormatter: _maskCep,
-      onChanged: controller.setCep,
+      onChanged: _controller.setCep,
       keyboardType: TextInputType.number,
       boxDecoration: WhiteBoxDecorationStyle(
         hintText: 'CEP',
         labelText: 'CEP',
-        errorText: controller.warningCep,
+        errorText: _controller.warningCep,
       ),
     );
   }
@@ -167,22 +168,22 @@ class _SignUpPageState extends ModularState<SignUpPage, SignUpController>
     return SingleTextInput(
       key: const Key('sign_up_cpf'),
       inputFormatter: _maskCpf,
-      onChanged: controller.setCpf,
+      onChanged: _controller.setCpf,
       keyboardType: TextInputType.number,
       boxDecoration: WhiteBoxDecorationStyle(
         hintText: 'CPF',
         labelText: 'CPF',
-        errorText: controller.warningCpf,
+        errorText: _controller.warningCpf,
       ),
     );
   }
 
   SingleTextInput _buildFullName() {
     return SingleTextInput(
-      onChanged: controller.setFullname,
+      onChanged: _controller.setFullname,
       boxDecoration: WhiteBoxDecorationStyle(
         labelText: 'Nome completo',
-        errorText: controller.warningFullname,
+        errorText: _controller.warningFullname,
       ),
     );
   }
@@ -216,19 +217,19 @@ class _SignUpPageState extends ModularState<SignUpPage, SignUpController>
   SingleTextInput _builBirthday() {
     return SingleTextInput(
       inputFormatter: _maskDate,
-      onChanged: controller.setBirthday,
+      onChanged: _controller.setBirthday,
       keyboardType: TextInputType.datetime,
       boxDecoration: WhiteBoxDecorationStyle(
         hintText: 'Dia / Mês / Ano',
         labelText: 'Data de nascimento',
-        errorText: controller.warningBirthday,
+        errorText: _controller.warningBirthday,
       ),
     );
   }
 
   Widget _buildNextButton() {
     return PenhasButton.roundedFilled(
-      onPressed: () => controller.nextStepPressed(),
+      onPressed: () => _controller.nextStepPressed(),
       child: const Text(
         'Próximo',
         style: kTextStyleDefaultFilledButtonLabel,
@@ -237,13 +238,14 @@ class _SignUpPageState extends ModularState<SignUpPage, SignUpController>
   }
 
   ReactionDisposer _showErrorMessage() {
-    return reaction((_) => controller.errorMessage, (String? message) {
+    return reaction((_) => _controller.errorMessage, (String? message) {
       showSnackBar(scaffoldKey: _scaffoldKey, message: message);
     });
   }
 
   ReactionDisposer _showProgress() {
-    return reaction((_) => controller.currentState, (PageProgressState status) {
+    return reaction((_) => _controller.currentState,
+        (PageProgressState status) {
       setState(() {
         _currentState = status;
       });

--- a/test/app/features/authentication/presentation/sign_in/sign_up/sign_up_page_test.dart
+++ b/test/app/features/authentication/presentation/sign_in/sign_up/sign_up_page_test.dart
@@ -1,11 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_modular/flutter_modular.dart';
-import 'package:flutter_modular_test/flutter_modular_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:penhas/app/core/entities/valid_fiel.dart';
 import 'package:penhas/app/core/error/failures.dart';
-import 'package:penhas/app/features/authentication/presentation/sign_in/sign_in_module.dart';
 import 'package:penhas/app/features/authentication/presentation/sign_in/sign_up/sign_up_controller.dart';
 import 'package:penhas/app/features/authentication/presentation/sign_in/sign_up/sign_up_page.dart';
 
@@ -18,31 +15,23 @@ import '../../mocks/authentication_modules_mock.dart';
 void main() {
   late Key cepKey;
   late Key cpfKey;
+  late SignUpController controller;
 
   setUp(() {
     AppModulesMock.init();
     AuthenticationModulesMock.init();
     cepKey = const Key('sign_up_cep');
     cpfKey = const Key('sign_up_cpf');
-
-    initModule(SignInModule(), replaceBinds: [
-      Bind<SignUpController>(
-        (i) =>
-            SignUpController(AuthenticationModulesMock.userRegisterRepository),
-      ),
-    ]);
+    controller = SignUpController(AuthenticationModulesMock.userRegisterRepository);
   });
 
-  tearDown(() {
-    Modular.removeModule(SignInModule());
-  });
   group(
     SignUpPage,
     () {
       testWidgets(
         'shows screen widgets',
         (tester) async {
-          await theAppIsRunning(tester, const SignUpPage());
+          await theAppIsRunning(tester, SignUpPage(controller: controller,));
           await iSeeText('Crie sua conta');
           await iSeeText(
               'Para sua segurança pedimos aos nossos usuários o CPF.');
@@ -58,7 +47,7 @@ void main() {
       testWidgets(
           'displays a warning message if an invalid value is entered in a widget',
           (tester) async {
-        await theAppIsRunning(tester, const SignUpPage());
+        await theAppIsRunning(tester, SignUpPage(controller: controller));
         await iTapText(tester, text: 'Próximo');
         await iSeeSingleTextInputErrorMessage(tester,
             text: 'Nome completo', message: 'Nome inválido para o sistema');
@@ -82,7 +71,7 @@ void main() {
             ),
           ).thenFailure((_) => ServerFailure());
 
-          await theAppIsRunning(tester, const SignUpPage());
+          await theAppIsRunning(tester, SignUpPage(controller: controller));
           await iEnterIntoSingleTextInput(
             tester,
             text: 'Nome completo',
@@ -125,7 +114,7 @@ void main() {
                   .pushNamed(any(), arguments: any(named: 'arguments')))
               .thenAnswer((i) => Future.value());
 
-          await theAppIsRunning(tester, const SignUpPage());
+          await theAppIsRunning(tester, SignUpPage(controller: controller));
           await iEnterIntoSingleTextInput(
             tester,
             text: 'Nome completo',
@@ -156,7 +145,7 @@ void main() {
       screenshotTest(
         'looks as expected',
         fileName: 'sign_up_step_1_page',
-        pageBuilder: () => const SignUpPage(),
+        pageBuilder: () => SignUpPage(controller: controller),
       );
     },
   );

--- a/test/app/features/authentication/presentation/sign_in/sign_up/sign_up_page_test.dart
+++ b/test/app/features/authentication/presentation/sign_in/sign_up/sign_up_page_test.dart
@@ -22,7 +22,8 @@ void main() {
     AuthenticationModulesMock.init();
     cepKey = const Key('sign_up_cep');
     cpfKey = const Key('sign_up_cpf');
-    controller = SignUpController(AuthenticationModulesMock.userRegisterRepository);
+    controller =
+        SignUpController(AuthenticationModulesMock.userRegisterRepository);
   });
 
   group(
@@ -31,7 +32,11 @@ void main() {
       testWidgets(
         'shows screen widgets',
         (tester) async {
-          await theAppIsRunning(tester, SignUpPage(controller: controller,));
+          await theAppIsRunning(
+              tester,
+              SignUpPage(
+                controller: controller,
+              ));
           await iSeeText('Crie sua conta');
           await iSeeText(
               'Para sua segurança pedimos aos nossos usuários o CPF.');


### PR DESCRIPTION
## Sugestão de Pull Request: Refatoração da Página SignUp

**Objetivo:**

Este pull request visa refatorar a página `SignUpPage` para injetar o `SignUpController` diretamente no widget, ao invés de utilizar o `ModularState`. Essa alteração simplifica o código, facilita os testes e melhora a manutenibilidade.

**Motivação:**

A injeção do controller diretamente no widget elimina a necessidade de usar o `ModularState` na página `SignUpPage`. Isso torna o código mais limpo e direto, além de facilitar a criação de testes unitários, pois o controller pode ser facilmente mockado e injetado nos testes.

**Alterações:**

*   **`lib/app/features/authentication/presentation/sign_in/sign_in_module.dart`:**
    *   O `SignUpPage` agora recebe o `SignUpController` como parâmetro através do construtor.
*   **`lib/app/features/authentication/presentation/sign_in/sign_up/sign_up_page.dart`:**
    *   Removida a mixin `ModularState`.
    *   O `SignUpController` é agora recebido como parâmetro no construtor do widget.
    *   Todas as referências ao `controller` foram atualizadas para usar o `_controller` (que agora é um getter para o controller recebido no construtor: `widget.controller`).
*   **`test/app/features/authentication/presentation/sign_in/sign_up/sign_up_page_test.dart`:**
    *   Removida a inicialização e remoção do módulo `SignInModule` nos testes, pois o controller agora é injetado diretamente.
    *   O `SignUpController` é agora instanciado diretamente nos testes.
    *   Os testes foram atualizados para passar o `controller` instanciado para o widget `SignUpPage`.

**Benefícios:**

*   **Código mais limpo e legível:** A remoção do `ModularState` simplifica a estrutura da página.
*   **Testabilidade aprimorada:** Fica mais fácil mockar e injetar o controller nos testes unitários.
*   **Melhor manutenibilidade:** O código refatorado é mais fácil de entender e manter.
*   **Melhor desacoplamento:** A página `SignUpPage` fica menos acoplada ao Modular.

**Considerações:**

Nenhuma dependência externa foi adicionada ou removida. As alterações são específicas para a página `SignUpPage` e não afetam outras partes do aplicativo.

**Próximos Passos:**

Após a aprovação deste pull request, os testes unitários devem ser revisados e, se necessário, atualizados para garantir a cobertura completa das alterações.