### PR TITLE
[Refactor] Refatoração da Página `SignUpThree` para receber `SignUpThreeController` por construtor

### DIFF
--- a/lib/app/features/authentication/presentation/shared/page_progress_indicator.dart
+++ b/lib/app/features/authentication/presentation/shared/page_progress_indicator.dart
@@ -39,9 +39,9 @@ class _PageProgressIndicator extends State<PageProgressIndicator>
     _animation = Tween(begin: 0.0, end: 1.0).animate(_controller);
     _animation.addStatusListener((status) {
       if (status == AnimationStatus.forward) {
-        setState(() => {_isProgressVisible = true});
+        setState(() => _isProgressVisible = true);
       } else if (status == AnimationStatus.dismissed) {
-        setState(() => {_isProgressVisible = false});
+        setState(() => _isProgressVisible = false);
       }
     });
 

--- a/lib/app/features/authentication/presentation/sign_in/sign_in_module.dart
+++ b/lib/app/features/authentication/presentation/sign_in/sign_in_module.dart
@@ -81,7 +81,9 @@ class SignInModule extends Module {
         ),
         ChildRoute(
           '/signup/step3',
-          child: (_, args) => const SignUpThreePage(),
+          child: (_, args) => SignUpThreePage(
+            controller: Modular.get<SignUpThreeController>(),
+          ),
         ),
         ChildRoute(
           '/reset_password',

--- a/lib/app/features/authentication/presentation/sign_in/sign_up/pages/sign_up_three/sign_up_three_page.dart
+++ b/lib/app/features/authentication/presentation/sign_in/sign_up/pages/sign_up_three/sign_up_three_page.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
-import 'package:flutter_modular/flutter_modular.dart';
 import 'package:mobx/mobx.dart';
 
 import '../../../../../../../shared/design_system/linear_gradient_design_system.dart';
@@ -15,21 +14,23 @@ import '../../../../shared/snack_bar_handler.dart';
 import 'sign_up_three_controller.dart';
 
 class SignUpThreePage extends StatefulWidget {
-  const SignUpThreePage({Key? key, this.title = 'SignUpThree'})
+  const SignUpThreePage(
+      {Key? key, this.title = 'SignUpThree', required this.controller})
       : super(key: key);
 
   final String title;
+  final SignUpThreeController controller;
 
   @override
   _SignUpThreePageState createState() => _SignUpThreePageState();
 }
 
-class _SignUpThreePageState
-    extends ModularState<SignUpThreePage, SignUpThreeController>
+class _SignUpThreePageState extends State<SignUpThreePage>
     with SnackBarHandler {
   List<ReactionDisposer>? _disposers;
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
   PageProgressState _currentState = PageProgressState.initial;
+  SignUpThreeController get _controller => widget.controller;
 
   @override
   void didChangeDependencies() {
@@ -99,10 +100,10 @@ class _SignUpThreePageState
   SingleTextInput _buildEmailField() {
     return SingleTextInput(
       keyboardType: TextInputType.emailAddress,
-      onChanged: controller.setEmail,
+      onChanged: _controller.setEmail,
       boxDecoration: WhiteBoxDecorationStyle(
         labelText: 'E-mail',
-        errorText: controller.warningEmail,
+        errorText: _controller.warningEmail,
       ),
     );
   }
@@ -130,8 +131,8 @@ class _SignUpThreePageState
     return PasswordInputField(
       labelText: 'Senha',
       hintText: 'Digite sua senha',
-      errorText: controller.warningPassword,
-      onChanged: controller.setPassword,
+      errorText: _controller.warningPassword,
+      onChanged: _controller.setPassword,
     );
   }
 
@@ -139,14 +140,14 @@ class _SignUpThreePageState
     return PasswordInputField(
       labelText: 'Confirmação de senha',
       hintText: 'Digite sua senha novamente',
-      errorText: controller.warningConfirmationPassword,
-      onChanged: controller.setConfirmationPassword,
+      errorText: _controller.warningConfirmationPassword,
+      onChanged: _controller.setConfirmationPassword,
     );
   }
 
   Widget _buildNextButton() {
     return PenhasButton.roundedFilled(
-      onPressed: () => controller.registerUserPress(),
+      onPressed: () => _controller.registerUserPress(),
       child: const Text(
         'Cadastrar',
         style: kTextStyleDefaultFilledButtonLabel,
@@ -162,13 +163,14 @@ class _SignUpThreePageState
   }
 
   ReactionDisposer _showErrorMessage() {
-    return reaction((_) => controller.errorMessage, (String? message) {
+    return reaction((_) => _controller.errorMessage, (String? message) {
       showSnackBar(scaffoldKey: _scaffoldKey, message: message);
     });
   }
 
   ReactionDisposer _showProgress() {
-    return reaction((_) => controller.currentState, (PageProgressState status) {
+    return reaction((_) => _controller.currentState,
+        (PageProgressState status) {
       setState(() {
         _currentState = status;
       });

--- a/test/app/features/authentication/presentation/sign_in/sign_up/pages/sign_up_three/sign_up_three_page_test.dart
+++ b/test/app/features/authentication/presentation/sign_in/sign_up/pages/sign_up_three/sign_up_three_page_test.dart
@@ -1,5 +1,3 @@
-import 'package:flutter_modular/flutter_modular.dart';
-import 'package:flutter_modular_test/flutter_modular_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:penhas/app/core/error/failures.dart';
@@ -7,7 +5,6 @@ import 'package:penhas/app/core/extension/either.dart';
 import 'package:penhas/app/features/authentication/domain/entities/session_entity.dart';
 import 'package:penhas/app/features/authentication/domain/usecases/password_validator.dart';
 import 'package:penhas/app/features/authentication/presentation/shared/user_register_form_field_model.dart';
-import 'package:penhas/app/features/authentication/presentation/sign_in/sign_in_module.dart';
 import 'package:penhas/app/features/authentication/presentation/sign_in/sign_up/pages/sign_up_three/sign_up_three_controller.dart';
 import 'package:penhas/app/features/authentication/presentation/sign_in/sign_up/pages/sign_up_three/sign_up_three_page.dart';
 
@@ -19,32 +16,24 @@ import '../../../../mocks/authentication_modules_mock.dart';
 
 void main() {
   late UserRegisterFormFieldModel userFormField;
+  late SignUpThreeController controller;
 
   setUp(() {
     AppModulesMock.init();
     AuthenticationModulesMock.init();
     userFormField = UserRegisterFormFieldModel();
-
-    initModule(SignInModule(), replaceBinds: [
-      Bind<SignUpThreeController>(
-        (i) => SignUpThreeController(
-          AuthenticationModulesMock.userRegisterRepository,
-          userFormField,
-          AuthenticationModulesMock.passwordValidator,
-        ),
-      ),
-    ]);
-  });
-
-  tearDown(() {
-    Modular.removeModule(SignInModule());
+    controller = SignUpThreeController(
+      AuthenticationModulesMock.userRegisterRepository,
+      userFormField,
+      AuthenticationModulesMock.passwordValidator,
+    );
   });
 
   group(SignUpThreePage, () {
     testWidgets(
       'shows screen widgets',
       (tester) async {
-        await theAppIsRunning(tester, const SignUpThreePage());
+        await theAppIsRunning(tester, SignUpThreePage(controller: controller));
 
         // check if necessary widgets are present
         await iSeeText('Crie sua conta');
@@ -63,7 +52,7 @@ void main() {
         when(() => AuthenticationModulesMock.passwordValidator.validate(
             any(), any())).thenAnswer((_) => failure(MinLengthRule()));
 
-        await theAppIsRunning(tester, const SignUpThreePage());
+        await theAppIsRunning(tester, SignUpThreePage(controller: controller));
         await iEnterIntoPasswordField(
           tester,
           text: 'Confirmação de senha',
@@ -110,7 +99,7 @@ void main() {
               race: any(named: 'race')),
         ).thenFailure((_) => ServerFailure());
 
-        await theAppIsRunning(tester, const SignUpThreePage());
+        await theAppIsRunning(tester, SignUpThreePage(controller: controller));
 
         await iEnterIntoSingleTextInput(
           tester,
@@ -159,7 +148,7 @@ void main() {
               .pushNamedAndRemoveUntil(any(), any()),
         ).thenAnswer((_) => Future.value());
 
-        await theAppIsRunning(tester, const SignUpThreePage());
+        await theAppIsRunning(tester, SignUpThreePage(controller: controller));
 
         await iEnterIntoSingleTextInput(
           tester,
@@ -185,7 +174,7 @@ void main() {
     screenshotTest(
       'looks as expected',
       fileName: 'sign_up_step_3_page',
-      pageBuilder: () => const SignUpThreePage(),
+      pageBuilder: () => SignUpThreePage(controller: controller),
     );
   });
 }


### PR DESCRIPTION
## Sugestão de Pull Request: Refatoração da Página SignUpThree

**Objetivo:**

Este pull request visa refatorar a página `SignUpThreePage` para injetar o `SignUpThreeController` diretamente no widget, ao invés de utilizar o `ModularState`. Essa alteração simplifica o código, facilita os testes e melhora a manutenibilidade.

**Motivação:**

A injeção do controller diretamente no widget elimina a necessidade de usar o `ModularState` na página `SignUpThreePage`. Isso torna o código mais limpo e direto, além de facilitar a criação de testes unitários, pois o controller pode ser facilmente mockado e injetado nos testes.

**Alterações:**

*   **`lib/app/features/authentication/presentation/sign_in/sign_in_module.dart`:**
    *   O `SignUpThreePage` agora recebe o `SignUpThreeController` como parâmetro através do construtor.
*   **`lib/app/features/authentication/presentation/sign_in/sign_up/pages/sign_up_three/sign_up_three_page.dart`:**
    *   Removida a mixin `ModularState`.
    *   O `SignUpThreeController` é agora recebido como parâmetro no construtor do widget.
    *   Todas as referências ao `controller` foram atualizadas para usar o `_controller` (que agora é um getter para o controller recebido no construtor: `widget.controller`).
*   **`test/app/features/authentication/presentation/sign_in/sign_up/pages/sign_up_three/sign_up_three_page_test.dart`:**
    *   Removida a inicialização e remoção do módulo `SignInModule` nos testes, pois o controller agora é injetado diretamente.
    *   O `SignUpThreeController` é agora instanciado diretamente nos testes.
    *   Os testes foram atualizados para passar o `controller` instanciado para o widget `SignUpThreePage`.

**Benefícios:**

*   **Código mais limpo e legível:** A remoção do `ModularState` simplifica a estrutura da página.
*   **Testabilidade aprimorada:** Fica mais fácil mockar e injetar o controller nos testes unitários.
*   **Melhor manutenibilidade:** O código refatorado é mais fácil de entender e manter.
*   **Melhor desacoplamento:** A página `SignUpThreePage` fica menos acoplada ao Modular.

**Considerações:**

Nenhuma dependência externa foi adicionada ou removida. As alterações são específicas para a página `SignUpThreePage` e não afetam outras partes do aplicativo.

**Próximos Passos:**

Após a aprovação deste pull request, os testes unitários devem ser revisados e, se necessário, atualizados para garantir a cobertura completa das alterações.