### PR TITLE
[Refactor] Refatoração da Página `SignUpTwo` para receber `SignUpTwoController` por construtor

### DIFF
--- a/lib/app/features/authentication/presentation/sign_in/sign_in_module.dart
+++ b/lib/app/features/authentication/presentation/sign_in/sign_in_module.dart
@@ -77,7 +77,9 @@ class SignInModule extends Module {
         ),
         ChildRoute(
           '/signup/step2',
-          child: (_, args) => const SignUpTwoPage(),
+          child: (_, args) => SignUpTwoPage(
+            controller: Modular.get<SignUpTwoController>(),
+          ),
         ),
         ChildRoute(
           '/signup/step3',

--- a/lib/app/features/authentication/presentation/sign_in/sign_up/pages/sign_up_two/sign_up_two_page.dart
+++ b/lib/app/features/authentication/presentation/sign_in/sign_up/pages/sign_up_two/sign_up_two_page.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
-import 'package:flutter_modular/flutter_modular.dart';
 import 'package:mobx/mobx.dart';
 
 import '../../../../../../../shared/design_system/linear_gradient_design_system.dart';
@@ -14,20 +13,22 @@ import '../../../../shared/snack_bar_handler.dart';
 import 'sign_up_two_controller.dart';
 
 class SignUpTwoPage extends StatefulWidget {
-  const SignUpTwoPage({Key? key, this.title = 'SignUpTwo'}) : super(key: key);
+  const SignUpTwoPage(
+      {Key? key, this.title = 'SignUpTwo', required this.controller})
+      : super(key: key);
 
   final String title;
+  final SignUpTwoController controller;
 
   @override
   _SignUpTwoPageState createState() => _SignUpTwoPageState();
 }
 
-class _SignUpTwoPageState
-    extends ModularState<SignUpTwoPage, SignUpTwoController>
-    with SnackBarHandler {
+class _SignUpTwoPageState extends State<SignUpTwoPage> with SnackBarHandler {
   List<ReactionDisposer>? _disposers;
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
   PageProgressState _currentState = PageProgressState.initial;
+  SignUpTwoController get _controller => widget.controller;
 
   final dataSourceGenre =
       _buildDataSource(SignUpTwoController.genreDataSource());
@@ -87,9 +88,9 @@ class _SignUpTwoPageState
                             context: context,
                             labelText: 'Gênero',
                             keyIdentification: const Key('genreDropdownList'),
-                            onError: controller.warningGenre,
-                            onChange: controller.setGenre,
-                            currentValue: controller.currentGenre,
+                            onError: _controller.warningGenre,
+                            onChange: _controller.setGenre,
+                            currentValue: _controller.currentGenre,
                             dataSource: dataSourceGenre,
                           );
                         },
@@ -101,9 +102,9 @@ class _SignUpTwoPageState
                             context: context,
                             labelText: 'Raça',
                             keyIdentification: const Key('raceDropdownList'),
-                            onError: controller.warningRace,
-                            onChange: controller.setRace,
-                            currentValue: controller.currentRace,
+                            onError: _controller.warningRace,
+                            onChange: _controller.setRace,
+                            currentValue: _controller.currentRace,
                             dataSource: dataSourceRace,
                           );
                         },
@@ -123,25 +124,25 @@ class _SignUpTwoPageState
 
   SingleTextInput _buildNickName() {
     return SingleTextInput(
-      onChanged: controller.setNickname,
+      onChanged: _controller.setNickname,
       boxDecoration: WhiteBoxDecorationStyle(
         labelText: 'Apelido',
-        errorText: controller.warningNickname,
+        errorText: _controller.warningNickname,
       ),
     );
   }
 
   Offstage _buildSocialName() {
     return Offstage(
-      offstage: !controller.hasSocialNameField,
+      offstage: !_controller.hasSocialNameField,
       child: Column(
         children: <Widget>[
           const SizedBox(height: 24.0),
           SingleTextInput(
-            onChanged: controller.setSocialName,
+            onChanged: _controller.setSocialName,
             boxDecoration: WhiteBoxDecorationStyle(
               labelText: 'Nome social',
-              errorText: controller.warningSocialName,
+              errorText: _controller.warningSocialName,
             ),
           ),
         ],
@@ -186,7 +187,7 @@ class _SignUpTwoPageState
 
   Widget _buildNextButton() {
     return PenhasButton.roundedFilled(
-      onPressed: () => controller.nextStepPressed(),
+      onPressed: () => _controller.nextStepPressed(),
       child: const Text(
         'Próximo',
         style: kTextStyleDefaultFilledButtonLabel,
@@ -208,13 +209,14 @@ class _SignUpTwoPageState
   }
 
   ReactionDisposer _showErrorMessage() {
-    return reaction((_) => controller.errorMessage, (String message) {
+    return reaction((_) => _controller.errorMessage, (String message) {
       showSnackBar(scaffoldKey: _scaffoldKey, message: message);
     });
   }
 
   ReactionDisposer _showProgress() {
-    return reaction((_) => controller.currentState, (PageProgressState status) {
+    return reaction((_) => _controller.currentState,
+        (PageProgressState status) {
       setState(() {
         _currentState = status;
       });

--- a/test/app/features/authentication/presentation/sign_in/sign_up/pages/sign_up_two/sign_up_two_page_test.dart
+++ b/test/app/features/authentication/presentation/sign_in/sign_up/pages/sign_up_two/sign_up_two_page_test.dart
@@ -1,12 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_modular/flutter_modular.dart';
-import 'package:flutter_modular_test/flutter_modular_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:penhas/app/core/entities/valid_fiel.dart';
 import 'package:penhas/app/core/error/failures.dart';
 import 'package:penhas/app/features/authentication/presentation/shared/user_register_form_field_model.dart';
-import 'package:penhas/app/features/authentication/presentation/sign_in/sign_in_module.dart';
 import 'package:penhas/app/features/authentication/presentation/sign_in/sign_up/pages/sign_up_two/sign_up_two_controller.dart';
 import 'package:penhas/app/features/authentication/presentation/sign_in/sign_up/pages/sign_up_two/sign_up_two_page.dart';
 
@@ -20,6 +17,7 @@ void main() {
   late UserRegisterFormFieldModel userFormField;
   late Key genreDropdownList;
   late Key raceDropdownList;
+  late SignUpTwoController controller;
 
   setUp(() {
     AppModulesMock.init();
@@ -27,24 +25,15 @@ void main() {
     userFormField = UserRegisterFormFieldModel();
     genreDropdownList = const Key('genreDropdownList');
     raceDropdownList = const Key('raceDropdownList');
-
-    initModule(SignInModule(), replaceBinds: [
-      Bind<SignUpTwoController>(
-        (i) => SignUpTwoController(
-            AuthenticationModulesMock.userRegisterRepository, userFormField),
-      ),
-    ]);
-  });
-
-  tearDown(() {
-    Modular.removeModule(SignInModule());
+    controller = SignUpTwoController(
+        AuthenticationModulesMock.userRegisterRepository, userFormField);
   });
 
   group(SignUpTwoPage, () {
     testWidgets(
       'shows screen widgets',
       (tester) async {
-        await theAppIsRunning(tester, const SignUpTwoPage());
+        await theAppIsRunning(tester, SignUpTwoPage(controller: controller));
 
         // check if necessary widgets are present
         await iSeeText('Crie sua conta');
@@ -61,7 +50,7 @@ void main() {
     testWidgets(
       'checks the genre list',
       (tester) async {
-        await theAppIsRunning(tester, const SignUpTwoPage());
+        await theAppIsRunning(tester, SignUpTwoPage(controller: controller));
         final genreList = [
           'Feminino',
           'Masculino',
@@ -84,7 +73,7 @@ void main() {
     testWidgets(
       'checks the race list',
       (tester) async {
-        await theAppIsRunning(tester, const SignUpTwoPage());
+        await theAppIsRunning(tester, SignUpTwoPage(controller: controller));
 
         final raceList = [
           'Branca',
@@ -109,7 +98,7 @@ void main() {
     testWidgets(
       'does not forward for any invalid field',
       (tester) async {
-        await theAppIsRunning(tester, const SignUpTwoPage());
+        await theAppIsRunning(tester, SignUpTwoPage(controller: controller));
         await iTapText(tester, text: 'Próximo');
         await iSeeSingleTextInputErrorMessage(
           tester,
@@ -138,7 +127,7 @@ void main() {
               race: any(named: 'race'),
             )).thenFailure((_) => ServerFailure());
 
-        await theAppIsRunning(tester, const SignUpTwoPage());
+        await theAppIsRunning(tester, SignUpTwoPage(controller: controller));
         await iEnterIntoSingleTextInput(
           tester,
           text: 'Apelido',
@@ -187,7 +176,7 @@ void main() {
               arguments: any(named: 'arguments')),
         ).thenAnswer((_) => Future.value());
 
-        await theAppIsRunning(tester, const SignUpTwoPage());
+        await theAppIsRunning(tester, SignUpTwoPage(controller: controller));
         await iEnterIntoSingleTextInput(
           tester,
           text: 'Apelido',
@@ -225,7 +214,7 @@ void main() {
     screenshotTest(
       'looks as expected',
       fileName: 'sign_up_step_2_page',
-      pageBuilder: () => const SignUpTwoPage(),
+      pageBuilder: () => SignUpTwoPage(controller: controller),
     );
   });
 }


### PR DESCRIPTION
## Sugestão de Pull Request: Refatoração da Página SignUpTwo

**Objetivo:**

Este pull request visa refatorar a página `SignUpTwoPage` para injetar o `SignUpTwoController` diretamente no widget, ao invés de utilizar o `ModularState`. Essa alteração simplifica o código, facilita os testes e melhora a manutenibilidade.

**Motivação:**

A injeção do controller diretamente no widget elimina a necessidade de usar o `ModularState` na página `SignUpTwoPage`. Isso torna o código mais limpo e direto, além de facilitar a criação de testes unitários, pois o controller pode ser facilmente mockado e injetado nos testes.

**Alterações:**

*   **`lib/app/features/authentication/presentation/sign_in/sign_in_module.dart`:**
    *   O `SignUpTwoPage` agora recebe o `SignUpTwoController` como parâmetro através do construtor.
*   **`lib/app/features/authentication/presentation/sign_in/sign_up/pages/sign_up_two/sign_up_two_page.dart`:**
    *   Removida a mixin `ModularState`.
    *   O `SignUpTwoController` é agora recebido como parâmetro no construtor do widget.
    *   Todas as referências ao `controller` foram atualizadas para usar o `_controller` (que agora é um getter para o controller recebido no construtor: `widget.controller`).
*   **`test/app/features/authentication/presentation/sign_in/sign_up/pages/sign_up_two/sign_up_two_page_test.dart`:**
    *   Removida a inicialização e remoção do módulo `SignInModule` nos testes, pois o controller agora é injetado diretamente.
    *   O `SignUpTwoController` é agora instanciado diretamente nos testes.
    *   Os testes foram atualizados para passar o `controller` instanciado para o widget `SignUpTwoPage`.

**Benefícios:**

*   **Código mais limpo e legível:** A remoção do `ModularState` simplifica a estrutura da página.
*   **Testabilidade aprimorada:** Fica mais fácil mockar e injetar o controller nos testes unitários.
*   **Melhor manutenibilidade:** O código refatorado é mais fácil de entender e manter.
*   **Melhor desacoplamento:** A página `SignUpTwoPage` fica menos acoplada ao Modular.

**Considerações:**

Nenhuma dependência externa foi adicionada ou removida. As alterações são específicas para a página `SignUpTwoPage` e não afetam outras partes do aplicativo.

**Próximos Passos:**

Após a aprovação deste pull request, os testes unitários devem ser revisados e, se necessário, atualizados para garantir a cobertura completa das alterações.