### PR TITLE
[Refactor] Refatoração da Página `SplashPage` para receber `SplashController` por construtor

### DIFF
--- a/lib/app/features/splash/splash_module.dart
+++ b/lib/app/features/splash/splash_module.dart
@@ -22,6 +22,8 @@ class SplashModule extends Module {
   @override
   List<ModularRoute> get routes => [
         ChildRoute(Modular.initialRoute,
-            child: (_, args) => const SplashPage()),
+            child: (_, args) => SplashPage(
+                  controller: Modular.get<SplashController>(),
+                )),
       ];
 }

--- a/lib/app/features/splash/splash_page.dart
+++ b/lib/app/features/splash/splash_page.dart
@@ -1,22 +1,24 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_modular/flutter_modular.dart';
 
 import '../../shared/design_system/colors.dart';
 import 'splash_controller.dart';
 
 class SplashPage extends StatefulWidget {
-  const SplashPage({Key? key, this.title = 'Splash'}) : super(key: key);
+  const SplashPage({Key? key, this.title = 'Splash', required this.controller})
+      : super(key: key);
 
   final String title;
+  final SplashController controller;
 
   @override
   _SplashPageState createState() => _SplashPageState();
 }
 
-class _SplashPageState extends ModularState<SplashPage, SplashController> {
+class _SplashPageState extends State<SplashPage> {
+  SplashController get _controller => widget.controller;
   @override
   Widget build(BuildContext context) {
-    controller.init();
+    _controller.init();
     return Container(
       color: DesignSystemColors.ligthPurple,
       child: const Center(

--- a/test/app/features/splash/splash_page_test.dart
+++ b/test/app/features/splash/splash_page_test.dart
@@ -1,5 +1,3 @@
-import 'package:flutter_modular/flutter_modular.dart';
-import 'package:flutter_modular_test/flutter_modular_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:penhas/app/core/data/authorization_status.dart';
@@ -7,7 +5,6 @@ import 'package:penhas/app/core/error/failures.dart';
 import 'package:penhas/app/features/appstate/domain/entities/app_state_entity.dart';
 import 'package:penhas/app/features/appstate/domain/entities/user_profile_entity.dart';
 import 'package:penhas/app/features/splash/splash_controller.dart';
-import 'package:penhas/app/features/splash/splash_module.dart';
 import 'package:penhas/app/features/splash/splash_page.dart';
 
 import '../../../utils/mocktail_extension.dart';
@@ -15,25 +12,15 @@ import '../../../utils/widget_test_steps.dart';
 import '../authentication/presentation/mocks/app_modules_mock.dart';
 
 void main() {
+  late SplashController controller;
   setUp(() {
     AppModulesMock.init();
 
-    initModule(
-      SplashModule(),
-      replaceBinds: [
-        Bind<SplashController>(
-          (i) => SplashController(
-            appConfiguration: AppModulesMock.appConfiguration,
-            appStateUseCase: AppModulesMock.appStateUseCase,
-            userProfileStore: AppModulesMock.userProfileStore,
-          ),
-        ),
-      ],
+    controller = SplashController(
+      appConfiguration: AppModulesMock.appConfiguration,
+      appStateUseCase: AppModulesMock.appStateUseCase,
+      userProfileStore: AppModulesMock.userProfileStore,
     );
-  });
-
-  tearDown(() {
-    Modular.removeModule(SplashModule());
   });
 
   group(
@@ -48,7 +35,7 @@ void main() {
                   AppModulesMock.modularNavigator.pushReplacementNamed(any()))
               .thenAnswer((i) => Future.value());
 
-          await theAppIsRunning(tester, const SplashPage());
+          await theAppIsRunning(tester, SplashPage(controller: controller));
           verify(() => AppModulesMock.modularNavigator
               .pushReplacementNamed('/authentication')).called(1);
         },
@@ -66,7 +53,7 @@ void main() {
                     AppModulesMock.modularNavigator.pushReplacementNamed(any()))
                 .thenAnswer((i) => Future.value());
 
-            await theAppIsRunning(tester, const SplashPage());
+            await theAppIsRunning(tester, SplashPage(controller: controller));
             verify(() => AppModulesMock.modularNavigator
                 .pushReplacementNamed('/authentication')).called(1);
           },
@@ -88,7 +75,7 @@ void main() {
                     AppModulesMock.modularNavigator.pushReplacementNamed(any()))
                 .thenAnswer((i) => Future.value());
 
-            await theAppIsRunning(tester, const SplashPage());
+            await theAppIsRunning(tester, SplashPage(controller: controller));
             verify(() => AppModulesMock.modularNavigator
                 .pushReplacementNamed('/authentication/stealth')).called(1);
           },
@@ -111,7 +98,7 @@ void main() {
                     AppModulesMock.modularNavigator.pushReplacementNamed(any()))
                 .thenAnswer((i) => Future.value());
 
-            await theAppIsRunning(tester, const SplashPage());
+            await theAppIsRunning(tester, SplashPage(controller: controller));
             verify(() => AppModulesMock.modularNavigator
                     .pushReplacementNamed('/authentication/sign_in_stealth'))
                 .called(1);
@@ -135,7 +122,7 @@ void main() {
                     .popAndPushNamed(any(), arguments: any(named: 'arguments')))
                 .thenAnswer((i) => Future.value());
 
-            await theAppIsRunning(tester, const SplashPage());
+            await theAppIsRunning(tester, SplashPage(controller: controller));
             verify(() => AppModulesMock.modularNavigator
                     .popAndPushNamed('/mainboard', arguments: {'page': 'feed'}))
                 .called(1);
@@ -155,7 +142,7 @@ void main() {
                     .popAndPushNamed(any(), arguments: any(named: 'arguments')))
                 .thenAnswer((i) => Future.value());
 
-            await theAppIsRunning(tester, const SplashPage());
+            await theAppIsRunning(tester, SplashPage(controller: controller));
             verify(
               () => AppModulesMock.modularNavigator.popAndPushNamed(
                 '/quiz?origin=splash',
@@ -181,7 +168,7 @@ void main() {
                     .popAndPushNamed(any(), arguments: any(named: 'arguments')))
                 .thenAnswer((i) => Future.value());
 
-            await theAppIsRunning(tester, const SplashPage());
+            await theAppIsRunning(tester, SplashPage(controller: controller));
             verify(() => AppModulesMock.modularNavigator
                     .popAndPushNamed('/mainboard', arguments: {'page': 'feed'}))
                 .called(1);


### PR DESCRIPTION
## Sugestão de Pull Request: Refatoração da Página Splash

**Objetivo:**

Este pull request visa refatorar a página `SplashPage` para injetar o `SplashController` diretamente no widget, ao invés de utilizar o `ModularState`. Essa alteração simplifica o código, facilita os testes e melhora a manutenibilidade.

**Motivação:**

A injeção do controller diretamente no widget elimina a necessidade de usar o `ModularState` na página `SplashPage`. Isso torna o código mais limpo e direto, além de facilitar a criação de testes unitários, pois o controller pode ser facilmente mockado e injetado nos testes.

**Alterações:**

*   **`lib/app/features/splash/splash_module.dart`:**
    *   O `SplashPage` agora recebe o `SplashController` como parâmetro através do construtor.
*   **`lib/app/features/splash/splash_page.dart`:**
    *   Removida a mixin `ModularState`.
    *   O `SplashController` é agora recebido como parâmetro no construtor do widget.
    *   Todas as referências ao `controller` foram atualizadas para usar o `_controller` (que agora é um getter para o controller recebido no construtor: `widget.controller`).
*   **`test/app/features/splash/splash_page_test.dart`:**
    *   Removida a inicialização e remoção do módulo `SplashModule` nos testes, pois o controller agora é injetado diretamente.
    *   O `SplashController` é agora instanciado diretamente nos testes.
    *   Os testes foram atualizados para passar o `controller` instanciado para o widget `SplashPage`.

**Benefícios:**

*   **Código mais limpo e legível:** A remoção do `ModularState` simplifica a estrutura da página.
*   **Testabilidade aprimorada:** Fica mais fácil mockar e injetar o controller nos testes unitários.
*   **Melhor manutenibilidade:** O código refatorado é mais fácil de entender e manter.
*   **Melhor desacoplamento:** A página `SplashPage` fica menos acoplada ao Modular.

**Considerações:**

Nenhuma dependência externa foi adicionada ou removida. As alterações são específicas para a página `SplashPage` e não afetam outras partes do aplicativo.

**Próximos Passos:**

Após a aprovação deste pull request, os testes unitários devem ser revisados e, se necessário, atualizados para garantir a cobertura completa das alterações.