### PR TITLE
[Refactor] Refatorar `PenhasDrawerPage` para receber `StealthModeTutorialPageController` por construtor

### DIFF
--- a/lib/app/features/main_menu/presentation/penhas_drawer_page.dart
+++ b/lib/app/features/main_menu/presentation/penhas_drawer_page.dart
@@ -8,17 +8,22 @@ import '../../../shared/design_system/colors.dart';
 import '../../../shared/design_system/text_styles.dart';
 import '../../../shared/design_system/widgets/buttons/penhas_button.dart';
 import '../../quiz/presentation/tutorial/stealth_mode_tutorial_page.dart';
+import '../../quiz/presentation/tutorial/stealth_mode_tutorial_page_controller.dart';
 import 'pages/penhas_drawer_header_page.dart';
 import 'pages/penhas_drawer_toggle_page.dart';
 import 'penhas_drawer_controller.dart';
 
 class PenhasDrawerPage extends StatefulWidget {
   const PenhasDrawerPage(
-      {Key? key, this.title = 'Penhas Drawer', required this.controller})
+      {Key? key,
+      this.title = 'Penhas Drawer',
+      required this.controller,
+      required this.stealthController})
       : super(key: key);
 
   final String title;
   final PenhasDrawerController controller;
+  final StealthModeTutorialPageController stealthController;
 
   @override
   _PenhasDrawerPageState createState() => _PenhasDrawerPageState();
@@ -28,6 +33,8 @@ class _PenhasDrawerPageState extends State<PenhasDrawerPage> {
   final double listHeight = 80;
   final Color drawerGrey = const Color.fromRGBO(239, 239, 239, 1.0);
   PenhasDrawerController get _controller => widget.controller;
+  StealthModeTutorialPageController get _stealthController =>
+      widget.stealthController;
 
   @override
   void initState() {
@@ -149,7 +156,10 @@ class _PenhasDrawerPageState extends State<PenhasDrawerPage> {
                   onPressed: () async {
                     Navigator.push(
                       context,
-                      TutorialScaleRoute(page: const StealthModeTutorialPage()),
+                      TutorialScaleRoute(
+                          page: StealthModeTutorialPage(
+                        controller: _stealthController,
+                      )),
                     );
                   },
                   child: Text(

--- a/lib/app/features/mainboard/presentation/mainboard/mainboard_module.dart
+++ b/lib/app/features/mainboard/presentation/mainboard/mainboard_module.dart
@@ -133,6 +133,7 @@ class MainboardModule extends Module {
             controller: Modular.get<MainboardController>(),
             composeTweetController: Modular.get<ComposeTweetController>(),
             penhasDrawerController: Modular.get<PenhasDrawerController>(),
+            stealthController: Modular.get<StealthModeTutorialPageController>(),
           ),
         ),
         ...tweetRoutes,

--- a/lib/app/features/mainboard/presentation/mainboard/mainboard_page.dart
+++ b/lib/app/features/mainboard/presentation/mainboard/mainboard_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter_mobx/flutter_mobx.dart';
 import '../../../feed/presentation/compose_tweet/compose_tweet_controller.dart';
 import '../../../main_menu/presentation/penhas_drawer_controller.dart';
 import '../../../main_menu/presentation/penhas_drawer_page.dart';
+import '../../../quiz/presentation/tutorial/stealth_mode_tutorial_page_controller.dart';
 import 'mainboard_controller.dart';
 import 'pages/mainboard_app_bar_page.dart';
 import 'pages/mainboard_body_page.dart';
@@ -15,11 +16,13 @@ class MainboardPage extends StatefulWidget {
     required this.controller,
     required this.composeTweetController,
     required this.penhasDrawerController,
+    required this.stealthController,
   }) : super(key: key);
 
   final MainboardController controller;
   final ComposeTweetController composeTweetController;
   final PenhasDrawerController penhasDrawerController;
+  final StealthModeTutorialPageController stealthController;
 
   static final mainBoardKey = GlobalKey<ScaffoldState>(
     debugLabel: 'main-board-scaffold-key',
@@ -39,6 +42,8 @@ class MainboardPageState extends State<MainboardPage>
       widget.penhasDrawerController;
   ComposeTweetController get composeTweetController =>
       widget.composeTweetController;
+  StealthModeTutorialPageController get _stealthController =>
+      widget.stealthController;
 
   @override
   void initState() {
@@ -66,6 +71,7 @@ class MainboardPageState extends State<MainboardPage>
         ),
         drawer: PenhasDrawerPage(
           controller: _penhasDrawerController,
+          stealthController: _stealthController,
         ),
         backgroundColor: Colors.white,
         body: Scaffold(

--- a/lib/app/features/quiz/presentation/tutorial/stealth_mode_tutorial_page.dart
+++ b/lib/app/features/quiz/presentation/tutorial/stealth_mode_tutorial_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
-import 'package:flutter_modular/flutter_modular.dart';
 
 import '../../../../core/pages/tutorial_page_view_widget.dart';
 import '../../../../shared/design_system/colors.dart';
@@ -8,18 +7,21 @@ import '../../../../shared/design_system/widgets/buttons/penhas_button.dart';
 import 'stealth_mode_tutorial_page_controller.dart';
 
 class StealthModeTutorialPage extends StatefulWidget {
-  const StealthModeTutorialPage({Key? key}) : super(key: key);
+  const StealthModeTutorialPage({Key? key, required this.controller})
+      : super(key: key);
+
+  final StealthModeTutorialPageController controller;
 
   @override
   _StealthModeTutorialPageState createState() =>
       _StealthModeTutorialPageState();
 }
 
-class _StealthModeTutorialPageState extends ModularState<
-    StealthModeTutorialPage, StealthModeTutorialPageController> {
+class _StealthModeTutorialPageState extends State<StealthModeTutorialPage> {
   List<TutorialPageViewWidget> _contentPageView = [];
   final PageController _pageController = PageController();
   int _currentPage = 0;
+  StealthModeTutorialPageController get _controller => widget.controller;
 
   @override
   Widget build(BuildContext context) {
@@ -57,7 +59,7 @@ class _StealthModeTutorialPageState extends ModularState<
                     },
                     children: pages(
                       isPermissionGranted:
-                          controller.state.locationPermissionGranted,
+                          _controller.state.locationPermissionGranted,
                     )!,
                   ),
                 ),
@@ -153,7 +155,7 @@ class _StealthModeTutorialPageState extends ModularState<
             ),
             if (!isPermissionGranted)
               PenhasButton.text(
-                onPressed: controller.requestLocationPermission,
+                onPressed: _controller.requestLocationPermission,
                 child: const Text(
                   'AUTORIZAR LOCALIZAÇÃO',
                   style: TextStyle(

--- a/lib/app/features/quiz/quiz_module.dart
+++ b/lib/app/features/quiz/quiz_module.dart
@@ -98,7 +98,9 @@ class QuizModule extends Module {
         ),
         ChildRoute(
           '/tutorial/stealth',
-          child: (_, __) => const StealthModeTutorialPage(),
+          child: (_, __) => StealthModeTutorialPage(
+            controller: Modular.get<StealthModeTutorialPageController>(),
+          ),
         ),
       ];
 }

--- a/test/app/features/main_menu/presentation/penhas_drawer_page_test.dart
+++ b/test/app/features/main_menu/presentation/penhas_drawer_page_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:penhas/app/core/managers/app_configuration.dart';
+import 'package:penhas/app/core/managers/location_services.dart';
 import 'package:penhas/app/core/managers/modules_sevices.dart';
 import 'package:penhas/app/features/appstate/domain/entities/app_state_entity.dart';
 import 'package:penhas/app/features/appstate/domain/entities/user_profile_entity.dart';
@@ -9,6 +10,7 @@ import 'package:penhas/app/features/help_center/domain/usecases/security_mode_ac
 import 'package:penhas/app/features/main_menu/domain/usecases/user_profile.dart';
 import 'package:penhas/app/features/main_menu/presentation/penhas_drawer_controller.dart';
 import 'package:penhas/app/features/main_menu/presentation/penhas_drawer_page.dart';
+import 'package:penhas/app/features/quiz/presentation/tutorial/stealth_mode_tutorial_page_controller.dart';
 
 import '../../../../utils/golden_tests.dart';
 import '../../../../utils/widget_test_steps.dart';
@@ -21,11 +23,20 @@ class MockAppModulesServices extends Mock implements IAppModulesServices {}
 
 class FakeAppStateModuleEntity extends Fake implements AppStateModuleEntity {}
 
+class MockLocationServices extends Mock implements ILocationServices {
+  @override
+  Future<bool> isPermissionGranted() async {
+    return Future.value(true);
+  }
+}
+
 void main() {
   late MockAppConfiguration appConfiguration;
   late MockUserProfile userProfile;
   late MockAppModulesServices modulesServices;
   late PenhasDrawerController penhasDrawerController;
+  late ILocationServices locationServices;
+  late StealthModeTutorialPageController stealthController;
 
   final userProfileEntity = UserProfileEntity(
     fullName: 'Penhas',
@@ -46,10 +57,14 @@ void main() {
     appConfiguration = MockAppConfiguration();
     userProfile = MockUserProfile();
     modulesServices = MockAppModulesServices();
+    locationServices = MockLocationServices();
     penhasDrawerController = PenhasDrawerController(
         appConfigure: appConfiguration,
         modulesServices: modulesServices,
         userProfile: userProfile);
+    stealthController = StealthModeTutorialPageController(
+      locationService: locationServices,
+    );
   });
 
   group(PenhasDrawerPage, () {
@@ -65,6 +80,7 @@ void main() {
       // act
       tester.theAppIsRunning(PenhasDrawerPage(
         controller: penhasDrawerController,
+        stealthController: stealthController,
       ));
       // assert
     });
@@ -76,6 +92,7 @@ void main() {
     pageBuilder: () => Scaffold(
         body: PenhasDrawerPage(
       controller: penhasDrawerController,
+      stealthController: stealthController,
     )),
     setUp: () {
       when(() => modulesServices.feature(
@@ -96,6 +113,7 @@ void main() {
     pageBuilder: () => Scaffold(
         body: PenhasDrawerPage(
       controller: penhasDrawerController,
+      stealthController: stealthController,
     )),
     setUp: () {
       when(() => modulesServices.feature(

--- a/test/app/features/mainboard/presentation/mainboard/mainboard_page_test.dart
+++ b/test/app/features/mainboard/presentation/mainboard/mainboard_page_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mobx/mobx.dart' as mobx;
 import 'package:mocktail/mocktail.dart';
+import 'package:penhas/app/core/managers/location_services.dart';
 import 'package:penhas/app/features/appstate/domain/usecases/app_preferences_use_case.dart';
 import 'package:penhas/app/features/feed/presentation/compose_tweet/compose_tweet_controller.dart';
 import 'package:penhas/app/features/main_menu/presentation/penhas_drawer_controller.dart';
@@ -12,6 +13,7 @@ import 'package:penhas/app/features/mainboard/domain/states/mainboard_store.dart
 import 'package:penhas/app/features/mainboard/presentation/mainboard/mainboard_controller.dart';
 import 'package:penhas/app/features/mainboard/presentation/mainboard/mainboard_page.dart';
 import 'package:penhas/app/features/notification/data/repositories/notification_repository.dart';
+import 'package:penhas/app/features/quiz/presentation/tutorial/stealth_mode_tutorial_page_controller.dart';
 
 import '../../../../../utils/golden_tests.dart';
 
@@ -33,6 +35,8 @@ class MockComposeTweetController extends Mock
 class MockPenhasDrawerController extends Mock
     implements PenhasDrawerController {}
 
+class MockLocationServices extends Mock implements ILocationServices {}
+
 void main() {
   late MainboardController controller;
   late ComposeTweetController composeTweetController;
@@ -42,6 +46,8 @@ void main() {
   late Timer notificationTimer;
   late PageController pageController;
   late PenhasDrawerController penhasDrawerController;
+  late ILocationServices locationServices;
+  late StealthModeTutorialPageController stealthController;
 
   setUp(() {
     mainboardStore = MockMainboardStore();
@@ -67,7 +73,11 @@ void main() {
       notification: notification,
       notificationTimer: notificationTimer,
     );
+    locationServices = MockLocationServices();
     composeTweetController = MockComposeTweetController();
+    stealthController = StealthModeTutorialPageController(
+      locationService: locationServices,
+    );
   });
 
   group(MainboardPage, () {
@@ -78,6 +88,7 @@ void main() {
         controller: controller,
         composeTweetController: composeTweetController,
         penhasDrawerController: penhasDrawerController,
+        stealthController: stealthController,
       ),
       skip: true,
       reason:

--- a/test/app/features/quiz/presentation/tutorial/stealth_mode_tutorial_page_test.dart
+++ b/test/app/features/quiz/presentation/tutorial/stealth_mode_tutorial_page_test.dart
@@ -1,41 +1,36 @@
-import 'package:flutter_modular/flutter_modular.dart';
-import 'package:flutter_modular_test/flutter_modular_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:penhas/app/core/managers/location_services.dart';
 import 'package:penhas/app/features/quiz/presentation/tutorial/stealth_mode_tutorial_page.dart';
 import 'package:penhas/app/features/quiz/presentation/tutorial/stealth_mode_tutorial_page_controller.dart';
-import 'package:penhas/app/features/quiz/quiz_module.dart';
 
 import '../../../../../utils/golden_tests.dart';
 
-class MockLocationServices extends Mock implements ILocationServices {}
+class MockLocationServices extends Mock implements ILocationServices {
+  @override
+  Future<bool> isPermissionGranted() async {
+    return Future.value(true);
+  }
+}
 
 void main() {
   late MockLocationServices mockLocationServices;
+  late StealthModeTutorialPageController controller;
 
   setUp(() {
     mockLocationServices = MockLocationServices();
-
-    initModule(QuizModule(), replaceBinds: [
-      Bind.factory<StealthModeTutorialPageController>(
-        (i) => StealthModeTutorialPageController(
-          locationService: mockLocationServices,
-        ),
-      ),
-    ]);
+    controller = StealthModeTutorialPageController(
+      locationService: mockLocationServices,
+    );
   });
 
   group(StealthModeTutorialPage, () {
     screenshotTest(
       'load stealth mode tutorial page',
       fileName: 'stealth_mode_tutorial_page',
-      pageBuilder: () => StealthModeTutorialPage(),
-      setUp: () async {
-        when(() => mockLocationServices.isPermissionGranted()).thenAnswer(
-          (invocation) async => true,
-        );
-      },
+      pageBuilder: () => StealthModeTutorialPage(
+        controller: controller,
+      ),
     );
   });
 }


### PR DESCRIPTION
## Sugestão de Pull Request: Refatorar `PenhasDrawerPage` para receber `StealthModeTutorialPageController` por construtor

**Objetivo:**

Este pull request visa refatorar as páginas `PenhasDrawerPage`, `StealthModeTutorialPage` e outras dependentes para injetar os respectivos controllers diretamente nos widgets, ao invés de utilizar o `ModularState`. Adicionalmente, o código foi formatado utilizando o comando `dart format` para garantir a consistência e legibilidade. Esta é uma versão atualizada da sugestão anterior, incorporando quaisquer revisões ou melhorias necessárias.

**Motivação:**

A injeção dos controllers diretamente nos widgets elimina a necessidade de usar o `ModularState` nas páginas. Isso torna o código mais limpo e direto, além de facilitar a criação de testes unitários, pois os controllers podem ser facilmente mockados e injetados nos testes. A formatação do código garante a padronização e facilita a leitura e manutenção do mesmo.

**Alterações:**

*   **`lib/app/features/main_menu/presentation/penhas_drawer_page.dart`:**
    *   A página `PenhasDrawerPage` agora recebe os controllers `PenhasDrawerController` e `StealthModeTutorialPageController` como parâmetros através do construtor.
    *   Todas as referências aos controllers foram atualizadas para usar os getters que acessam os controllers recebidos no construtor.
*   **`lib/app/features/mainboard/presentation/mainboard/mainboard_module.dart`:**
    *   Os controllers necessários para a `MainboardPage` (incluindo `PenhasDrawerController` e `StealthModeTutorialPageController`) são agora injetados no construtor da página.
*   **`lib/app/features/mainboard/presentation/mainboard/mainboard_page.dart`:**
    *   A página `MainboardPage` agora recebe os controllers como parâmetros através do construtor.
    *   Todas as referências aos controllers foram atualizadas para usar os getters que acessam os controllers recebidos no construtor.
*   **`lib/app/features/quiz/presentation/tutorial/stealth_mode_tutorial_page.dart`:**
    *   A página `StealthModeTutorialPage` agora recebe o controller `StealthModeTutorialPageController` como parâmetro através do construtor.
    *   Removida a mixin `ModularState`.
    *   Todas as referências ao `controller` foram atualizadas para usar o `_controller` (getter para o controller recebido no construtor).
*   **`lib/app/features/quiz/quiz_module.dart`:**
    *   A injeção do `StealthModeTutorialPageController` foi ajustada para usar o `Modular.get`.
*   **`test/app/features/main_menu/presentation/penhas_drawer_page_test.dart`:**
    *   Os testes foram atualizados para passar os controllers mockados para o widget `PenhasDrawerPage`.
*   **`test/app/features/mainboard/presentation/mainboard/mainboard_page_test.dart`:**
    *   Os testes foram atualizados para passar os controllers mockados para o widget `MainboardPage`.
*   **`test/app/features/quiz/presentation/tutorial/stealth_mode_tutorial_page_test.dart`:**
    *   Os testes foram atualizados para passar o controller mockado para o widget `StealthModeTutorialPage`.
*   **Todos os arquivos `.dart`:**
    *   Executado o comando `dart format` para formatar o código.

**Benefícios:**

*   **Código mais limpo e legível:** A remoção do `ModularState` simplifica a estrutura das páginas.
*   **Testabilidade aprimorada:** Fica mais fácil mockar e injetar os controllers nos testes unitários.
*   **Melhor manutenibilidade:** O código refatorado e formatado é mais fácil de entender e manter.
*   **Melhor desacoplamento:** As páginas ficam menos acopladas ao Modular.
*   **Consistência do código:** A formatação automática garante um estilo de código consistente em todo o projeto.

**Considerações:**

Nenhuma dependência externa foi adicionada ou removida. As alterações são específicas para as páginas mencionadas, os testes relacionados e a formatação geral do código.

**Próximos Passos:**

Após a aprovação deste pull request, os testes unitários devem ser revisados e, se necessário, atualizados para garantir a cobertura completa das alterações. Recomenda-se executar o comando `dart format` periodicamente para manter a consistência do código.