### PR TITLE
Refactor HTTP response parsing and improve error handling

### DIFF
--- a/lib/app/core/network/interfaces/api_content_type.dart
+++ b/lib/app/core/network/interfaces/api_content_type.dart
@@ -2,3 +2,11 @@ enum ApiContentType {
   json,
   formUrlEncoded,
 }
+
+extension ApiContentTypeExtension on ApiContentType {
+  String get value {
+    return this == ApiContentType.json
+        ? 'application/json; charset=utf-8'
+        : 'application/x-www-form-urlencoded; charset=utf-8';
+  }
+}

--- a/test/utils/api_provider_mock.dart
+++ b/test/utils/api_provider_mock.dart
@@ -1,0 +1,60 @@
+import 'package:http/http.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:penhas/app/core/network/api_client.dart';
+import 'package:penhas/app/core/network/api_server_configure.dart';
+
+class ApiProviderMock {
+  static late IApiProvider apiProvider;
+  static late MockHttpClient httpClient;
+  static late MockApiServerConfigure serverConfigure;
+
+  static void init() {
+    _initMocks();
+    _initFallbacks();
+  }
+
+  static void _initMocks() {
+    httpClient = MockHttpClient();
+    serverConfigure = MockApiServerConfigure();
+
+    apiProvider = ApiProvider(
+      serverConfiguration: serverConfigure,
+      apiClient: httpClient,
+    );
+  }
+
+  static void _initFallbacks() {
+    registerFallbackValue(Uri());
+    registerFallbackValue(BaseRequestFake());
+  }
+
+  static void apiClientResponse(String body, int statusCode) {
+    final stream = Stream.value(body.codeUnits);
+    when(() => httpClient.send(any())).thenAnswer(
+      (_) async => StreamedResponse(
+        stream,
+        statusCode,
+      ),
+    );
+  }
+
+  static Map<String, String> apiClientCapturedRequest() {
+    final captured =
+        verify(() => ApiProviderMock.httpClient.send(captureAny())).captured;
+    final request = captured.first as Request;
+    final Map<String, String> requestDetails = {
+      'method': request.method,
+      'path': request.url.path,
+      'queryParameters': request.url.queryParameters.toString(),
+      'body': request.body,
+    };
+
+    return requestDetails;
+  }
+}
+
+class BaseRequestFake extends Fake implements BaseRequest {}
+
+class MockHttpClient extends Mock implements Client {}
+
+class MockApiServerConfigure extends Mock implements IApiServerConfigure {}


### PR DESCRIPTION
## Descrição
Este PR refatora a lógica de parsing de respostas HTTP no `ApiProvider`, simplificando o tratamento de códigos de status e melhorando o gerenciamento de erros. 

## Mudanças principais
- Substituição de `_parseStreamedResponse` por `_parseResponse`.
- Simplificação do tratamento de códigos de status HTTP.
- Adição de `ApiContentTypeExtension` para gerenciamento de tipos de conteúdo.
- Adição de `api_provider_mock.dart` para testes.

## Impacto
Nenhum impacto externo é esperado, pois as mudanças são internas e não alteram o comportamento da API.