### PR TITLE
[refactor] Substituição de device_info e package_info por device_info_plus e package_info_plus

### DIFF
--- a/lib/app/core/network/api_server_configure.dart
+++ b/lib/app/core/network/api_server_configure.dart
@@ -1,5 +1,5 @@
-import 'package:device_info/device_info.dart';
-import 'package:package_info/package_info.dart';
+import 'package:device_info_plus/device_info_plus.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:platform/platform.dart';
 
 import '../managers/app_configuration.dart';
@@ -61,13 +61,17 @@ class ApiServerConfigure implements IApiServerConfigure {
   _DeviceInfo _readAndroidBuildData(AndroidDeviceInfo build) {
     return _DeviceInfo(
       'Android',
-      build.version.release,
+      build.version.release ?? '0.0.0',
       '${build.brand} ${build.model}',
     );
   }
 
   _DeviceInfo _readIosDeviceInfo(IosDeviceInfo data) {
-    return _DeviceInfo('iOS', data.systemVersion, data.model);
+    return _DeviceInfo(
+      'iOS',
+      data.systemVersion ?? '0.0.0',
+      data.model ?? 'Invalid Model',
+    );
   }
 }
 

--- a/lib/app/core/network/api_server_configure.dart
+++ b/lib/app/core/network/api_server_configure.dart
@@ -14,11 +14,14 @@ class ApiServerConfigure implements IApiServerConfigure {
   ApiServerConfigure({
     required IAppConfiguration appConfiguration,
     Platform? platform,
+    DeviceInfoPlugin? deviceInfoPlugin,
   })  : _appConfiguration = appConfiguration,
-        _platform = platform ?? const LocalPlatform();
+        _platform = platform ?? const LocalPlatform(),
+        _deviceInfoPlugin = deviceInfoPlugin ?? DeviceInfoPlugin();
 
   final IAppConfiguration _appConfiguration;
   final Platform _platform;
+  final DeviceInfoPlugin _deviceInfoPlugin;
 
   @override
   Uri get baseUri => _appConfiguration.penhasServer;
@@ -42,14 +45,13 @@ class ApiServerConfigure implements IApiServerConfigure {
   }
 
   Future<String> _deviceInfo() async {
-    final DeviceInfoPlugin deviceInfoPlugin = DeviceInfoPlugin();
     _DeviceInfo deviceData = _DeviceInfo('Error', '0.0.0', 'Invalid Model');
 
     try {
       if (_platform.isAndroid) {
-        deviceData = _readAndroidBuildData(await deviceInfoPlugin.androidInfo);
+        deviceData = _readAndroidBuildData(await _deviceInfoPlugin.androidInfo);
       } else if (_platform.isIOS) {
-        deviceData = _readIosDeviceInfo(await deviceInfoPlugin.iosInfo);
+        deviceData = _readIosDeviceInfo(await _deviceInfoPlugin.iosInfo);
       }
     } catch (_) {
       deviceData = _DeviceInfo('Error', '0.0.0', 'Invalid Model');

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -274,20 +274,48 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.10.1"
-  device_info:
+  device_info_plus:
     dependency: "direct main"
     description:
-      name: device_info
+      name: device_info_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
-  device_info_platform_interface:
+    version: "4.0.0"
+  device_info_plus_linux:
     dependency: transitive
     description:
-      name: device_info_platform_interface
+      name: device_info_plus_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.1.1"
+  device_info_plus_macos:
+    dependency: transitive
+    description:
+      name: device_info_plus_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.2.3"
+  device_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: device_info_plus_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.6.1"
+  device_info_plus_web:
+    dependency: transitive
+    description:
+      name: device_info_plus_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.0"
+  device_info_plus_windows:
+    dependency: transitive
+    description:
+      name: device_info_plus_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.1"
   email_validator:
     dependency: "direct main"
     description:
@@ -979,13 +1007,48 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
-  package_info:
+  package_info_plus:
     dependency: "direct main"
     description:
-      name: package_info
+      name: package_info_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "1.4.2"
+  package_info_plus_linux:
+    dependency: transitive
+    description:
+      name: package_info_plus_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.5"
+  package_info_plus_macos:
+    dependency: transitive
+    description:
+      name: package_info_plus_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.0"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.2"
+  package_info_plus_web:
+    dependency: transitive
+    description:
+      name: package_info_plus_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.6"
+  package_info_plus_windows:
+    dependency: transitive
+    description:
+      name: package_info_plus_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.5"
   path:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   crypto: ^3.0.1
   cupertino_icons: ^1.0.4
   dartz: ^0.10.1
-  device_info: ^2.0.3
+  device_info_plus:
   email_validator: ^2.0.1
   equatable: ^2.0.3
   firebase_analytics: '9.3.1'
@@ -59,7 +59,7 @@ dependencies:
   mask_text_input_formatter: ^2.0.0
   meta: ^1.7.0
   mobx: ^2.0.5
-  package_info: ^2.0.2
+  package_info_plus:
   path: ^1.8.0
   path_provider: ^2.0.8
   path_provider_android: ^2.0.22

--- a/test/app/core/network/api_server_configure_test.dart
+++ b/test/app/core/network/api_server_configure_test.dart
@@ -9,6 +9,8 @@ class MockAppConfiguration extends Mock implements IAppConfiguration {}
 
 class MockPlatform extends Mock implements Platform {}
 
+const packageInfoChannel = 'dev.fluttercommunity.plus/package_info';
+const deviceInfoChannel = 'dev.fluttercommunity.plus/device_info';
 void main() {
   late IAppConfiguration appConfiguration;
   late Platform platform;
@@ -48,7 +50,7 @@ void main() {
     test('crash return default userAgent', () async {
       // arrange
       const expected = 'Error 0.0.0/Invalid Model/42';
-      const channelPackage = MethodChannel('plugins.flutter.io/package_info');
+      const channelPackage = MethodChannel(packageInfoChannel);
 
       channelPackage.setMockMethodCallHandler((call) async {
         return {
@@ -68,8 +70,8 @@ void main() {
     test('in Android return userAgent with Android info', () async {
       // arrange
       const expected = 'Android release/Google model/42';
-      const channelPackage = MethodChannel('plugins.flutter.io/package_info');
-      const channelDeviceInfo = MethodChannel('plugins.flutter.io/device_info');
+      const channelPackage = MethodChannel(packageInfoChannel);
+      const channelDeviceInfo = MethodChannel(deviceInfoChannel);
 
       channelPackage.setMockMethodCallHandler((call) async {
         return {
@@ -94,8 +96,8 @@ void main() {
     test('in iOS return userAgent with iOS info', () async {
       // arrange
       const expected = 'iOS systemVersion/model/42';
-      const channelPackage = MethodChannel('plugins.flutter.io/package_info');
-      const channelDeviceInfo = MethodChannel('plugins.flutter.io/device_info');
+      const channelPackage = MethodChannel(packageInfoChannel);
+      const channelDeviceInfo = MethodChannel(deviceInfoChannel);
 
       channelPackage.setMockMethodCallHandler((call) async {
         return {


### PR DESCRIPTION
Este PR realiza a migração das dependências `device_info` e `package_info` para suas versões atualizadas e mantidas pela comunidade: `device_info_plus` e `package_info_plus`. Essa mudança visa garantir maior compatibilidade com as versões mais recentes do Flutter e melhorar a manutenção do código.

## Principais Alterações

1. **Migração para `device_info_plus`:**
   - Substituição da dependência `device_info` por `device_info_plus`.
   - Atualização do código para utilizar as novas APIs fornecidas pelo `device_info_plus`.
   - Adição de verificações de nulidade para garantir segurança em cenários onde os dados do dispositivo podem não estar disponíveis.

2. **Migração para `package_info_plus`:**
   - Substituição da dependência `package_info` por `package_info_plus`.
   - Atualização do código para utilizar as novas APIs fornecidas pelo `package_info_plus`.
   - Ajustes nos testes para refletir a mudança no canal de comunicação (`MethodChannel`).

3. **Atualização do `pubspec.yaml`:**
   - Remoção das dependências antigas (`device_info` e `package_info`).
   - Adição das novas dependências (`device_info_plus` e `package_info_plus`).

4. **Ajustes nos Testes:**
   - Atualização dos testes para refletir as mudanças nas dependências.
   - Correção dos canais de comunicação (`MethodChannel`) nos testes para utilizar os novos pacotes.

## Impacto e Benefícios

- **Compatibilidade Melhorada:** As novas dependências são mais compatíveis com as versões recentes do Flutter e Dart.
- **Manutenção Simplificada:** `device_info_plus` e `package_info_plus` são mantidos ativamente pela comunidade, garantindo atualizações e correções de bugs mais rápidas.
