### PR TITLE
fix(workflow) : Adiciona permissões explícitas ao `GITHUB_TOKEN` nos workflows

### DIFF
--- a/.github/workflows/check-generated-files.yml
+++ b/.github/workflows/check-generated-files.yml
@@ -12,6 +12,12 @@ concurrency:
 jobs:
   check:
     runs-on: ubuntu-latest
+
+    # Define permissions for the GITHUB_TOKEN
+    permissions:
+      contents: read  # Only read access to repository contents
+      pull-requests: read  # Only read access to pull requests
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/check_secrets.yml
+++ b/.github/workflows/check_secrets.yml
@@ -2,14 +2,22 @@
 name: Leaked Secrets Scan
 on:
   - pull_request
+
 jobs:
   TruffleHog:
     runs-on: ubuntu-latest
+
+    # Restrict permissions for GITHUB_TOKEN
+    permissions:
+      contents: read  # Only allow reading the repository contents
+      pull-requests: read  # Only allow reading pull requests
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - name: TruffleHog OSS
         uses: trufflesecurity/trufflehog@main
         with:

--- a/.github/workflows/distribute-flutter-android.yml
+++ b/.github/workflows/distribute-flutter-android.yml
@@ -20,6 +20,13 @@ on:
       TESTER_EMAIL:
         required: false
 
+# Define permissions for GITHUB_TOKEN
+permissions:
+  contents: read  # Required for actions/checkout
+  id-token: write # Required for some authentication tasks
+  packages: write # Required if you're publishing packages
+  actions: write  # Required if you're triggering other workflows
+
 jobs:
   distribute:
     runs-on: ubuntu-latest

--- a/.github/workflows/distribute-flutter-ios.yml
+++ b/.github/workflows/distribute-flutter-ios.yml
@@ -33,6 +33,14 @@ jobs:
   distribute:
     runs-on: macos-latest
     environment: ${{ inputs.environment }}
+    
+    # Add permissions here
+    permissions:
+      contents: read  # Only read access to the repository contents
+      actions: write  # If you need to trigger other workflows
+      checks: write   # If you need to create or update checks
+      deployments: write  # If you need to create deployments
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/manual-distribution.yml
+++ b/.github/workflows/manual-distribution.yml
@@ -16,6 +16,12 @@ on:
         type: environment
         required: true
 
+# Define permissions for the GITHUB_TOKEN
+permissions:
+  contents: read  # Required to read the repository contents
+  packages: write # Required if you are publishing packages
+  actions: read   # Required if you are using reusable workflows
+
 jobs:
 
   distribute-android:

--- a/.github/workflows/tester-email-distribute.yml
+++ b/.github/workflows/tester-email-distribute.yml
@@ -16,6 +16,13 @@ on:
         type: string
         required: true
 
+# Define permissions for the GITHUB_TOKEN
+permissions:
+  contents: read  # Only read access to the repository contents
+  actions: write  # Allow writing to actions (if needed)
+  checks: write   # Allow writing to checks (if needed)
+  # Add other permissions as needed
+
 jobs:
 
   distribute-android:


### PR DESCRIPTION
Este PR adiciona permissões explícitas ao `GITHUB_TOKEN` em vários workflows para garantir que as ações tenham apenas as permissões necessárias para executar suas tarefas. Isso segue as melhores práticas de segurança, minimizando o risco de acesso indevido ou ações maliciosas.

## Alterações realizadas
- Adicionadas permissões explícitas ao `GITHUB_TOKEN` nos seguintes workflows:
  - `check-generated-files.yml`
  - `check_secrets.yml`
  - `distribute-flutter-android.yml`
  - `distribute-flutter-ios.yml`
  - `manual-distribution.yml`
  - `tester-email-distribute.yml`

## Permissões configuradas
- `contents: read`: Permite apenas leitura do conteúdo do repositório.
- `pull-requests: read`: Permite apenas leitura de pull requests.
- `id-token: write`: Necessário para autenticação em alguns cenários.
- `packages: write`: Necessário para publicar pacotes.
- `actions: write`: Necessário para acionar outros workflows.
- `checks: write`: Necessário para criar ou atualizar verificações.
- `deployments: write`: Necessário para criar implantações.

