### PR TITLE
Fix: Adicionar id-token no actions

### DIFF
--- a/.github/workflows/manual-distribution.yml
+++ b/.github/workflows/manual-distribution.yml
@@ -20,7 +20,8 @@ on:
 permissions:
   contents: read  # Required to read the repository contents
   packages: write # Required if you are publishing packages
-  actions: read   # Required if you are using reusable workflows
+  actions: write  # Required if you are using reusable workflows
+  id-token: write   
 
 jobs:
 


### PR DESCRIPTION
Ao tentar rodar o workflow para gerar app de teste, o actions esta mostrando um erro, pedindo para que nas permissoes, o actions e id-token sejam configurados como write.
Este pr altera actions para write e adicionar id.token.