### PR TITLE
Habilita renovate bot para atualizações

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:best-practices",
+    "shcedule:monthly"
+  ]
+}


### PR DESCRIPTION
A proposta é usarmos o renovate para não deixar nossas dependências de pacotes ficarem muito defasadas novamente.
Não precisarmos de um fluxo de incorporar tais modificações num ritmo muito rápido, então configurei ele para rodar uma vez por mês (se entendi direito as configurações).

Mesmo assim não precisa ser algo sempre nesse ritmo, mas pelo menos nos dá uma perspectiva de quão defasados estamos em termos de atualizar versões e dependências.

**Comentário: Para fazer merge depois de fazermos o merge das atualizações finais do flutter.**