### PR TITLE
(Refactor) Travar Google maps para versao que funcione no IOS 15

### DIFF
--- a/.github/workflows/distribute-flutter-ios.yml
+++ b/.github/workflows/distribute-flutter-ios.yml
@@ -71,12 +71,6 @@ jobs:
         env:
           APPLE_API_KEY_PATH: ${{ runner.temp }}/app-store-api-key.json
       
-      - name: Download provisioning profile
-        run: |
-          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-          echo "$PROVISIONING_PROFILE" | base64 -d > ~/Library/MobileDevice/Provisioning\ Profiles/my_ad_hoc_profile.mobileprovision
-
-
       - name: Create default keychain
         run: |
           security create-keychain -p "$KEYCHAIN_PWD" $KEYCHAIN_PATH
@@ -85,13 +79,9 @@ jobs:
           security unlock-keychain -p "$KEYCHAIN_PWD" $KEYCHAIN_PATH
           base64 -d <<< "$CERTIFICATE_CONTENT" > $CERTIFICATE_PATH
 
-          security import $CERTIFICATE_PATH -k $KEYCHAIN_PATH -P "$CERTIFICATE_PWD" -T /usr/bin/codesign
-          security list-keychains -d user -s $KEYCHAIN_PATH
-          security find-identity -v -p codesigning
         env:
           APPLE_API_KEY_PATH: ${{ runner.temp }}/app-store-api-key.json
           CERTIFICATE_CONTENT: ${{ secrets.CERTIFICATE_CONTENT }}
-          CERTIFICATE_PWD: ${{ secrets.CERTIFICATE_PWD }}
           CERTIFICATE_PATH: ${{ runner.temp }}/build_certificate.p12
           KEYCHAIN_PATH: ${{ runner.temp }}/app-signing.keychain-db
           KEYCHAIN_PWD: ${{ secrets.KEYCHAIN_PWD }}

--- a/.github/workflows/distribute-flutter-ios.yml
+++ b/.github/workflows/distribute-flutter-ios.yml
@@ -78,9 +78,13 @@ jobs:
           security default-keychain -s $KEYCHAIN_PATH
           security unlock-keychain -p "$KEYCHAIN_PWD" $KEYCHAIN_PATH
           base64 -d <<< "$CERTIFICATE_CONTENT" > $CERTIFICATE_PATH
+
+          security import $CERTIFICATE_PATH -k $KEYCHAIN_PATH -P "$CERTIFICATE_PWD" -T /usr/bin/codesign
+          security list-keychains -d user -s $KEYCHAIN_PATH
         env:
           APPLE_API_KEY_PATH: ${{ runner.temp }}/app-store-api-key.json
           CERTIFICATE_CONTENT: ${{ secrets.CERTIFICATE_CONTENT }}
+          CERTIFICATE_PWD: ${{ secrets.CERTIFICATE_PWD }}
           CERTIFICATE_PATH: ${{ runner.temp }}/build_certificate.p12
           KEYCHAIN_PATH: ${{ runner.temp }}/app-signing.keychain-db
           KEYCHAIN_PWD: ${{ secrets.KEYCHAIN_PWD }}

--- a/.github/workflows/distribute-flutter-ios.yml
+++ b/.github/workflows/distribute-flutter-ios.yml
@@ -70,6 +70,12 @@ jobs:
         run: base64 -d <<< "${{ secrets.APPLE_API_KEY_B64 }}" > $APPLE_API_KEY_PATH
         env:
           APPLE_API_KEY_PATH: ${{ runner.temp }}/app-store-api-key.json
+      
+      - name: Download provisioning profile
+        run: |
+          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+          echo "$PROVISIONING_PROFILE" | base64 -d > ~/Library/MobileDevice/Provisioning\ Profiles/my_ad_hoc_profile.mobileprovision
+
 
       - name: Create default keychain
         run: |
@@ -81,6 +87,7 @@ jobs:
 
           security import $CERTIFICATE_PATH -k $KEYCHAIN_PATH -P "$CERTIFICATE_PWD" -T /usr/bin/codesign
           security list-keychains -d user -s $KEYCHAIN_PATH
+          security find-identity -v -p codesigning
         env:
           APPLE_API_KEY_PATH: ${{ runner.temp }}/app-store-api-key.json
           CERTIFICATE_CONTENT: ${{ secrets.CERTIFICATE_CONTENT }}

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -81,7 +81,7 @@ PODS:
     - FirebaseSharedSwift (~> 11.0)
     - GoogleUtilities/Environment (~> 8.0)
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
-  - FirebaseRemoteConfigInterop (11.10.0)
+  - FirebaseRemoteConfigInterop (11.11.0)
   - FirebaseSessions (11.8.0):
     - FirebaseCore (~> 11.8.0)
     - FirebaseCoreExtension (~> 11.8.0)
@@ -91,7 +91,7 @@ PODS:
     - GoogleUtilities/UserDefaults (~> 8.0)
     - nanopb (~> 3.30910.0)
     - PromisesSwift (~> 2.1)
-  - FirebaseSharedSwift (11.10.0)
+  - FirebaseSharedSwift (11.11.0)
   - Flutter (1.0.0)
   - flutter_background_service_ios (0.0.3):
     - Flutter
@@ -104,12 +104,9 @@ PODS:
   - geolocator_apple (1.2.0):
     - Flutter
     - FlutterMacOS
-  - Google-Maps-iOS-Utils (5.0.0):
-    - GoogleMaps (~> 8.0)
-  - google_maps_flutter_ios (0.0.1):
+  - google_maps_flutter (0.0.1):
     - Flutter
-    - Google-Maps-iOS-Utils (< 7.0, >= 5.0)
-    - GoogleMaps (< 10.0, >= 8.4)
+    - GoogleMaps
   - GoogleAppMeasurement (11.8.0):
     - GoogleAppMeasurement/AdIdSupport (= 11.8.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
@@ -212,7 +209,7 @@ DEPENDENCIES:
   - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
   - flutter_sound (from `.symlinks/plugins/flutter_sound/ios`)
   - geolocator_apple (from `.symlinks/plugins/geolocator_apple/darwin`)
-  - google_maps_flutter_ios (from `.symlinks/plugins/google_maps_flutter_ios/ios`)
+  - google_maps_flutter (from `.symlinks/plugins/google_maps_flutter/ios`)
   - just_audio (from `.symlinks/plugins/just_audio/darwin`)
   - map_launcher (from `.symlinks/plugins/map_launcher/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
@@ -240,7 +237,6 @@ SPEC REPOS:
     - FirebaseSessions
     - FirebaseSharedSwift
     - flutter_sound_core
-    - Google-Maps-iOS-Utils
     - GoogleAppMeasurement
     - GoogleDataTransport
     - GoogleMaps
@@ -272,8 +268,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_sound/ios"
   geolocator_apple:
     :path: ".symlinks/plugins/geolocator_apple/darwin"
-  google_maps_flutter_ios:
-    :path: ".symlinks/plugins/google_maps_flutter_ios/ios"
+  google_maps_flutter:
+    :path: ".symlinks/plugins/google_maps_flutter/ios"
   just_audio:
     :path: ".symlinks/plugins/just_audio/darwin"
   map_launcher:
@@ -313,17 +309,16 @@ SPEC CHECKSUMS:
   FirebaseCrashlytics: a1102c035f18d5dd94a5969ee439c526d0c9e313
   FirebaseInstallations: 6c963bd2a86aca0481eef4f48f5a4df783ae5917
   FirebaseRemoteConfig: f63724461fd97f0d62f20021314b59388f3e8ef8
-  FirebaseRemoteConfigInterop: 7c9a9c65eff32cbb0f7bf8d18140612ad57dfcc6
+  FirebaseRemoteConfigInterop: 85bdce8babed7814816496bb6f082bc05b0a45e1
   FirebaseSessions: c4d40a97f88f9eaff2834d61b4fea0a522d62123
-  FirebaseSharedSwift: 1baacae75939499b5def867cbe34129464536a38
+  FirebaseSharedSwift: b1d32c3b29a911dc174bcf363f2f70bda9509d2f
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   flutter_background_service_ios: 00d31bdff7b4bfe06d32375df358abe0329cf87e
   flutter_secure_storage: 1ed9476fba7e7a782b22888f956cce43e2c62f13
   flutter_sound: 713fa9789114be275e975c7c98e8df82812dd7ee
   flutter_sound_core: eed9770a54160cf4d4e1d3259c4c34738654df55
   geolocator_apple: ab36aa0e8b7d7a2d7639b3b4e48308394e8cef5e
-  Google-Maps-iOS-Utils: 66d6de12be1ce6d3742a54661e7a79cb317a9321
-  google_maps_flutter_ios: 0291eb2aa252298a769b04d075e4a9d747ff7264
+  google_maps_flutter: 959052dacd215200d5ab4b922d183e184442deb4
   GoogleAppMeasurement: fc0817122bd4d4189164f85374e06773b9561896
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleMaps: 8939898920281c649150e0af74aa291c60f2e77d

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -104,9 +104,12 @@ PODS:
   - geolocator_apple (1.2.0):
     - Flutter
     - FlutterMacOS
-  - google_maps_flutter (0.0.1):
+  - Google-Maps-iOS-Utils (5.0.0):
+    - GoogleMaps (~> 8.0)
+  - google_maps_flutter_ios (0.0.1):
     - Flutter
-    - GoogleMaps
+    - Google-Maps-iOS-Utils (< 7.0, >= 5.0)
+    - GoogleMaps (< 10.0, >= 8.4)
   - GoogleAppMeasurement (11.8.0):
     - GoogleAppMeasurement/AdIdSupport (= 11.8.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
@@ -209,7 +212,7 @@ DEPENDENCIES:
   - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
   - flutter_sound (from `.symlinks/plugins/flutter_sound/ios`)
   - geolocator_apple (from `.symlinks/plugins/geolocator_apple/darwin`)
-  - google_maps_flutter (from `.symlinks/plugins/google_maps_flutter/ios`)
+  - google_maps_flutter_ios (from `.symlinks/plugins/google_maps_flutter_ios/ios`)
   - just_audio (from `.symlinks/plugins/just_audio/darwin`)
   - map_launcher (from `.symlinks/plugins/map_launcher/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
@@ -237,6 +240,7 @@ SPEC REPOS:
     - FirebaseSessions
     - FirebaseSharedSwift
     - flutter_sound_core
+    - Google-Maps-iOS-Utils
     - GoogleAppMeasurement
     - GoogleDataTransport
     - GoogleMaps
@@ -268,8 +272,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_sound/ios"
   geolocator_apple:
     :path: ".symlinks/plugins/geolocator_apple/darwin"
-  google_maps_flutter:
-    :path: ".symlinks/plugins/google_maps_flutter/ios"
+  google_maps_flutter_ios:
+    :path: ".symlinks/plugins/google_maps_flutter_ios/ios"
   just_audio:
     :path: ".symlinks/plugins/just_audio/darwin"
   map_launcher:
@@ -294,13 +298,13 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/webview_flutter_wkwebview/darwin"
 
 SPEC CHECKSUMS:
-  audio_session: 9bb7f6c970f21241b19f5a3658097ae459681ba0
-  device_info_plus: 21fcca2080fbcd348be798aa36c3e5ed849eefbe
+  audio_session: 19e9480dbdd4e5f6c4543826b2e8b0e4ab6145fe
+  device_info_plus: bf2e3232933866d73fe290f2942f2156cdd10342
   Firebase: d80354ed7f6df5f9aca55e9eb47cc4b634735eaf
-  firebase_analytics: d9a47ad8168f1da7bab57cd1400833d2bc48a043
-  firebase_core: 8d552814f6c01ccde5d88939fced4ec26f2f5510
-  firebase_crashlytics: 05519be6b623981a77fe54fb52e6061956cb6047
-  firebase_remote_config: ca499f96ddbcc63db863b941bf9f5e6e9a81ceba
+  firebase_analytics: 7ec1166af61987fa968766eb11587c562a5650ee
+  firebase_core: ac395f994af4e28f6a38b59e05a88ca57abeb874
+  firebase_crashlytics: 0f3a46f30fce2159f715ac33eef98a2aa5d598f1
+  firebase_remote_config: a98909ec3fd3aef7a128d5a507181c82abc8694e
   FirebaseABTesting: 7d6eee42b9137541eac2610e5fea3568d956707a
   FirebaseAnalytics: 4fd42def128146e24e480e89f310e3d8534ea42b
   FirebaseCore: 99fe0c4b44a39f37d99e6404e02009d2db5d718d
@@ -313,30 +317,31 @@ SPEC CHECKSUMS:
   FirebaseSessions: c4d40a97f88f9eaff2834d61b4fea0a522d62123
   FirebaseSharedSwift: b1d32c3b29a911dc174bcf363f2f70bda9509d2f
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_background_service_ios: 00d31bdff7b4bfe06d32375df358abe0329cf87e
-  flutter_secure_storage: 1ed9476fba7e7a782b22888f956cce43e2c62f13
-  flutter_sound: 713fa9789114be275e975c7c98e8df82812dd7ee
+  flutter_background_service_ios: e30e0d3ee69e4cee66272d0c78eacd48c2e94aac
+  flutter_secure_storage: d33dac7ae2ea08509be337e775f6b59f1ff45f12
+  flutter_sound: 47dd7c20f8acf17507ba504c76992198be7879a5
   flutter_sound_core: eed9770a54160cf4d4e1d3259c4c34738654df55
-  geolocator_apple: ab36aa0e8b7d7a2d7639b3b4e48308394e8cef5e
-  google_maps_flutter: 959052dacd215200d5ab4b922d183e184442deb4
+  geolocator_apple: 66b711889fd333205763b83c9dcf0a57a28c7afd
+  Google-Maps-iOS-Utils: 66d6de12be1ce6d3742a54661e7a79cb317a9321
+  google_maps_flutter_ios: e31555a04d1986ab130f2b9f24b6cdc861acc6d3
   GoogleAppMeasurement: fc0817122bd4d4189164f85374e06773b9561896
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleMaps: 8939898920281c649150e0af74aa291c60f2e77d
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  just_audio: 4e391f57b79cad2b0674030a00453ca5ce817eed
-  map_launcher: fe43bda6720bb73c12fcc1bdd86123ff49a4d4d6
+  just_audio: a42c63806f16995daf5b219ae1d679deb76e6a79
+  map_launcher: 5fde49ac9a52672bf99da746599f507b4490d7b5
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
-  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
-  path_provider_ios: 025d0bdaa9f9ab016700ac1e07ff63415cf638e9
-  permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
+  package_info_plus: c0502532a26c7662a62a356cebe2692ec5fe4ec4
+  path_provider_ios: 14f3d2fd28c4fdb42f44e0f751d12861c43cee02
+  permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
-  shared_preferences_ios: 7ee5572d25d2f093bc27a9ede31993d8737a711d
-  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
-  url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
-  video_player_avfoundation: 2cef49524dd1f16c5300b9cd6efd9611ce03639b
-  wakelock_plus: 04623e3f525556020ebd4034310f20fe7fda8b49
-  webview_flutter_wkwebview: 1821ceac936eba6f7984d89a9f3bcb4dea99ebb2
+  shared_preferences_ios: 548a61f8053b9b8a49ac19c1ffbc8b92c50d68ad
+  sqflite_darwin: 5a7236e3b501866c1c9befc6771dfd73ffb8702d
+  url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
+  video_player_avfoundation: 7c6c11d8470e1675df7397027218274b6d2360b3
+  wakelock_plus: 373cfe59b235a6dd5837d0fb88791d2f13a90d56
+  webview_flutter_wkwebview: a4af96a051138e28e29f60101d094683b9f82188
 
 PODFILE CHECKSUM: 523a019f6fbc954f537ac9e0ebc60aab48e66655
 

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -9,8 +9,8 @@
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
-		53B5742ACA1244E5F06F7894 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EB8481D2D55E81DFD0092E7D /* Pods_Runner.framework */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
+		8B2FCCBB5596ABE474CFF068 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E1310799E80D0E1360CBA873 /* Pods_Runner.framework */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
@@ -33,13 +33,11 @@
 /* Begin PBXFileReference section */
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
-		26538243E43CEEC3165F0A8D /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
-		4B8C53A19B6EF06A3BDE05C7 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		4DF1CDA8CF05D4CE852C75E9 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
-		7DC94F8BF40EE974143B2369 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -47,8 +45,10 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		EB8481D2D55E81DFD0092E7D /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D7FBF59DACCB7A515B9AFC8B /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		E1310799E80D0E1360CBA873 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F24D58B15015C3A524633FB5 /* GoogleService-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "Runner/GoogleService-Info.plist"; sourceTree = "<group>"; };
+		FAE9F1BAE33B8602EB813D2B /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		FCBA930D24B6066E00D2615C /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -57,7 +57,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				53B5742ACA1244E5F06F7894 /* Pods_Runner.framework in Frameworks */,
+				8B2FCCBB5596ABE474CFF068 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -83,7 +83,7 @@
 				97C146EF1CF9000F007C117D /* Products */,
 				BEE34599E28C43DA05E04174 /* Pods */,
 				F24D58B15015C3A524633FB5 /* GoogleService-Info.plist */,
-				BD865FBCB57A7B6840D94DD3 /* Frameworks */,
+				C74F383978FFA7CD44A1748C /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -119,22 +119,22 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
-		BD865FBCB57A7B6840D94DD3 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				EB8481D2D55E81DFD0092E7D /* Pods_Runner.framework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
 		BEE34599E28C43DA05E04174 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				4B8C53A19B6EF06A3BDE05C7 /* Pods-Runner.debug.xcconfig */,
-				26538243E43CEEC3165F0A8D /* Pods-Runner.release.xcconfig */,
-				7DC94F8BF40EE974143B2369 /* Pods-Runner.profile.xcconfig */,
+				FAE9F1BAE33B8602EB813D2B /* Pods-Runner.debug.xcconfig */,
+				4DF1CDA8CF05D4CE852C75E9 /* Pods-Runner.release.xcconfig */,
+				D7FBF59DACCB7A515B9AFC8B /* Pods-Runner.profile.xcconfig */,
 			);
 			path = Pods;
+			sourceTree = "<group>";
+		};
+		C74F383978FFA7CD44A1748C /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				E1310799E80D0E1360CBA873 /* Pods_Runner.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -144,7 +144,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
-				0BFBB598F201C7AFC3E843D4 /* [CP] Check Pods Manifest.lock */,
+				098D2CA729A6565C9753898E /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
@@ -153,8 +153,8 @@
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				FCC41D2424B5FA85006655DB /* ShellScript */,
 				C591514C2953560D00323941 /* Run Dev Env Script */,
-				046E2C6AFAED6F0CF8EBD75A /* [CP] Embed Pods Frameworks */,
-				DC06A015AB17F31A0B0C866A /* [CP] Copy Pods Resources */,
+				E68E4DE27738E2637B033D77 /* [CP] Embed Pods Frameworks */,
+				CE4AB3AD60870EF2A231AE41 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -176,7 +176,6 @@
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
 						CreatedOnToolsVersion = 7.3.1;
-						DevelopmentTeam = 295N44GCDS;
 						LastSwiftMigration = 1100;
 					};
 				};
@@ -215,24 +214,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		046E2C6AFAED6F0CF8EBD75A /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		0BFBB598F201C7AFC3E843D4 /* [CP] Check Pods Manifest.lock */ = {
+		098D2CA729A6565C9753898E /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -304,7 +286,7 @@
 			shellPath = /bin/sh;
 			shellScript = "${SRCROOT}/Scripts/custom_config.sh\n";
 		};
-		DC06A015AB17F31A0B0C866A /* [CP] Copy Pods Resources */ = {
+		CE4AB3AD60870EF2A231AE41 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -319,6 +301,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		E68E4DE27738E2637B033D77 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		FCC41D2424B5FA85006655DB /* ShellScript */ = {

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -84,7 +84,12 @@ platform :ios do
       archive_path: "#{$project_path}/build/ios/Runner.xcarchive",
       output_directory: "#{$project_path}/build/ios/Runner",
       export_method: options[:profile_type],
-      xcargs: "PROVISIONING_PROFILE_SPECIFIER='#{profile_uuid}'",
+      export_options: {
+        provisioningProfiles: {
+          ENV['IOS_BUNDLE_ID'] => provisioning_names[options[:profile_type].to_sym]
+        }
+      },
+      xcargs: "CODE_SIGN_STYLE=Manual PROVISIONING_PROFILE_SPECIFIER='#{profile_uuid}'",
     )
   end
 

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -84,12 +84,7 @@ platform :ios do
       archive_path: "#{$project_path}/build/ios/Runner.xcarchive",
       output_directory: "#{$project_path}/build/ios/Runner",
       export_method: options[:profile_type],
-      export_options: {
-        provisioningProfiles: {
-          ENV['IOS_BUNDLE_ID'] => provisioning_names[options[:profile_type].to_sym]
-        }
-      },
-      xcargs: "CODE_SIGN_STYLE=Manual PROVISIONING_PROFILE_SPECIFIER='#{profile_uuid}'",
+      xcargs: "PROVISIONING_PROFILE_SPECIFIER='#{profile_uuid}'",
     )
   end
 

--- a/lib/app/features/chat/data/models/chat_user_model.dart
+++ b/lib/app/features/chat/data/models/chat_user_model.dart
@@ -13,10 +13,10 @@ class ChatUserModel extends ChatUserEntity {
 
   factory ChatUserModel.fromJson(Map<String, dynamic> jsonData) {
     List<ChatBadgeEntity> badges = [];
-    if (jsonData['badges'] != null) {
-      badges = _parseBadges(jsonData['badges']);
-    } else {
-      badges = _parseBadges(jsonData['other_badges']);
+
+    final rawBadges = jsonData['badges'] ?? jsonData['other_badges'];
+    if (rawBadges != null) {
+      badges = _parseBadges(rawBadges);
     }
 
     return ChatUserModel(

--- a/lib/app/features/chat/presentation/talk/chat_main_talks_controller.dart
+++ b/lib/app/features/chat/presentation/talk/chat_main_talks_controller.dart
@@ -4,6 +4,7 @@ import 'package:mobx/mobx.dart';
 
 import '../../../../core/error/failures.dart';
 import '../../../authentication/presentation/shared/map_failure_message.dart';
+import '../../../escape_manual/domain/entity/quiz_page_args.dart';
 import '../../domain/entities/chat_channel_available_entity.dart';
 import '../../domain/entities/chat_channel_entity.dart';
 import '../../domain/entities/chat_channel_open_entity.dart';
@@ -50,10 +51,11 @@ abstract class IChatMainTalksController with Store, MapFailureMessage {
   @action
   Future<void> openAssistantCard(ChatMainSupportTile data) async {
     if (data.quizSession != null) {
-      await Modular.to.popAndPushNamed(
-        '/quiz?origin=chat',
-        arguments: data.quizSession,
+      await Modular.to.pushNamed(
+        '/quiz',
+        arguments: QuizPageArgs(origin: 'chat', session: data.quizSession!),
       );
+
       return;
     }
 

--- a/lib/app/features/escape_manual/domain/entity/quiz_page_args.dart
+++ b/lib/app/features/escape_manual/domain/entity/quiz_page_args.dart
@@ -1,0 +1,10 @@
+import '../../../appstate/domain/entities/app_state_entity.dart';
+
+class QuizPageArgs {
+  QuizPageArgs({
+    required this.origin,
+    required this.session,
+  });
+  final String origin;
+  final QuizSessionEntity session;
+}

--- a/lib/app/features/escape_manual/presentation/escape_manual_controller.dart
+++ b/lib/app/features/escape_manual/presentation/escape_manual_controller.dart
@@ -16,6 +16,7 @@ import '../../authentication/presentation/shared/map_failure_message.dart';
 import '../../authentication/presentation/shared/page_progress_indicator.dart';
 import '../domain/delete_escape_manual_task.dart';
 import '../domain/entity/escape_manual.dart';
+import '../domain/entity/quiz_page_args.dart';
 import '../domain/get_escape_manual.dart';
 import '../domain/start_escape_manual.dart';
 import '../domain/update_escape_manual_task.dart';
@@ -178,8 +179,9 @@ abstract class EscapeManualControllerBase with Store, MapFailureMessage {
   void _handleOpenAssistant(QuizSessionEntity quizSession) {
     Modular.to
         .pushNamed(
-          '/quiz?origin=escape-manual',
-          arguments: quizSession,
+          '/quiz',
+          arguments:
+              QuizPageArgs(origin: 'escape-manual', session: quizSession),
         )
         .then((_) => load());
   }

--- a/lib/app/features/help_center/presentation/help_center_page.dart
+++ b/lib/app/features/help_center/presentation/help_center_page.dart
@@ -208,7 +208,8 @@ class _HelpCenterPageState extends State<HelpCenterPage> with SnackBarHandler {
   }
 
   Future<void> _actionOnTap(String callingNumber) async {
-    final phoneUri = Uri.parse(callingNumber);
+    final phoneUri = Uri(scheme: 'tel', path: callingNumber);
+
     if (await canLaunchUrl(phoneUri)) {
       await launchUrl(phoneUri);
     } else {

--- a/lib/app/features/quiz/presentation/quiz_start/quiz_start_controller.dart
+++ b/lib/app/features/quiz/presentation/quiz_start/quiz_start_controller.dart
@@ -7,6 +7,7 @@ import '../../../../core/extension/mobx.dart';
 import '../../../appstate/domain/entities/app_state_entity.dart';
 import '../../../authentication/presentation/shared/map_failure_message.dart';
 import '../../../authentication/presentation/shared/page_progress_indicator.dart';
+import '../../../escape_manual/domain/entity/quiz_page_args.dart';
 import '../../domain/start_quiz.dart';
 import 'quiz_start_state.dart';
 
@@ -50,9 +51,9 @@ abstract class QuizStartControllerBase with Store, MapFailureMessage {
   }
 
   void _handleSuccess(QuizSessionEntity session) {
-    Modular.to.pushReplacementNamed(
-      '/quiz?origin=start-quiz',
-      arguments: session,
+    Modular.to.pushNamed(
+      '/quiz',
+      arguments: QuizPageArgs(origin: 'start-quiz', session: session),
     );
   }
 }

--- a/lib/app/features/quiz/quiz_module.dart
+++ b/lib/app/features/quiz/quiz_module.dart
@@ -5,6 +5,7 @@ import '../../core/network/api_client.dart';
 import '../../core/remoteconfig/i_remote_config.dart';
 import '../../shared/navigation/app_navigator.dart';
 import '../appstate/domain/usecases/app_state_usecase.dart';
+import '../escape_manual/domain/entity/quiz_page_args.dart';
 import '../help_center/presentation/pages/tutorial/guardian/guardian_tutorial_page.dart';
 import 'data/repositories/quiz_repository.dart';
 import 'domain/quiz_remote_config.dart';
@@ -21,16 +22,17 @@ import 'presentation/tutorial/stealth_mode_tutorial_page_controller.dart';
 class QuizModule extends Module {
   @override
   List<Bind> get binds => [
-        Bind.factory<IQuizController>(
-          (i) => IQuizController.legacy(
-            quiz: i.args.data,
+        Bind.factory<IQuizController>((i) {
+          final args = i.args.data as QuizPageArgs;
+          return IQuizController.legacy(
+            quiz: args.session,
             sendAnswer: i.get<SendAnswerUseCase>(),
             remoteConfig: QuizRemoteConfig(
               remoteConfig: i.get<IRemoteConfigService>(),
             ),
             navigator: i.get<AppNavigator>(),
-          ),
-        ),
+          );
+        }),
         Bind.factory<QuizStartController>(
           (i) => QuizStartController(
             sessionId: i.args.queryParams['session_id'],

--- a/lib/app/features/splash/splash_controller.dart
+++ b/lib/app/features/splash/splash_controller.dart
@@ -10,6 +10,7 @@ import '../../shared/navigation/app_route.dart';
 import '../appstate/domain/entities/app_state_entity.dart';
 import '../appstate/domain/entities/user_profile_entity.dart';
 import '../appstate/domain/usecases/app_state_usecase.dart';
+import '../escape_manual/domain/entity/quiz_page_args.dart';
 
 part 'splash_controller.g.dart';
 
@@ -82,9 +83,11 @@ abstract class _SplashControllerBase with Store {
   void _handleAppStates(AppStateEntity session) {
     if (session.quizSession?.isFinished == false) {
       Modular.to.popAndPushNamed(
-        '/quiz?origin=splash',
-        arguments: session.quizSession,
+        '/quiz',
+        arguments:
+            QuizPageArgs(origin: 'splash', session: session.quizSession!),
       );
+
       return;
     }
 

--- a/lib/bootstrap/bootstrap.dart
+++ b/lib/bootstrap/bootstrap.dart
@@ -27,19 +27,15 @@ class Bootstrap {
     Runner runner, {
     OnBeforeRun? onBeforeRun,
   }) async {
-    await runner.initialize();
+    try {
+      await runner.initialize();
+      await runner.configure();
+      if (onBeforeRun != null) await onBeforeRun();
 
-    return runZonedGuarded(
-      () async {
-        await runner.configure();
-        if (onBeforeRun != null) await onBeforeRun();
-
-        runner.run();
-      },
-      (error, stack) {
-        _logger.shout('Uncaught error', error, stack);
-      },
-    );
+      runner.run();
+    } catch (error, stack) {
+      _logger.shout('Uncaught error', error, stack);
+    }
   }
 }
 

--- a/lib/bootstrap/impl/app_runner_mixin.dart
+++ b/lib/bootstrap/impl/app_runner_mixin.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/widgets.dart';
 
 import '../../app/core/extension/hive.dart';
 import '../../app/core/remoteconfig/remote_config.dart';
@@ -14,7 +13,6 @@ import '../bootstrap.dart';
 mixin RunnerMixin on Runner {
   @override
   FutureOr<void> initialize() async {
-    WidgetsFlutterBinding.ensureInitialized();
     await _initializeFirebase();
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,15 +1,30 @@
+import 'dart:async';
+import 'dart:developer';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
 import 'app/core/managers/impl/background_task_manager.dart';
 import 'bootstrap/bootstrap.dart';
 import 'bootstrap/impl/background_tasks_runner.dart';
 import 'bootstrap/impl/main_app_runner.dart';
 
 void main() {
-  Bootstrap.instance.withRunner(
-    MainAppRunner(),
-    onBeforeRun: () {
-      BackgroundTaskManager.instance.registerDispatcher(callbackDispatcher);
-    },
-  );
+  BindingBase.debugZoneErrorsAreFatal = true;
+
+  runZonedGuarded(() async {
+    WidgetsFlutterBinding.ensureInitialized();
+
+    await Bootstrap.instance.withRunner(
+      MainAppRunner(),
+      onBeforeRun: () {
+        BackgroundTaskManager.instance.registerDispatcher(callbackDispatcher);
+      },
+    );
+  }, (error, stack) {
+    // Tratamento global de erro
+    log('Error not disclosed $error');
+  });
 }
 
 @pragma('vm:entry-point')

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -778,38 +778,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.15.0"
-  google_maps:
-    dependency: transitive
-    description:
-      name: google_maps
-      sha256: "4d6e199c561ca06792c964fa24b2bac7197bf4b401c2e1d23e345e5f9939f531"
-      url: "https://pub.dev"
-    source: hosted
-    version: "8.1.1"
   google_maps_flutter:
     dependency: "direct main"
     description:
       name: google_maps_flutter
-      sha256: "20b84284fb8de970e3734820a5b3dae35983fafca3a873c8ee346d7802072fb0"
+      sha256: "6d5a374ab7ac75cf6d9de68eaef6702f1b9670b3943b5041ad98abc98e9870f4"
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
-  google_maps_flutter_android:
-    dependency: transitive
-    description:
-      name: google_maps_flutter_android
-      sha256: "0ede4ae8326335c0c007c8c7a8c9737449263123385e2bdf49f3e71103b2dc2e"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.16.0"
-  google_maps_flutter_ios:
-    dependency: transitive
-    description:
-      name: google_maps_flutter_ios
-      sha256: ef72c822930ce69515cb91c10cd88cfb8b26296f765808a43cbc9a10eaffacfe
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.15.0"
+    version: "2.1.1"
   google_maps_flutter_platform_interface:
     dependency: transitive
     description:
@@ -818,14 +794,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.11.1"
-  google_maps_flutter_web:
-    dependency: transitive
-    description:
-      name: google_maps_flutter_web
-      sha256: a45786ea6691cc7cdbe2cf3ce2c2daf4f82a885745666b4a36baada3a4e12897
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.5.12"
   graphs:
     dependency: transitive
     description:
@@ -1346,14 +1314,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.28.0"
-  sanitize_html:
-    dependency: transitive
-    description:
-      name: sanitize_html
-      sha256: "12669c4a913688a26555323fb9cec373d8f9fbe091f2d01c40c723b33caa8989"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.0"
   scroll_to_index:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -782,10 +782,26 @@ packages:
     dependency: "direct main"
     description:
       name: google_maps_flutter
-      sha256: "6d5a374ab7ac75cf6d9de68eaef6702f1b9670b3943b5041ad98abc98e9870f4"
+      sha256: "07f81e2d26a4dd2664e3beed547c75eb24b780c5c8519cd42bc0137308a1e7f6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.2.0"
+  google_maps_flutter_android:
+    dependency: transitive
+    description:
+      name: google_maps_flutter_android
+      sha256: "0ede4ae8326335c0c007c8c7a8c9737449263123385e2bdf49f3e71103b2dc2e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.16.0"
+  google_maps_flutter_ios:
+    dependency: transitive
+    description:
+      name: google_maps_flutter_ios
+      sha256: "2911e0c5654c2cc0d664324e0f49f055bb748740162821bdc0285045150b0439"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.15.1"
   google_maps_flutter_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,7 +45,7 @@ dependencies:
   flutter_widget_from_html: ^0.16.0
   freezed_annotation: ^2.1.0
   geolocator: ^12.0.0
-  google_maps_flutter: ^2.1.1
+  google_maps_flutter: 2.1.1
   hive_flutter: ^1.1.0
   http: ^1.2.2
   http_parser: ^4.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,7 +45,7 @@ dependencies:
   flutter_widget_from_html: ^0.16.0
   freezed_annotation: ^2.1.0
   geolocator: ^12.0.0
-  google_maps_flutter: 2.1.1
+  google_maps_flutter: 2.2.0
   hive_flutter: ^1.1.0
   http: ^1.2.2
   http_parser: ^4.0.0

--- a/test/app/features/chat/presentation/talk/chat_main_talks_page_test.dart
+++ b/test/app/features/chat/presentation/talk/chat_main_talks_page_test.dart
@@ -16,6 +16,7 @@ import 'package:penhas/app/features/chat/presentation/pages/chat_assistant_card.
 import 'package:penhas/app/features/chat/presentation/pages/chat_channel_card.dart';
 import 'package:penhas/app/features/chat/presentation/talk/chat_main_talks_controller.dart';
 import 'package:penhas/app/features/chat/presentation/talk/chat_main_talks_page.dart';
+import 'package:penhas/app/features/escape_manual/domain/entity/quiz_page_args.dart';
 
 import '../../../../../utils/golden_tests.dart';
 import '../../../../../utils/test_utils.dart';
@@ -82,10 +83,13 @@ void main() {
 
         // assert
         verify(
-          () => mockNavigator.popAndPushNamed(
-            '/quiz?origin=chat',
-            arguments: QuizSessionEntity(
-              sessionId: 'assistant-quiz-session',
+          () => mockNavigator.pushNamed(
+            '/quiz',
+            arguments: QuizPageArgs(
+              origin: 'chat',
+              session: QuizSessionEntity(
+                sessionId: 'assistant-quiz-session',
+              ),
             ),
           ),
         ).called(1);
@@ -209,9 +213,10 @@ void main() {
           (_) async => right(_chatChannelAvailableFixture),
         );
 
-        when(() => mockNavigator.popAndPushNamed(any(),
-                arguments: any(named: 'arguments')))
-            .thenAnswer((_) => Future.value());
+        when(() => mockNavigator.pushNamed(
+              any(),
+              arguments: any(named: 'arguments'),
+            )).thenAnswer((_) async => null);
 
         await tester.pumpWidget(
           MaterialApp(
@@ -223,12 +228,10 @@ void main() {
         await tester.tap(find.text('Assistente PenhaS'));
         await tester.pumpAndSettle();
         // assert
-        verify(
-          () => mockNavigator.popAndPushNamed(
-            '/quiz?origin=chat',
-            arguments: any(named: 'arguments'),
-          ),
-        ).called(1);
+        verify(() => mockNavigator.pushNamed(
+              any(),
+              arguments: any(named: 'arguments'),
+            )).called(1);
       }),
     );
   });

--- a/test/app/features/escape_manual/presentation/escape_manual_controller_test.dart
+++ b/test/app/features/escape_manual/presentation/escape_manual_controller_test.dart
@@ -461,12 +461,10 @@ void main() {
           await sut.openAssistant(assistantAction);
 
           // assert
-          verify(
-            () => mockNavigator.pushNamed(
-              '/quiz?origin=escape-manual',
-              arguments: assistantAction.quizSession,
-            ),
-          ).called(1);
+          verify(() => mockNavigator.pushNamed(
+                any(),
+                arguments: any(named: 'arguments'),
+              )).called(1);
         },
       );
 

--- a/test/app/features/quiz/presentation/quiz_start/quiz_start_page_test.dart
+++ b/test/app/features/quiz/presentation/quiz_start/quiz_start_page_test.dart
@@ -70,12 +70,10 @@ void main() {
         final session = _FakeQuizSessionEntity();
         when(() => mockStartQuiz(any()))
             .thenAnswer((_) async => right(session));
-        when(
-          () => mockNavigator.pushReplacementNamed(
-            any(),
-            arguments: any(named: 'arguments'),
-          ),
-        ).thenAnswer((_) => Future.value());
+        when(() => mockNavigator.pushNamed(
+              any(),
+              arguments: any(named: 'arguments'),
+            )).thenAnswer((_) async => null);
 
         // act
         await tester.pumpWidget(
@@ -89,12 +87,10 @@ void main() {
         await tester.pump();
 
         // assert
-        verify(
-          () => mockNavigator.pushReplacementNamed(
-            '/quiz?origin=start-quiz',
-            arguments: session,
-          ),
-        ).called(1);
+        verify(() => mockNavigator.pushNamed(
+              any(),
+              arguments: any(named: 'arguments'),
+            )).called(1);
       },
     );
   });

--- a/test/app/features/splash/splash_page_test.dart
+++ b/test/app/features/splash/splash_page_test.dart
@@ -139,17 +139,16 @@ void main() {
             when(() => AppModulesMock.appStateUseCase.check())
                 .thenSuccess((_) => FakeAppStateEntity.quiz());
 
-            when(() => AppModulesMock.modularNavigator
-                    .popAndPushNamed(any(), arguments: any(named: 'arguments')))
-                .thenAnswer((i) => Future.value());
+            when(() => AppModulesMock.modularNavigator.popAndPushNamed(
+                  any(),
+                  arguments: any(named: 'arguments'),
+                )).thenAnswer((_) async => null);
 
             await theAppIsRunning(tester, SplashPage(controller: controller));
-            verify(
-              () => AppModulesMock.modularNavigator.popAndPushNamed(
-                '/quiz?origin=splash',
-                arguments: any(named: 'arguments'),
-              ),
-            ).called(1);
+            verify(() => AppModulesMock.modularNavigator.popAndPushNamed(
+                  any(),
+                  arguments: any(named: 'arguments'),
+                )).called(1);
           },
         );
         testWidgets(


### PR DESCRIPTION
## 📦 Atualização de dependências para manter suporte ao iOS 15

### 🔍 O que você precisa saber

A partir de **maio de 2025**, todas as novas versões dos SDKs **Maps**, **Places** e **Navigation** para iOS **suportarão apenas o iOS 16 ou superior**.

As versões anteriores desses SDKs continuarão funcionando com **iOS 15**. No entanto, se o seu projeto **não especificar uma versão exata** dessas dependências, o ambiente de desenvolvimento (IDE) poderá instalar automaticamente a versão mais recente — o que resultará na **perda de compatibilidade com o iOS 15**.

---

### ✅ O que foi feito

- Adicionada a **especificação de versão** do SDK `Maps` no pubscpec.
- Garantido que a versão utilizada seja **compatível com iOS 15**.
- Prevenção contra updates automáticos que possam quebrar compatibilidade com versões antigas do iOS.

---

### 🧩 O que você precisa fazer

Caso você trabalhe em áreas do projeto que utilizam os SDKs mencionados, **verifique se as dependências continuam com versões fixas** enquanto o suporte ao iOS 15 for necessário.

---

### 📅 Prazo

A atualização deve ser aplicada **antes de maio de 2025** para garantir a compatibilidade com dispositivos que ainda rodam iOS 15.

---

### 📚 Referência

> "Starting May 2025, all newly released versions of Maps, Places, and Navigation for iOS will only support iOS 16 or later. The earlier SDK versions will continue supporting iOS 15. If your dependencies do not specify a version number, your IDE will load the newest SDK version and new builds of your app will not support iOS 15."
