### PR TITLE
feat(audio): add background audio upload with optimistic queue, resilience fallback, and upload status indicators

### DIFF
--- a/.github/workflows/manual-distribution.yml
+++ b/.github/workflows/manual-distribution.yml
@@ -18,7 +18,7 @@ on:
 
 # Define permissions for the GITHUB_TOKEN
 permissions:
-  contents: read # Required to read the repository contents
+  contents: write # Required to commit the version bump
   packages: write # Required if you are publishing packages
   actions: write # Required if you are using reusable workflows
   id-token: write

--- a/.github/workflows/tester-email-distribute.yml
+++ b/.github/workflows/tester-email-distribute.yml
@@ -18,13 +18,12 @@ on:
 
 # Define permissions for the GITHUB_TOKEN
 permissions:
-  contents: read  # Only read access to the repository contents
-  actions: write  # Allow writing to actions (if needed)
-  checks: write   # Allow writing to checks (if needed)
+  contents: write # Required to commit the version bump
+  actions: write # Allow writing to actions (if needed)
+  checks: write # Allow writing to checks (if needed)
   # Add other permissions as needed
 
 jobs:
-
   distribute-android:
     if: ${{ github.event.inputs.platform == 'android' || github.event.inputs.platform == 'all' }}
     uses: ./.github/workflows/distribute-flutter-android.yml

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -37,7 +37,7 @@ def isFirebaseDistribution = System.getenv('IS_FIREBASE_DISTRIBUTION') == 'true'
 android {
     namespace 'br.com.azmina.penhas'
 
-    compileSdkVersion 35
+    compileSdkVersion 36
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -43,17 +43,19 @@ android {
         main.java.srcDirs += 'src/main/kotlin'
     }
 
+defaultConfig {
+    applicationId "penhas.com.br"
+    minSdkVersion 24
+    targetSdkVersion 35
+    versionCode flutterVersionCode.toInteger()
+    versionName flutterVersionName
+    testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
-    defaultConfig {
-        applicationId "penhas.com.br"
-        minSdkVersion 24
-        targetSdkVersion 35
-        versionCode flutterVersionCode.toInteger()
-        versionName flutterVersionName
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-
-        manifestPlaceholders["GEO_API_KEY"] = System.getenv('GEO_API_KEY') ?: secretsProperties.getProperty('GEO_API_KEY')
-    }
+   manifestPlaceholders = [
+        GEO_API_KEY: project.findProperty('GEO_API_KEY') ?: "DUMMY",
+        applicationName: project.findProperty('applicationName') ?: "android.app.Application"
+    ]
+}
     
     buildFeatures {
         buildConfig true

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -65,11 +65,6 @@
             </intent-filter>
         </service>
 
-        <service
-            android:name="com.bbflight.background_downloader.UploadWorkerService"
-            android:exported="false"
-            android:foregroundServiceType="dataSync" />
-
     </application>
 
     <uses-permission android:name="android.permission.INTERNET"/>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -65,10 +65,16 @@
             </intent-filter>
         </service>
 
+        <service
+            android:name="com.bbflight.background_downloader.UploadWorkerService"
+            android:exported="false"
+            android:foregroundServiceType="dataSync" />
+
     </application>
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.9.24'
+    ext.kotlin_version = '2.1.0'
     repositories {
         google()
         jcenter()

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version '8.5.0' apply false
+    id "com.android.application" version '8.9.1' apply false
     id "org.jetbrains.kotlin.android" version "2.1.0" apply false
     id "com.google.gms.google-services" version "4.3.15" apply false
     id "com.google.firebase.crashlytics" version "2.8.1" apply false

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version '8.5.0' apply false
-    id "org.jetbrains.kotlin.android" version "1.9.24" apply false
+    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
     id "com.google.gms.google-services" version "4.3.15" apply false
     id "com.google.firebase.crashlytics" version "2.8.1" apply false
 }

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,6 +1,8 @@
 PODS:
   - audio_session (0.0.1):
     - Flutter
+  - background_downloader (0.0.1):
+    - Flutter
   - device_info_plus (0.0.1):
     - Flutter
   - Firebase/Analytics (11.8.0):
@@ -202,6 +204,7 @@ PODS:
 
 DEPENDENCIES:
   - audio_session (from `.symlinks/plugins/audio_session/ios`)
+  - background_downloader (from `.symlinks/plugins/background_downloader/ios`)
   - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
   - firebase_analytics (from `.symlinks/plugins/firebase_analytics/ios`)
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
@@ -252,6 +255,8 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   audio_session:
     :path: ".symlinks/plugins/audio_session/ios"
+  background_downloader:
+    :path: ".symlinks/plugins/background_downloader/ios"
   device_info_plus:
     :path: ".symlinks/plugins/device_info_plus/ios"
   firebase_analytics:
@@ -299,6 +304,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   audio_session: 19e9480dbdd4e5f6c4543826b2e8b0e4ab6145fe
+  background_downloader: a05c77d32a0d70615b9c04577aa203535fc924ff
   device_info_plus: bf2e3232933866d73fe290f2942f2156cdd10342
   Firebase: d80354ed7f6df5f9aca55e9eb47cc4b634735eaf
   firebase_analytics: 7ec1166af61987fa968766eb11587c562a5650ee

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -53,6 +53,7 @@
 		<string>location</string>
 		<string>audio</string>
 		<string>processing</string>
+		<string>fetch</string>
 	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>

--- a/lib/app/app_module.dart
+++ b/lib/app/app_module.dart
@@ -116,6 +116,7 @@ class AppModule extends Module {
         Bind.lazySingleton<IAudioSyncManager>(
           (i) => AudioSyncManager(
             audioRepository: i.get<IAudioSyncRepository>(),
+            serverConfiguration: i.get<IApiServerConfigure>(),
           ),
         ),
         Bind.factory<IAudioSyncRepository>(

--- a/lib/app/core/managers/audio_record_services.dart
+++ b/lib/app/core/managers/audio_record_services.dart
@@ -219,7 +219,17 @@ extension _AudioRecordServices on AudioRecordServices {
       );
     } catch (err, stack) {
       logError(err, stack);
-      _stopRecorder();
+      try { // PALLIATIVE_FIX_20260523
+        await _recorder.startRecorder(
+          codec: Codec.aacMP4,
+          toFile: path,
+          bitRate: 96000,
+          sampleRate: 32000,
+        ); // PALLIATIVE_FIX_20260523
+      } catch (fallbackErr, fallbackStack) { // PALLIATIVE_FIX_20260523
+        logError(fallbackErr, fallbackStack); // PALLIATIVE_FIX_20260523
+        _stopRecorder(); // PALLIATIVE_FIX_20260523
+      } // PALLIATIVE_FIX_20260523
     }
   }
 

--- a/lib/app/core/managers/audio_record_services.dart
+++ b/lib/app/core/managers/audio_record_services.dart
@@ -219,14 +219,16 @@ extension _AudioRecordServices on AudioRecordServices {
       );
     } catch (err, stack) {
       logError(err, stack);
-      try { // PALLIATIVE_FIX_20260523
+      try {
+        // PALLIATIVE_FIX_20260523
         await _recorder.startRecorder(
           codec: Codec.aacMP4,
           toFile: path,
           bitRate: 96000,
           sampleRate: 32000,
         ); // PALLIATIVE_FIX_20260523
-      } catch (fallbackErr, fallbackStack) { // PALLIATIVE_FIX_20260523
+      } catch (fallbackErr, fallbackStack) {
+        // PALLIATIVE_FIX_20260523
         logError(fallbackErr, fallbackStack); // PALLIATIVE_FIX_20260523
         _stopRecorder(); // PALLIATIVE_FIX_20260523
       } // PALLIATIVE_FIX_20260523

--- a/lib/app/core/managers/audio_sync_manager.dart
+++ b/lib/app/core/managers/audio_sync_manager.dart
@@ -22,6 +22,13 @@ abstract class IAudioSyncManager {
   Future<bool> syncAudio();
   Future<Either<Failure, File>> cache(AudioEntity audio);
   Future<List<Map<String, String>>> pendingUploads();
+
+  /// Broadcast re-emit of `FileDownloader().updates`. The manager owns the
+  /// single subscription to that single-subscription stream; consumers (e.g.
+  /// AudiosController) listen here instead of subscribing to FileDownloader
+  /// directly — a second direct subscription throws "Stream has already been
+  /// listened to".
+  Stream<TaskUpdate> get updates;
   void dispose();
 }
 
@@ -37,6 +44,11 @@ class AudioSyncManager implements IAudioSyncManager {
   final IAudioSyncRepository _audioRepository;
   final IApiServerConfigure _serverConfiguration;
   StreamSubscription<TaskUpdate>? _updatesSubscription;
+  final StreamController<TaskUpdate> _updatesController =
+      StreamController<TaskUpdate>.broadcast();
+
+  @override
+  Stream<TaskUpdate> get updates => _updatesController.stream;
 
   Future _init() async {
     _updatesSubscription = FileDownloader().updates.listen(_handleUpdate);
@@ -44,6 +56,10 @@ class AudioSyncManager implements IAudioSyncManager {
   }
 
   void _handleUpdate(TaskUpdate update) {
+    // Re-broadcast every update so multiple consumers can react.
+    if (!_updatesController.isClosed) {
+      _updatesController.add(update);
+    }
     if (update is TaskStatusUpdate && update.status == TaskStatus.complete) {
       update.task.filePath().then((path) {
         final file = File(path);
@@ -165,6 +181,7 @@ class AudioSyncManager implements IAudioSyncManager {
   @override
   void dispose() {
     _updatesSubscription?.cancel();
+    _updatesController.close();
   }
 
   @override

--- a/lib/app/core/managers/audio_sync_manager.dart
+++ b/lib/app/core/managers/audio_sync_manager.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
-import 'dart:collection';
 import 'dart:io';
 
-import 'package:collection/collection.dart' show IterableExtension;
+import 'package:background_downloader/background_downloader.dart';
+import 'package:crypto/crypto.dart';
 import 'package:dartz/dartz.dart';
 import 'package:path/path.dart';
 import 'package:path_provider/path_provider.dart';
@@ -11,6 +11,7 @@ import '../../features/help_center/data/repositories/audio_sync_repository.dart'
 import '../../features/help_center/domain/entities/audio_entity.dart';
 import '../../shared/logger/log.dart';
 import '../error/failures.dart';
+import '../network/api_server_configure.dart';
 
 abstract class IAudioSyncManager {
   Future<String> audioFile({
@@ -20,23 +21,91 @@ abstract class IAudioSyncManager {
   });
   Future<bool> syncAudio();
   Future<Either<Failure, File>> cache(AudioEntity audio);
+  Future<List<Map<String, String>>> pendingUploads();
+  void dispose();
 }
 
 class AudioSyncManager implements IAudioSyncManager {
-  AudioSyncManager({required IAudioSyncRepository audioRepository})
-      : _audioRepository = audioRepository {
+  AudioSyncManager({
+    required IAudioSyncRepository audioRepository,
+    required IApiServerConfigure serverConfiguration,
+  })  : _audioRepository = audioRepository,
+        _serverConfiguration = serverConfiguration {
     _init();
   }
 
-  bool _syncAudioRunning = false;
-  // ignore: unused_field
-  late Timer _syncTimer;
-  final _pendingUploadAudio = Queue<File>();
   final IAudioSyncRepository _audioRepository;
+  final IApiServerConfigure _serverConfiguration;
+  StreamSubscription<TaskUpdate>? _updatesSubscription;
 
   Future _init() async {
-    await loadAudioQueue();
-    setupUploadTimer();
+    _updatesSubscription = FileDownloader().updates.listen(_handleUpdate);
+    await _migrateOrphanFiles();
+  }
+
+  void _handleUpdate(TaskUpdate update) {
+    if (update is TaskStatusUpdate && update.status == TaskStatus.complete) {
+      update.task.filePath().then((path) {
+        final file = File(path);
+        if (file.existsSync()) {
+          file.deleteSync();
+        }
+      });
+    }
+    if (update is TaskStatusUpdate && update.status == TaskStatus.failed) {
+      logError('Upload failed: ${update.task.taskId} - ${update.task.url}');
+    }
+  }
+
+  Future<void> _migrateOrphanFiles() async {
+    final files = await dirAudioUploadContent();
+    for (final file in files) {
+      await _enqueueFile(file);
+    }
+  }
+
+  Future<void> _enqueueFile(File file) async {
+    if (file.statSync().size < 30) {
+      file.deleteSync();
+      return;
+    }
+
+    final fileName = file.name;
+    final parts = fileName.split(RegExp('[_.]'));
+    if (parts.length < 3) return;
+
+    final epoch = parts[0];
+    final eventId = parts[1];
+    final sequence = parts[2];
+    final createdAt = mapEpochToUTC(epoch);
+    final fileSha1 = sha1.convert(file.readAsBytesSync()).toString();
+    final baseUri = _serverConfiguration.baseUri;
+    final apiToken = await _serverConfiguration.apiToken ?? '';
+    final userAgent = await _serverConfiguration.userAgent;
+
+    final task = UploadTask.fromFile(
+      file: file,
+      taskId: fileName,
+      url: baseUri.replace(path: '/me/audios').toString(),
+      fileField: 'media',
+      httpRequestMethod: 'POST',
+      fields: {
+        'sha1': fileSha1,
+        'event_id': eventId,
+        'event_sequence': sequence,
+        'cliente_created_at': createdAt,
+        'current_time': DateTime.now().toUtc().toIso8601String(),
+      },
+      headers: {
+        'X-Api-Key': apiToken,
+        'User-Agent': userAgent,
+      },
+      updates: Updates.statusAndProgress,
+      retries: 5,
+      requiresWiFi: false,
+    );
+
+    await FileDownloader().enqueue(task);
   }
 
   @override
@@ -63,15 +132,39 @@ class AudioSyncManager implements IAudioSyncManager {
   @override
   Future<bool> syncAudio() async {
     try {
-      await loadAudioQueue();
-      setupUploadTimer();
-      syncAudios();
-
+      final files = await dirAudioUploadContent();
+      for (final file in files) {
+        await _enqueueFile(file);
+      }
       return true;
     } catch (e, stack) {
       logError(e, stack);
       return true;
     }
+  }
+
+  @override
+  Future<List<Map<String, String>>> pendingUploads() async {
+    try {
+      final records = await FileDownloader().database.allRecords();
+      return records
+          .where((r) =>
+              r.status == TaskStatus.enqueued ||
+              r.status == TaskStatus.running)
+          .map((r) => {
+                'taskId': r.taskId,
+                'status': r.status.name,
+                'progress': (r.progress * 100).toStringAsFixed(0),
+              })
+          .toList();
+    } catch (_) {
+      return [];
+    }
+  }
+
+  @override
+  void dispose() {
+    _updatesSubscription?.cancel();
   }
 
   @override
@@ -94,116 +187,6 @@ class AudioSyncManager implements IAudioSyncManager {
       file.deleteSync();
       return left(FileSystemFailure());
     }
-  }
-}
-
-extension _AudioSyncManager on AudioSyncManager {
-  Future<File> cacheFile(AudioEntity audio) async {
-    final fileName = [audio.id, 'cached'].join('.');
-    final path =
-        await getTemporaryDirectory().then((dir) => join(dir.path, fileName));
-
-    final file = File(path);
-
-    if (!file.existsSync()) {
-      file.createSync(recursive: true);
-    }
-
-    return file;
-  }
-
-  void setupUploadTimer() {
-    // Why this block is commented?
-    // if (_syncTimer != null) {
-    //   return;
-    // }
-
-    // _syncTimer = Timer.periodic(
-    //   Duration(seconds: 10),
-    //   (timer) async {
-    //     await loadAudioQueue();
-
-    //     if (_pendingUploadAudio?.isEmpty ?? true) {
-    //       timer.cancel();
-    //       if (_syncTimer != null) {
-    //         _syncTimer.cancel();
-    //         _syncTimer = null;
-    //       }
-    //     }
-
-    //     cleanCache();
-    //     syncAudios();
-    //   },
-    // );
-  }
-
-  // ignore: unused_element
-  Future<void> cleanCache() async {
-    final DateTime purgeCacheTime =
-        DateTime.now().subtract(const Duration(days: 3));
-
-    final List<File> files = await getTemporaryDirectory()
-        .then((dir) => dir.listSync(recursive: true))
-        .then((value) => value.map((e) => File.fromUri(e.uri)).toList());
-
-    files.retainWhere((f) => f.path.endsWith('.cached'));
-    // se o último acesso for maior que o purgeCacheTime
-    files.retainWhere(
-      (f) => purgeCacheTime.compareTo(f.statSync().accessed) > 0,
-    );
-    files.map((e) => e.deleteSync());
-  }
-
-  Future<void> syncAudios() async {
-    if (_syncAudioRunning || _pendingUploadAudio.isEmpty) {
-      return;
-    }
-
-    _syncAudioRunning = true;
-    setupUploadTimer();
-    try {
-      while (_pendingUploadAudio.isNotEmpty) {
-        final file = _pendingUploadAudio.removeFirst();
-        await _syncAudio(file);
-      }
-    } catch (e, stack) {
-      logError(e, stack);
-    }
-
-    _pendingUploadAudio.retainWhere((e) => e.existsSync());
-    _syncAudioRunning = false;
-  }
-
-  Future<void> _syncAudio(File file) async {
-    try {
-      if (file.statSync().size < 30) {
-        file.deleteSync();
-        return;
-      }
-
-      final fileName = file.name;
-      final parts = fileName.split(RegExp('[_.]'));
-      final audio = AudioData(
-        media: file,
-        eventId: parts[1],
-        sequence: parts[2],
-        createdAt: mapEpochToUTC(parts[0]),
-      );
-
-      final result = await _audioRepository.upload(audio);
-      result.fold(
-        (l) => handleUploadFailure(l, file),
-        (r) => file.deleteSync(),
-      );
-    } catch (e, stack) {
-      logError(e, stack);
-    }
-
-    return Future.value();
-  }
-
-  void handleUploadFailure(Failure failure, File file) {
-    logError(failure);
   }
 
   String mapEpochToUTC(String time) {
@@ -230,23 +213,26 @@ extension _AudioSyncManager on AudioSyncManager {
     files.sort((a, b) => a.path.compareTo(b.path));
     return files;
   }
+}
 
-  Future<void> loadAudioQueue() async {
-    final dirs = await dirAudioUploadContent();
-    for (final file in dirs) {
-      final status = _pendingUploadAudio.firstWhereOrNull(
-        (e) => e.path == file.path,
-      );
-
-      if (status == null) {
-        _pendingUploadAudio.add(file);
-      }
-    }
+extension _FileExtension on File {
+  String get name {
+    return path.split(Platform.pathSeparator).last;
   }
 }
 
-extension _FileExtention on File {
-  String get name {
-    return path.split(Platform.pathSeparator).last;
+extension _AudioSyncManager on AudioSyncManager {
+  Future<File> cacheFile(AudioEntity audio) async {
+    final fileName = [audio.id, 'cached'].join('.');
+    final path =
+        await getTemporaryDirectory().then((dir) => join(dir.path, fileName));
+
+    final file = File(path);
+
+    if (!file.existsSync()) {
+      file.createSync(recursive: true);
+    }
+
+    return file;
   }
 }

--- a/lib/app/core/managers/audio_sync_manager.dart
+++ b/lib/app/core/managers/audio_sync_manager.dart
@@ -165,8 +165,7 @@ class AudioSyncManager implements IAudioSyncManager {
       final records = await FileDownloader().database.allRecords();
       return records
           .where((r) =>
-              r.status == TaskStatus.enqueued ||
-              r.status == TaskStatus.running)
+              r.status == TaskStatus.enqueued || r.status == TaskStatus.running)
           .map((r) => {
                 'taskId': r.taskId,
                 'status': r.status.name,

--- a/lib/app/core/states/audio_permission_state.freezed.dart
+++ b/lib/app/core/states/audio_permission_state.freezed.dart
@@ -91,9 +91,6 @@ class _$AudioPermissionStateCopyWithImpl<$Res,
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
-
-  /// Create a copy of AudioPermissionState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -110,9 +107,6 @@ class __$$GrantedImplCopyWithImpl<$Res>
   __$$GrantedImplCopyWithImpl(
       _$GrantedImpl _value, $Res Function(_$GrantedImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of AudioPermissionState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -233,9 +227,6 @@ class __$$DeniedImplCopyWithImpl<$Res>
   __$$DeniedImplCopyWithImpl(
       _$DeniedImpl _value, $Res Function(_$DeniedImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of AudioPermissionState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -356,9 +347,6 @@ class __$$PermanentlyDeniedImplCopyWithImpl<$Res>
   __$$PermanentlyDeniedImplCopyWithImpl(_$PermanentlyDeniedImpl _value,
       $Res Function(_$PermanentlyDeniedImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of AudioPermissionState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -479,9 +467,6 @@ class __$$RestrictedImplCopyWithImpl<$Res>
   __$$RestrictedImplCopyWithImpl(
       _$RestrictedImpl _value, $Res Function(_$RestrictedImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of AudioPermissionState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -602,9 +587,6 @@ class __$$UndefinedImplCopyWithImpl<$Res>
   __$$UndefinedImplCopyWithImpl(
       _$UndefinedImpl _value, $Res Function(_$UndefinedImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of AudioPermissionState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc

--- a/lib/app/core/states/location_permission_state.freezed.dart
+++ b/lib/app/core/states/location_permission_state.freezed.dart
@@ -91,9 +91,6 @@ class _$LocationPermissionStateCopyWithImpl<$Res,
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
-
-  /// Create a copy of LocationPermissionState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -110,9 +107,6 @@ class __$$GrantedImplCopyWithImpl<$Res>
   __$$GrantedImplCopyWithImpl(
       _$GrantedImpl _value, $Res Function(_$GrantedImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of LocationPermissionState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -233,9 +227,6 @@ class __$$DeniedImplCopyWithImpl<$Res>
   __$$DeniedImplCopyWithImpl(
       _$DeniedImpl _value, $Res Function(_$DeniedImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of LocationPermissionState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -356,9 +347,6 @@ class __$$PermanentlyDeniedImplCopyWithImpl<$Res>
   __$$PermanentlyDeniedImplCopyWithImpl(_$PermanentlyDeniedImpl _value,
       $Res Function(_$PermanentlyDeniedImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of LocationPermissionState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -479,9 +467,6 @@ class __$$RestrictedImplCopyWithImpl<$Res>
   __$$RestrictedImplCopyWithImpl(
       _$RestrictedImpl _value, $Res Function(_$RestrictedImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of LocationPermissionState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -602,9 +587,6 @@ class __$$UndefinedImplCopyWithImpl<$Res>
   __$$UndefinedImplCopyWithImpl(
       _$UndefinedImpl _value, $Res Function(_$UndefinedImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of LocationPermissionState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc

--- a/lib/app/features/chat/domain/states/chat_channel_state.freezed.dart
+++ b/lib/app/features/chat/domain/states/chat_channel_state.freezed.dart
@@ -78,9 +78,6 @@ class _$ChatChannelStateCopyWithImpl<$Res, $Val extends ChatChannelState>
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
-
-  /// Create a copy of ChatChannelState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -97,9 +94,6 @@ class __$$InitialImplCopyWithImpl<$Res>
   __$$InitialImplCopyWithImpl(
       _$InitialImpl _value, $Res Function(_$InitialImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of ChatChannelState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -208,9 +202,6 @@ class __$$LoadedImplCopyWithImpl<$Res>
   __$$LoadedImplCopyWithImpl(
       _$LoadedImpl _value, $Res Function(_$LoadedImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of ChatChannelState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -322,8 +313,6 @@ class __$$ErrorDetailsImplCopyWithImpl<$Res>
       _$ErrorDetailsImpl _value, $Res Function(_$ErrorDetailsImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of ChatChannelState
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -362,9 +351,7 @@ class _$ErrorDetailsImpl implements _ErrorDetails {
   @override
   int get hashCode => Object.hash(runtimeType, message);
 
-  /// Create a copy of ChatChannelState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ErrorDetailsImplCopyWith<_$ErrorDetailsImpl> get copyWith =>
@@ -443,10 +430,7 @@ abstract class _ErrorDetails implements ChatChannelState {
   const factory _ErrorDetails(final String message) = _$ErrorDetailsImpl;
 
   String get message;
-
-  /// Create a copy of ChatChannelState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ErrorDetailsImplCopyWith<_$ErrorDetailsImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/app/features/chat/domain/states/chat_channel_usecase_event.freezed.dart
+++ b/lib/app/features/chat/domain/states/chat_channel_usecase_event.freezed.dart
@@ -99,9 +99,6 @@ class _$ChatChannelUseCaseEventCopyWithImpl<$Res,
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
-
-  /// Create a copy of ChatChannelUseCaseEvent
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -118,9 +115,6 @@ class __$$InitialImplCopyWithImpl<$Res>
   __$$InitialImplCopyWithImpl(
       _$InitialImpl _value, $Res Function(_$InitialImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of ChatChannelUseCaseEvent
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -249,9 +243,6 @@ class __$$LoadedImplCopyWithImpl<$Res>
   __$$LoadedImplCopyWithImpl(
       _$LoadedImpl _value, $Res Function(_$LoadedImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of ChatChannelUseCaseEvent
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -383,8 +374,6 @@ class __$$UpdateUserImplCopyWithImpl<$Res>
       _$UpdateUserImpl _value, $Res Function(_$UpdateUserImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of ChatChannelUseCaseEvent
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -423,9 +412,7 @@ class _$UpdateUserImpl implements _UpdateUser {
   @override
   int get hashCode => Object.hash(runtimeType, user);
 
-  /// Create a copy of ChatChannelUseCaseEvent
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$UpdateUserImplCopyWith<_$UpdateUserImpl> get copyWith =>
@@ -524,10 +511,7 @@ abstract class _UpdateUser implements ChatChannelUseCaseEvent {
   const factory _UpdateUser(final ChatUserEntity user) = _$UpdateUserImpl;
 
   ChatUserEntity get user;
-
-  /// Create a copy of ChatChannelUseCaseEvent
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$UpdateUserImplCopyWith<_$UpdateUserImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -549,8 +533,6 @@ class __$$UpdateMetadataImplCopyWithImpl<$Res>
       _$UpdateMetadataImpl _value, $Res Function(_$UpdateMetadataImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of ChatChannelUseCaseEvent
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -590,9 +572,7 @@ class _$UpdateMetadataImpl implements _UpdateMetadata {
   @override
   int get hashCode => Object.hash(runtimeType, metadata);
 
-  /// Create a copy of ChatChannelUseCaseEvent
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$UpdateMetadataImplCopyWith<_$UpdateMetadataImpl> get copyWith =>
@@ -693,10 +673,7 @@ abstract class _UpdateMetadata implements ChatChannelUseCaseEvent {
       final ChatChannelSessionMetadataEntity metadata) = _$UpdateMetadataImpl;
 
   ChatChannelSessionMetadataEntity get metadata;
-
-  /// Create a copy of ChatChannelUseCaseEvent
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$UpdateMetadataImplCopyWith<_$UpdateMetadataImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -718,8 +695,6 @@ class __$$UpdateMessageImplCopyWithImpl<$Res>
       _$UpdateMessageImpl _value, $Res Function(_$UpdateMessageImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of ChatChannelUseCaseEvent
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -765,9 +740,7 @@ class _$UpdateMessageImpl implements _UpdateMessage {
   int get hashCode =>
       Object.hash(runtimeType, const DeepCollectionEquality().hash(_messages));
 
-  /// Create a copy of ChatChannelUseCaseEvent
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$UpdateMessageImplCopyWith<_$UpdateMessageImpl> get copyWith =>
@@ -867,10 +840,7 @@ abstract class _UpdateMessage implements ChatChannelUseCaseEvent {
       _$UpdateMessageImpl;
 
   List<ChatChannelMessage> get messages;
-
-  /// Create a copy of ChatChannelUseCaseEvent
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$UpdateMessageImplCopyWith<_$UpdateMessageImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -892,8 +862,6 @@ class __$$ErrorOnLoadingImplCopyWithImpl<$Res>
       _$ErrorOnLoadingImpl _value, $Res Function(_$ErrorOnLoadingImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of ChatChannelUseCaseEvent
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -932,9 +900,7 @@ class _$ErrorOnLoadingImpl implements _ErrorOnLoading {
   @override
   int get hashCode => Object.hash(runtimeType, message);
 
-  /// Create a copy of ChatChannelUseCaseEvent
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ErrorOnLoadingImplCopyWith<_$ErrorOnLoadingImpl> get copyWith =>
@@ -1034,10 +1000,7 @@ abstract class _ErrorOnLoading implements ChatChannelUseCaseEvent {
   const factory _ErrorOnLoading(final String message) = _$ErrorOnLoadingImpl;
 
   String get message;
-
-  /// Create a copy of ChatChannelUseCaseEvent
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ErrorOnLoadingImplCopyWith<_$ErrorOnLoadingImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/app/features/chat/domain/states/chat_main_security_state.freezed.dart
+++ b/lib/app/features/chat/domain/states/chat_main_security_state.freezed.dart
@@ -73,9 +73,6 @@ class _$ChatMainSecurityStateCopyWithImpl<$Res,
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
-
-  /// Create a copy of ChatMainSecurityState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -92,9 +89,6 @@ class __$$OnlySupportImplCopyWithImpl<$Res>
   __$$OnlySupportImplCopyWithImpl(
       _$OnlySupportImpl _value, $Res Function(_$OnlySupportImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of ChatMainSecurityState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -197,9 +191,6 @@ class __$$SupportAndPrivateImplCopyWithImpl<$Res>
   __$$SupportAndPrivateImplCopyWithImpl(_$SupportAndPrivateImpl _value,
       $Res Function(_$SupportAndPrivateImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of ChatMainSecurityState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc

--- a/lib/app/features/chat/domain/states/chat_main_talks_state.freezed.dart
+++ b/lib/app/features/chat/domain/states/chat_main_talks_state.freezed.dart
@@ -84,9 +84,6 @@ class _$ChatMainTalksStateCopyWithImpl<$Res, $Val extends ChatMainTalksState>
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
-
-  /// Create a copy of ChatMainTalksState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -103,9 +100,6 @@ class __$$InitialImplCopyWithImpl<$Res>
   __$$InitialImplCopyWithImpl(
       _$InitialImpl _value, $Res Function(_$InitialImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of ChatMainTalksState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -220,9 +214,6 @@ class __$$LoadingImplCopyWithImpl<$Res>
   __$$LoadingImplCopyWithImpl(
       _$LoadingImpl _value, $Res Function(_$LoadingImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of ChatMainTalksState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -340,8 +331,6 @@ class __$$LoadedImplCopyWithImpl<$Res>
       _$LoadedImpl _value, $Res Function(_$LoadedImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of ChatMainTalksState
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -386,9 +375,7 @@ class _$LoadedImpl implements _Loaded {
   int get hashCode =>
       Object.hash(runtimeType, const DeepCollectionEquality().hash(_tiles));
 
-  /// Create a copy of ChatMainTalksState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$LoadedImplCopyWith<_$LoadedImpl> get copyWith =>
@@ -473,10 +460,7 @@ abstract class _Loaded implements ChatMainTalksState {
   const factory _Loaded(final List<ChatMainTileEntity> tiles) = _$LoadedImpl;
 
   List<ChatMainTileEntity> get tiles;
-
-  /// Create a copy of ChatMainTalksState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$LoadedImplCopyWith<_$LoadedImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -498,8 +482,6 @@ class __$$ErrorDetailsImplCopyWithImpl<$Res>
       _$ErrorDetailsImpl _value, $Res Function(_$ErrorDetailsImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of ChatMainTalksState
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -538,9 +520,7 @@ class _$ErrorDetailsImpl implements _ErrorDetails {
   @override
   int get hashCode => Object.hash(runtimeType, message);
 
-  /// Create a copy of ChatMainTalksState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ErrorDetailsImplCopyWith<_$ErrorDetailsImpl> get copyWith =>
@@ -625,10 +605,7 @@ abstract class _ErrorDetails implements ChatMainTalksState {
   const factory _ErrorDetails(final String message) = _$ErrorDetailsImpl;
 
   String get message;
-
-  /// Create a copy of ChatMainTalksState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ErrorDetailsImplCopyWith<_$ErrorDetailsImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/app/features/escape_manual/data/model/escape_manual_local.g.dart
+++ b/lib/app/features/escape_manual/data/model/escape_manual_local.g.dart
@@ -23,16 +23,24 @@ EscapeManualTaskLocalModel _$EscapeManualTaskLocalModelFromJson(
     );
 
 Map<String, dynamic> _$EscapeManualTaskLocalModelToJson(
-        EscapeManualTaskLocalModel instance) =>
-    <String, dynamic>{
-      'id': instance.id,
-      'type': _$EscapeManualTaskTypeEnumMap[instance.type]!,
-      if (instance.value case final value?) 'value': value,
-      'isDone': instance.isDone,
-      'isRemoved': instance.isRemoved,
-      if (instance.updatedAt?.toIso8601String() case final value?)
-        'updatedAt': value,
-    };
+    EscapeManualTaskLocalModel instance) {
+  final val = <String, dynamic>{
+    'id': instance.id,
+    'type': _$EscapeManualTaskTypeEnumMap[instance.type]!,
+  };
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('value', instance.value);
+  val['isDone'] = instance.isDone;
+  val['isRemoved'] = instance.isRemoved;
+  writeNotNull('updatedAt', instance.updatedAt?.toIso8601String());
+  return val;
+}
 
 const _$EscapeManualTaskTypeEnumMap = {
   EscapeManualTaskType.unknown: 'unknown',

--- a/lib/app/features/escape_manual/data/model/escape_manual_remote.g.dart
+++ b/lib/app/features/escape_manual/data/model/escape_manual_remote.g.dart
@@ -41,12 +41,21 @@ EscapeManualAssistantRemoteModel _$EscapeManualAssistantRemoteModelFromJson(
     );
 
 Map<String, dynamic> _$EscapeManualAssistantRemoteModelToJson(
-        EscapeManualAssistantRemoteModel instance) =>
-    <String, dynamic>{
-      'title': instance.title,
-      if (instance.subtitle case final value?) 'subtitle': value,
-      'quiz_session': instance.quizSession,
-    };
+    EscapeManualAssistantRemoteModel instance) {
+  final val = <String, dynamic>{
+    'title': instance.title,
+  };
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('subtitle', instance.subtitle);
+  val['quiz_session'] = instance.quizSession;
+  return val;
+}
 
 EscapeManualTaskRemoteModel _$EscapeManualTaskRemoteModelFromJson(
         Map<String, dynamic> json) =>
@@ -69,22 +78,30 @@ EscapeManualTaskRemoteModel _$EscapeManualTaskRemoteModelFromJson(
     );
 
 Map<String, dynamic> _$EscapeManualTaskRemoteModelToJson(
-        EscapeManualTaskRemoteModel instance) =>
-    <String, dynamic>{
-      'id': instance.id,
-      'tipo': _$EscapeManualTaskTypeEnumMap[instance.type]!,
-      if (instance.rawType case final value?) 'rawType': value,
-      'agrupador': instance.group,
-      if (const JsonEmptyStringToNullConverter().toJson(instance.title)
-          case final value?)
-        'titulo': value,
-      'descricao': instance.description,
-      if (instance.value case final value?) 'campo_livre': value,
-      if (const JsonBoolConverter().toJson(instance.isDone) case final value?)
-        'checkbox_feito': value,
-      'atualizado_em':
-          const JsonSecondsFromEpochConverter().toJson(instance.updatedAt),
-    };
+    EscapeManualTaskRemoteModel instance) {
+  final val = <String, dynamic>{
+    'id': instance.id,
+    'tipo': _$EscapeManualTaskTypeEnumMap[instance.type]!,
+  };
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('rawType', instance.rawType);
+  val['agrupador'] = instance.group;
+  writeNotNull(
+      'titulo', const JsonEmptyStringToNullConverter().toJson(instance.title));
+  val['descricao'] = instance.description;
+  writeNotNull('campo_livre', instance.value);
+  writeNotNull(
+      'checkbox_feito', const JsonBoolConverter().toJson(instance.isDone));
+  val['atualizado_em'] =
+      const JsonSecondsFromEpochConverter().toJson(instance.updatedAt);
+  return val;
+}
 
 const _$EscapeManualTaskTypeEnumMap = {
   EscapeManualTaskType.unknown: 'unknown',

--- a/lib/app/features/escape_manual/presentation/edit/edit_trusted_contacts_state.freezed.dart
+++ b/lib/app/features/escape_manual/presentation/edit/edit_trusted_contacts_state.freezed.dart
@@ -50,9 +50,7 @@ mixin _$EditTrustedContactsState {
   }) =>
       throw _privateConstructorUsedError;
 
-  /// Create a copy of EditTrustedContactsState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $EditTrustedContactsStateCopyWith<EditTrustedContactsState> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -77,8 +75,6 @@ class _$EditTrustedContactsStateCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of EditTrustedContactsState
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -112,8 +108,6 @@ class __$$LoadedStateImplCopyWithImpl<$Res>
       _$LoadedStateImpl _value, $Res Function(_$LoadedStateImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of EditTrustedContactsState
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -159,9 +153,7 @@ class _$LoadedStateImpl implements _LoadedState {
   int get hashCode =>
       Object.hash(runtimeType, const DeepCollectionEquality().hash(_contacts));
 
-  /// Create a copy of EditTrustedContactsState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$LoadedStateImplCopyWith<_$LoadedStateImpl> get copyWith =>
@@ -230,11 +222,8 @@ abstract class _LoadedState implements EditTrustedContactsState {
 
   @override
   List<ContactEntity> get contacts;
-
-  /// Create a copy of EditTrustedContactsState
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$LoadedStateImplCopyWith<_$LoadedStateImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -283,9 +272,7 @@ mixin _$EditTrustedContactsReaction {
   }) =>
       throw _privateConstructorUsedError;
 
-  /// Create a copy of EditTrustedContactsReaction
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $EditTrustedContactsReactionCopyWith<EditTrustedContactsReaction>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -312,8 +299,6 @@ class _$EditTrustedContactsReactionCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of EditTrustedContactsReaction
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -348,8 +333,6 @@ class __$$RequestContactInfoImplCopyWithImpl<$Res>
       $Res Function(_$RequestContactInfoImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of EditTrustedContactsReaction
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -388,9 +371,7 @@ class _$RequestContactInfoImpl implements _RequestContactInfo {
   @override
   int get hashCode => Object.hash(runtimeType, contact);
 
-  /// Create a copy of EditTrustedContactsReaction
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$RequestContactInfoImplCopyWith<_$RequestContactInfoImpl> get copyWith =>
@@ -468,11 +449,8 @@ abstract class _RequestContactInfo implements EditTrustedContactsReaction {
 
   @override
   ContactEntity get contact;
-
-  /// Create a copy of EditTrustedContactsReaction
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$RequestContactInfoImplCopyWith<_$RequestContactInfoImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -499,8 +477,6 @@ class __$$AskForDeleteConfirmationImplCopyWithImpl<$Res>
       $Res Function(_$AskForDeleteConfirmationImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of EditTrustedContactsReaction
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -539,9 +515,7 @@ class _$AskForDeleteConfirmationImpl implements _AskForDeleteConfirmation {
   @override
   int get hashCode => Object.hash(runtimeType, contact);
 
-  /// Create a copy of EditTrustedContactsReaction
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$AskForDeleteConfirmationImplCopyWith<_$AskForDeleteConfirmationImpl>
@@ -620,11 +594,8 @@ abstract class _AskForDeleteConfirmation
 
   @override
   ContactEntity get contact;
-
-  /// Create a copy of EditTrustedContactsReaction
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$AskForDeleteConfirmationImplCopyWith<_$AskForDeleteConfirmationImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/app/features/escape_manual/presentation/escape_manual_state.freezed.dart
+++ b/lib/app/features/escape_manual/presentation/escape_manual_state.freezed.dart
@@ -78,9 +78,6 @@ class _$EscapeManualStateCopyWithImpl<$Res, $Val extends EscapeManualState>
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
-
-  /// Create a copy of EscapeManualState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -97,9 +94,6 @@ class __$$InitialStateImplCopyWithImpl<$Res>
   __$$InitialStateImplCopyWithImpl(
       _$InitialStateImpl _value, $Res Function(_$InitialStateImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of EscapeManualState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -211,8 +205,6 @@ class __$$LoadedStateImplCopyWithImpl<$Res>
       _$LoadedStateImpl _value, $Res Function(_$LoadedStateImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of EscapeManualState
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -251,9 +243,7 @@ class _$LoadedStateImpl implements _LoadedState {
   @override
   int get hashCode => Object.hash(runtimeType, data);
 
-  /// Create a copy of EscapeManualState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$LoadedStateImplCopyWith<_$LoadedStateImpl> get copyWith =>
@@ -332,10 +322,7 @@ abstract class _LoadedState implements EscapeManualState {
   const factory _LoadedState(final EscapeManualEntity data) = _$LoadedStateImpl;
 
   EscapeManualEntity get data;
-
-  /// Create a copy of EscapeManualState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$LoadedStateImplCopyWith<_$LoadedStateImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -357,8 +344,6 @@ class __$$ErrorStateImplCopyWithImpl<$Res>
       _$ErrorStateImpl _value, $Res Function(_$ErrorStateImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of EscapeManualState
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -397,9 +382,7 @@ class _$ErrorStateImpl implements _ErrorState {
   @override
   int get hashCode => Object.hash(runtimeType, message);
 
-  /// Create a copy of EscapeManualState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ErrorStateImplCopyWith<_$ErrorStateImpl> get copyWith =>
@@ -478,10 +461,7 @@ abstract class _ErrorState implements EscapeManualState {
   const factory _ErrorState(final String message) = _$ErrorStateImpl;
 
   String get message;
-
-  /// Create a copy of EscapeManualState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ErrorStateImplCopyWith<_$ErrorStateImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -522,9 +502,7 @@ mixin _$EscapeManualReaction {
   }) =>
       throw _privateConstructorUsedError;
 
-  /// Create a copy of EscapeManualReaction
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $EscapeManualReactionCopyWith<EscapeManualReaction> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -549,8 +527,6 @@ class _$EscapeManualReactionCopyWithImpl<$Res,
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of EscapeManualReaction
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -584,8 +560,6 @@ class __$$ShowSnackbarReactionImplCopyWithImpl<$Res>
       $Res Function(_$ShowSnackbarReactionImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of EscapeManualReaction
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -624,9 +598,7 @@ class _$ShowSnackbarReactionImpl implements _ShowSnackbarReaction {
   @override
   int get hashCode => Object.hash(runtimeType, message);
 
-  /// Create a copy of EscapeManualReaction
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ShowSnackbarReactionImplCopyWith<_$ShowSnackbarReactionImpl>
@@ -697,11 +669,8 @@ abstract class _ShowSnackbarReaction implements EscapeManualReaction {
 
   @override
   String get message;
-
-  /// Create a copy of EscapeManualReaction
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ShowSnackbarReactionImplCopyWith<_$ShowSnackbarReactionImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/app/features/feed/domain/states/feed_router_type.freezed.dart
+++ b/lib/app/features/feed/domain/states/feed_router_type.freezed.dart
@@ -56,9 +56,7 @@ mixin _$FeedRouterType {
   }) =>
       throw _privateConstructorUsedError;
 
-  /// Create a copy of FeedRouterType
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $FeedRouterTypeCopyWith<FeedRouterType> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -82,8 +80,6 @@ class _$FeedRouterTypeCopyWithImpl<$Res, $Val extends FeedRouterType>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of FeedRouterType
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -116,8 +112,6 @@ class __$$ChatImplCopyWithImpl<$Res>
   __$$ChatImplCopyWithImpl(_$ChatImpl _value, $Res Function(_$ChatImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of FeedRouterType
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -157,9 +151,7 @@ class _$ChatImpl implements _Chat {
   @override
   int get hashCode => Object.hash(runtimeType, clientId);
 
-  /// Create a copy of FeedRouterType
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ChatImplCopyWith<_$ChatImpl> get copyWith =>
@@ -233,11 +225,8 @@ abstract class _Chat implements FeedRouterType {
 
   @override
   int get clientId;
-
-  /// Create a copy of FeedRouterType
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ChatImplCopyWith<_$ChatImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -261,8 +250,6 @@ class __$$ProfileImplCopyWithImpl<$Res>
       _$ProfileImpl _value, $Res Function(_$ProfileImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of FeedRouterType
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -302,9 +289,7 @@ class _$ProfileImpl implements _Profile {
   @override
   int get hashCode => Object.hash(runtimeType, clientId);
 
-  /// Create a copy of FeedRouterType
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ProfileImplCopyWith<_$ProfileImpl> get copyWith =>
@@ -378,11 +363,8 @@ abstract class _Profile implements FeedRouterType {
 
   @override
   int get clientId;
-
-  /// Create a copy of FeedRouterType
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ProfileImplCopyWith<_$ProfileImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/app/features/feed/domain/states/feed_routing_state.freezed.dart
+++ b/lib/app/features/feed/domain/states/feed_routing_state.freezed.dart
@@ -56,9 +56,7 @@ mixin _$FeedRoutingState {
   }) =>
       throw _privateConstructorUsedError;
 
-  /// Create a copy of FeedRoutingState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $FeedRoutingStateCopyWith<FeedRoutingState> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -82,8 +80,6 @@ class _$FeedRoutingStateCopyWithImpl<$Res, $Val extends FeedRoutingState>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of FeedRoutingState
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -117,8 +113,6 @@ class __$$InitialImplCopyWithImpl<$Res>
       _$InitialImpl _value, $Res Function(_$InitialImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of FeedRoutingState
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -157,9 +151,7 @@ class _$InitialImpl implements _Initial {
   @override
   int get hashCode => Object.hash(runtimeType, title);
 
-  /// Create a copy of FeedRoutingState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$InitialImplCopyWith<_$InitialImpl> get copyWith =>
@@ -233,11 +225,8 @@ abstract class _Initial implements FeedRoutingState {
 
   @override
   String get title;
-
-  /// Create a copy of FeedRoutingState
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$InitialImplCopyWith<_$InitialImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -261,8 +250,6 @@ class __$$ErrorDetailsImplCopyWithImpl<$Res>
       _$ErrorDetailsImpl _value, $Res Function(_$ErrorDetailsImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of FeedRoutingState
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -309,9 +296,7 @@ class _$ErrorDetailsImpl implements _ErrorDetails {
   @override
   int get hashCode => Object.hash(runtimeType, title, message);
 
-  /// Create a copy of FeedRoutingState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ErrorDetailsImplCopyWith<_$ErrorDetailsImpl> get copyWith =>
@@ -387,11 +372,8 @@ abstract class _ErrorDetails implements FeedRoutingState {
   @override
   String get title;
   String get message;
-
-  /// Create a copy of FeedRoutingState
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ErrorDetailsImplCopyWith<_$ErrorDetailsImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/app/features/feed/domain/states/feed_security_state.freezed.dart
+++ b/lib/app/features/feed/domain/states/feed_security_state.freezed.dart
@@ -72,9 +72,6 @@ class _$FeedSecurityStateCopyWithImpl<$Res, $Val extends FeedSecurityState>
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
-
-  /// Create a copy of FeedSecurityState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -91,9 +88,6 @@ class __$$EnableImplCopyWithImpl<$Res>
   __$$EnableImplCopyWithImpl(
       _$EnableImpl _value, $Res Function(_$EnableImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of FeedSecurityState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -196,9 +190,6 @@ class __$$DisableImplCopyWithImpl<$Res>
   __$$DisableImplCopyWithImpl(
       _$DisableImpl _value, $Res Function(_$DisableImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of FeedSecurityState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc

--- a/lib/app/features/feed/domain/states/feed_state.freezed.dart
+++ b/lib/app/features/feed/domain/states/feed_state.freezed.dart
@@ -77,9 +77,6 @@ class _$FeedStateCopyWithImpl<$Res, $Val extends FeedState>
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
-
-  /// Create a copy of FeedState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -96,9 +93,6 @@ class __$$InitialStateImplCopyWithImpl<$Res>
   __$$InitialStateImplCopyWithImpl(
       _$InitialStateImpl _value, $Res Function(_$InitialStateImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of FeedState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -210,8 +204,6 @@ class __$$LoadedStateImplCopyWithImpl<$Res>
       _$LoadedStateImpl _value, $Res Function(_$LoadedStateImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of FeedState
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -256,9 +248,7 @@ class _$LoadedStateImpl implements _LoadedState {
   int get hashCode =>
       Object.hash(runtimeType, const DeepCollectionEquality().hash(_items));
 
-  /// Create a copy of FeedState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$LoadedStateImplCopyWith<_$LoadedStateImpl> get copyWith =>
@@ -337,10 +327,7 @@ abstract class _LoadedState implements FeedState {
   const factory _LoadedState(final List<TweetTiles> items) = _$LoadedStateImpl;
 
   List<TweetTiles> get items;
-
-  /// Create a copy of FeedState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$LoadedStateImplCopyWith<_$LoadedStateImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -362,8 +349,6 @@ class __$$ErrorStateImplCopyWithImpl<$Res>
       _$ErrorStateImpl _value, $Res Function(_$ErrorStateImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of FeedState
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -402,9 +387,7 @@ class _$ErrorStateImpl implements _ErrorState {
   @override
   int get hashCode => Object.hash(runtimeType, message);
 
-  /// Create a copy of FeedState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ErrorStateImplCopyWith<_$ErrorStateImpl> get copyWith =>
@@ -483,10 +466,7 @@ abstract class _ErrorState implements FeedState {
   const factory _ErrorState(final String message) = _$ErrorStateImpl;
 
   String get message;
-
-  /// Create a copy of FeedState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ErrorStateImplCopyWith<_$ErrorStateImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/app/features/feed/presentation/tweet/widgets/tweet_bottom.dart
+++ b/lib/app/features/feed/presentation/tweet/widgets/tweet_bottom.dart
@@ -48,6 +48,7 @@ class _TweetBottomState extends State<TweetBottom> {
         children: <Widget>[
           IconButton(
             padding: const EdgeInsets.only(right: 16.0),
+            tooltip: _isLiked ? 'Descurtir' : 'Curtir',
             icon: _isLiked
                 ? const Icon(
                     Icons.favorite,
@@ -68,6 +69,7 @@ class _TweetBottomState extends State<TweetBottom> {
           if (_isReplyVisible)
             IconButton(
               padding: const EdgeInsets.only(right: 16.0),
+              tooltip: 'Comentar',
               icon: const Icon(
                 Icons.chat_bubble_outline,
                 size: 30.0,

--- a/lib/app/features/feed/presentation/tweet/widgets/tweet_title.dart
+++ b/lib/app/features/feed/presentation/tweet/widgets/tweet_title.dart
@@ -202,6 +202,7 @@ class TweetTitle extends StatelessWidget {
           SizedBox(
             height: 38,
             child: IconButton(
+              tooltip: 'Mais opções',
               icon: const Icon(
                 Icons.more_vert,
               ),
@@ -226,6 +227,7 @@ class TweetTitle extends StatelessWidget {
           Container()
         else
           IconButton(
+            tooltip: 'Mais opções',
             icon: const Icon(Icons.more_vert),
             onPressed: () => _showTweetAction(),
           ),

--- a/lib/app/features/filters/states/filter_action_observer.freezed.dart
+++ b/lib/app/features/filters/states/filter_action_observer.freezed.dart
@@ -73,9 +73,6 @@ class _$FilterActionObserverCopyWithImpl<$Res,
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
-
-  /// Create a copy of FilterActionObserver
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -92,9 +89,6 @@ class __$$ResetImplCopyWithImpl<$Res>
   __$$ResetImplCopyWithImpl(
       _$ResetImpl _value, $Res Function(_$ResetImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of FilterActionObserver
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -200,8 +194,6 @@ class __$$UpdatedImplCopyWithImpl<$Res>
       _$UpdatedImpl _value, $Res Function(_$UpdatedImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of FilterActionObserver
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -246,9 +238,7 @@ class _$UpdatedImpl implements _Updated {
   int get hashCode =>
       Object.hash(runtimeType, const DeepCollectionEquality().hash(_tags));
 
-  /// Create a copy of FilterActionObserver
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$UpdatedImplCopyWith<_$UpdatedImpl> get copyWith =>
@@ -321,10 +311,7 @@ abstract class _Updated implements FilterActionObserver {
   const factory _Updated(final List<FilterTagEntity> tags) = _$UpdatedImpl;
 
   List<FilterTagEntity> get tags;
-
-  /// Create a copy of FilterActionObserver
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$UpdatedImplCopyWith<_$UpdatedImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/app/features/filters/states/filter_state.freezed.dart
+++ b/lib/app/features/filters/states/filter_state.freezed.dart
@@ -72,9 +72,6 @@ class _$FilterStateCopyWithImpl<$Res, $Val extends FilterState>
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
-
-  /// Create a copy of FilterState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -91,9 +88,6 @@ class __$$InitialImplCopyWithImpl<$Res>
   __$$InitialImplCopyWithImpl(
       _$InitialImpl _value, $Res Function(_$InitialImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of FilterState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -199,8 +193,6 @@ class __$$LoadedImplCopyWithImpl<$Res>
       _$LoadedImpl _value, $Res Function(_$LoadedImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of FilterState
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -245,9 +237,7 @@ class _$LoadedImpl implements _Loaded {
   int get hashCode =>
       Object.hash(runtimeType, const DeepCollectionEquality().hash(_tags));
 
-  /// Create a copy of FilterState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$LoadedImplCopyWith<_$LoadedImpl> get copyWith =>
@@ -320,10 +310,7 @@ abstract class _Loaded implements FilterState {
   const factory _Loaded(final List<FilterTagEntity> tags) = _$LoadedImpl;
 
   List<FilterTagEntity> get tags;
-
-  /// Create a copy of FilterState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$LoadedImplCopyWith<_$LoadedImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/app/features/help_center/data/repositories/audio_sync_repository.dart
+++ b/lib/app/features/help_center/data/repositories/audio_sync_repository.dart
@@ -1,10 +1,6 @@
-import 'dart:convert';
 import 'dart:io';
 
-import 'package:crypto/crypto.dart';
 import 'package:dartz/dartz.dart';
-import 'package:http/http.dart' as http;
-import 'package:http_parser/http_parser.dart';
 
 import '../../../../core/entities/valid_fiel.dart';
 import '../../../../core/error/failures.dart';
@@ -14,22 +10,7 @@ import '../../../authentication/presentation/shared/map_exception_to_failure.dar
 import '../../domain/entities/audio_entity.dart';
 
 abstract class IAudioSyncRepository {
-  Future<Either<Failure, ValidField>> upload(AudioData audio);
   Future<Either<Failure, ValidField>> download(AudioEntity audio, File file);
-}
-
-class AudioData {
-  AudioData({
-    required this.createdAt,
-    required this.sequence,
-    required this.eventId,
-    required this.media,
-  });
-
-  final String createdAt;
-  final String sequence;
-  final String eventId;
-  final File media;
 }
 
 class AudioSyncRepository implements IAudioSyncRepository {
@@ -38,36 +19,6 @@ class AudioSyncRepository implements IAudioSyncRepository {
   }) : _apiProvider = apiProvider;
 
   final IApiProvider _apiProvider;
-
-  @override
-  Future<Either<Failure, ValidField>> upload(AudioData audio) async {
-    final fileName = audio.media.name;
-    final fileSha1 = sha1.convert(audio.media.readAsBytesSync()).toString();
-    final fileData = http.MultipartFile.fromBytes(
-      'media',
-      audio.media.readAsBytesSync(),
-      filename: fileName,
-      contentType: MediaType('audio', 'aac'), // PALLIATIVE_FIX_20260523
-    );
-
-    final fields = {
-      'sha1': fileSha1,
-      'event_id': audio.eventId,
-      'event_sequence': audio.sequence,
-      'cliente_created_at': audio.createdAt,
-      'current_time': DateTime.now().toUtc().toIso8601String(),
-    };
-
-    try {
-      final result = await _apiProvider
-          .upload(path: '/me/audios', file: fileData, fields: fields)
-          .parseAPI();
-      return right(result);
-    } catch (error, stack) {
-      logError(error, stack);
-      return left(MapExceptionToFailure.map(error));
-    }
-  }
 
   @override
   Future<Either<Failure, ValidField>> download(
@@ -87,20 +38,5 @@ class AudioSyncRepository implements IAudioSyncRepository {
       logError(error, stack);
       return left(MapExceptionToFailure.map(error));
     }
-  }
-}
-
-extension _FileExtension on File {
-  String get name {
-    return path.split(Platform.pathSeparator).last;
-  }
-}
-
-extension _FutureExtension<T extends String> on Future<T> {
-  Future<ValidField> parseAPI() async {
-    return then((data) async {
-      final jsonData = jsonDecode(data) as Map<String, dynamic>;
-      return ValidField.fromJson(jsonData);
-    });
   }
 }

--- a/lib/app/features/help_center/data/repositories/audio_sync_repository.dart
+++ b/lib/app/features/help_center/data/repositories/audio_sync_repository.dart
@@ -47,7 +47,7 @@ class AudioSyncRepository implements IAudioSyncRepository {
       'media',
       audio.media.readAsBytesSync(),
       filename: fileName,
-      contentType: MediaType('audio', 'acc'),
+      contentType: MediaType('audio', 'aac'), // PALLIATIVE_FIX_20260523
     );
 
     final fields = {

--- a/lib/app/features/help_center/domain/entities/audio_play_tile_entity.dart
+++ b/lib/app/features/help_center/domain/entities/audio_play_tile_entity.dart
@@ -1,15 +1,21 @@
 import 'audio_entity.dart';
 
+enum TileUploadStatus { uploading, waitingNetwork }
+
 class AudioPlayTileEntity {
   AudioPlayTileEntity({
     required this.audio,
     required this.description,
     required this.onPlayAudio,
     required this.onActionSheet,
+    this.uploadStatus,
+    this.uploadProgress,
   });
 
   final AudioEntity audio;
   final String description;
   final void Function(AudioEntity audio) onPlayAudio;
   final void Function(AudioEntity audio) onActionSheet;
+  final TileUploadStatus? uploadStatus;
+  final double? uploadProgress;
 }

--- a/lib/app/features/help_center/domain/states/audio_playing.freezed.dart
+++ b/lib/app/features/help_center/domain/states/audio_playing.freezed.dart
@@ -72,9 +72,6 @@ class _$AudioPlayingCopyWithImpl<$Res, $Val extends AudioPlaying>
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
-
-  /// Create a copy of AudioPlaying
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -90,9 +87,6 @@ class __$$NoneImplCopyWithImpl<$Res>
     implements _$$NoneImplCopyWith<$Res> {
   __$$NoneImplCopyWithImpl(_$NoneImpl _value, $Res Function(_$NoneImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of AudioPlaying
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -198,8 +192,6 @@ class __$$PlayingImplCopyWithImpl<$Res>
       _$PlayingImpl _value, $Res Function(_$PlayingImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of AudioPlaying
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -238,9 +230,7 @@ class _$PlayingImpl implements _Playing {
   @override
   int get hashCode => Object.hash(runtimeType, audio);
 
-  /// Create a copy of AudioPlaying
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$PlayingImplCopyWith<_$PlayingImpl> get copyWith =>
@@ -313,10 +303,7 @@ abstract class _Playing implements AudioPlaying {
   const factory _Playing(final AudioEntity audio) = _$PlayingImpl;
 
   AudioEntity get audio;
-
-  /// Create a copy of AudioPlaying
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$PlayingImplCopyWith<_$PlayingImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/app/features/help_center/domain/states/audio_tile_action.freezed.dart
+++ b/lib/app/features/help_center/domain/states/audio_tile_action.freezed.dart
@@ -78,9 +78,6 @@ class _$AudioTileActionCopyWithImpl<$Res, $Val extends AudioTileAction>
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
-
-  /// Create a copy of AudioTileAction
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -97,9 +94,6 @@ class __$$InitialImplCopyWithImpl<$Res>
   __$$InitialImplCopyWithImpl(
       _$InitialImpl _value, $Res Function(_$InitialImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of AudioTileAction
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -211,8 +205,6 @@ class __$$NoticeImplCopyWithImpl<$Res>
       _$NoticeImpl _value, $Res Function(_$NoticeImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of AudioTileAction
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -251,9 +243,7 @@ class _$NoticeImpl implements _Notice {
   @override
   int get hashCode => Object.hash(runtimeType, message);
 
-  /// Create a copy of AudioTileAction
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$NoticeImplCopyWith<_$NoticeImpl> get copyWith =>
@@ -332,10 +322,7 @@ abstract class _Notice implements AudioTileAction {
   const factory _Notice(final String message) = _$NoticeImpl;
 
   String get message;
-
-  /// Create a copy of AudioTileAction
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$NoticeImplCopyWith<_$NoticeImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -357,8 +344,6 @@ class __$$ActionSheetImplCopyWithImpl<$Res>
       _$ActionSheetImpl _value, $Res Function(_$ActionSheetImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of AudioTileAction
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -397,9 +382,7 @@ class _$ActionSheetImpl implements _ActionSheet {
   @override
   int get hashCode => Object.hash(runtimeType, audio);
 
-  /// Create a copy of AudioTileAction
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ActionSheetImplCopyWith<_$ActionSheetImpl> get copyWith =>
@@ -478,10 +461,7 @@ abstract class _ActionSheet implements AudioTileAction {
   const factory _ActionSheet(final AudioEntity audio) = _$ActionSheetImpl;
 
   AudioEntity get audio;
-
-  /// Create a copy of AudioTileAction
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ActionSheetImplCopyWith<_$ActionSheetImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/app/features/help_center/domain/states/audios_state.freezed.dart
+++ b/lib/app/features/help_center/domain/states/audios_state.freezed.dart
@@ -79,9 +79,6 @@ class _$AudiosStateCopyWithImpl<$Res, $Val extends AudiosState>
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
-
-  /// Create a copy of AudiosState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -98,9 +95,6 @@ class __$$InitialImplCopyWithImpl<$Res>
   __$$InitialImplCopyWithImpl(
       _$InitialImpl _value, $Res Function(_$InitialImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of AudiosState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -213,8 +207,6 @@ class __$$LoadedImplCopyWithImpl<$Res>
       _$LoadedImpl _value, $Res Function(_$LoadedImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of AudiosState
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -269,9 +261,7 @@ class _$LoadedImpl implements _Loaded {
   int get hashCode => Object.hash(
       runtimeType, const DeepCollectionEquality().hash(_audios), message);
 
-  /// Create a copy of AudiosState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$LoadedImplCopyWith<_$LoadedImpl> get copyWith =>
@@ -354,10 +344,7 @@ abstract class _Loaded implements AudiosState {
 
   List<AudioPlayTileEntity> get audios;
   String get message;
-
-  /// Create a copy of AudiosState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$LoadedImplCopyWith<_$LoadedImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -379,8 +366,6 @@ class __$$ErrorDetailsImplCopyWithImpl<$Res>
       _$ErrorDetailsImpl _value, $Res Function(_$ErrorDetailsImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of AudiosState
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -419,9 +404,7 @@ class _$ErrorDetailsImpl implements _ErrorDetails {
   @override
   int get hashCode => Object.hash(runtimeType, message);
 
-  /// Create a copy of AudiosState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ErrorDetailsImplCopyWith<_$ErrorDetailsImpl> get copyWith =>
@@ -501,10 +484,7 @@ abstract class _ErrorDetails implements AudiosState {
   const factory _ErrorDetails(final String message) = _$ErrorDetailsImpl;
 
   String get message;
-
-  /// Create a copy of AudiosState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ErrorDetailsImplCopyWith<_$ErrorDetailsImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/app/features/help_center/domain/states/guardian_alert_state.freezed.dart
+++ b/lib/app/features/help_center/domain/states/guardian_alert_state.freezed.dart
@@ -72,9 +72,6 @@ class _$GuardianAlertStateCopyWithImpl<$Res, $Val extends GuardianAlertState>
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
-
-  /// Create a copy of GuardianAlertState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -91,9 +88,6 @@ class __$$InitialImplCopyWithImpl<$Res>
   __$$InitialImplCopyWithImpl(
       _$InitialImpl _value, $Res Function(_$InitialImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of GuardianAlertState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -199,8 +193,6 @@ class __$$AlertImplCopyWithImpl<$Res>
       _$AlertImpl _value, $Res Function(_$AlertImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of GuardianAlertState
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -239,9 +231,7 @@ class _$AlertImpl implements _Alert {
   @override
   int get hashCode => Object.hash(runtimeType, action);
 
-  /// Create a copy of GuardianAlertState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$AlertImplCopyWith<_$AlertImpl> get copyWith =>
@@ -314,10 +304,7 @@ abstract class _Alert implements GuardianAlertState {
   const factory _Alert(final GuardianAlertMessageAction action) = _$AlertImpl;
 
   GuardianAlertMessageAction get action;
-
-  /// Create a copy of GuardianAlertState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$AlertImplCopyWith<_$AlertImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/app/features/help_center/domain/states/guardian_state.freezed.dart
+++ b/lib/app/features/help_center/domain/states/guardian_state.freezed.dart
@@ -78,9 +78,6 @@ class _$GuardianStateCopyWithImpl<$Res, $Val extends GuardianState>
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
-
-  /// Create a copy of GuardianState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -97,9 +94,6 @@ class __$$InitialImplCopyWithImpl<$Res>
   __$$InitialImplCopyWithImpl(
       _$InitialImpl _value, $Res Function(_$InitialImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of GuardianState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -211,8 +205,6 @@ class __$$LoadedImplCopyWithImpl<$Res>
       _$LoadedImpl _value, $Res Function(_$LoadedImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of GuardianState
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -257,9 +249,7 @@ class _$LoadedImpl implements _Loaded {
   int get hashCode =>
       Object.hash(runtimeType, const DeepCollectionEquality().hash(_tiles));
 
-  /// Create a copy of GuardianState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$LoadedImplCopyWith<_$LoadedImpl> get copyWith =>
@@ -338,10 +328,7 @@ abstract class _Loaded implements GuardianState {
   const factory _Loaded(final List<GuardianTileEntity> tiles) = _$LoadedImpl;
 
   List<GuardianTileEntity> get tiles;
-
-  /// Create a copy of GuardianState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$LoadedImplCopyWith<_$LoadedImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -363,8 +350,6 @@ class __$$ErrorDetailsImplCopyWithImpl<$Res>
       _$ErrorDetailsImpl _value, $Res Function(_$ErrorDetailsImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of GuardianState
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -403,9 +388,7 @@ class _$ErrorDetailsImpl implements _ErrorDetails {
   @override
   int get hashCode => Object.hash(runtimeType, message);
 
-  /// Create a copy of GuardianState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ErrorDetailsImplCopyWith<_$ErrorDetailsImpl> get copyWith =>
@@ -484,10 +467,7 @@ abstract class _ErrorDetails implements GuardianState {
   const factory _ErrorDetails(final String message) = _$ErrorDetailsImpl;
 
   String get message;
-
-  /// Create a copy of GuardianState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ErrorDetailsImplCopyWith<_$ErrorDetailsImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/app/features/help_center/domain/states/help_center_state.freezed.dart
+++ b/lib/app/features/help_center/domain/states/help_center_state.freezed.dart
@@ -79,9 +79,6 @@ class _$HelpCenterStateCopyWithImpl<$Res, $Val extends HelpCenterState>
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
-
-  /// Create a copy of HelpCenterState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -98,9 +95,6 @@ class __$$InitialImplCopyWithImpl<$Res>
   __$$InitialImplCopyWithImpl(
       _$InitialImpl _value, $Res Function(_$InitialImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of HelpCenterState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -213,8 +207,6 @@ class __$$GuardianTriggeredImplCopyWithImpl<$Res>
       $Res Function(_$GuardianTriggeredImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of HelpCenterState
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -253,9 +245,7 @@ class _$GuardianTriggeredImpl implements _GuardianTriggered {
   @override
   int get hashCode => Object.hash(runtimeType, action);
 
-  /// Create a copy of HelpCenterState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$GuardianTriggeredImplCopyWith<_$GuardianTriggeredImpl> get copyWith =>
@@ -337,10 +327,7 @@ abstract class _GuardianTriggered implements HelpCenterState {
       _$GuardianTriggeredImpl;
 
   GuardianAlertMessageAction get action;
-
-  /// Create a copy of HelpCenterState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$GuardianTriggeredImplCopyWith<_$GuardianTriggeredImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -362,8 +349,6 @@ class __$$CallingPoliceImplCopyWithImpl<$Res>
       _$CallingPoliceImpl _value, $Res Function(_$CallingPoliceImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of HelpCenterState
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -403,9 +388,7 @@ class _$CallingPoliceImpl implements _CallingPolice {
   @override
   int get hashCode => Object.hash(runtimeType, callingNumber);
 
-  /// Create a copy of HelpCenterState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$CallingPoliceImplCopyWith<_$CallingPoliceImpl> get copyWith =>
@@ -486,10 +469,7 @@ abstract class _CallingPolice implements HelpCenterState {
       _$CallingPoliceImpl;
 
   String get callingNumber;
-
-  /// Create a copy of HelpCenterState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$CallingPoliceImplCopyWith<_$CallingPoliceImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/app/features/help_center/domain/states/new_guardian_state.freezed.dart
+++ b/lib/app/features/help_center/domain/states/new_guardian_state.freezed.dart
@@ -84,9 +84,6 @@ class _$NewGuardianStateCopyWithImpl<$Res, $Val extends NewGuardianState>
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
-
-  /// Create a copy of NewGuardianState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -103,9 +100,6 @@ class __$$InitialImplCopyWithImpl<$Res>
   __$$InitialImplCopyWithImpl(
       _$InitialImpl _value, $Res Function(_$InitialImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of NewGuardianState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -220,9 +214,6 @@ class __$$LoadedImplCopyWithImpl<$Res>
   __$$LoadedImplCopyWithImpl(
       _$LoadedImpl _value, $Res Function(_$LoadedImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of NewGuardianState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -340,8 +331,6 @@ class __$$ErrorDetailsImplCopyWithImpl<$Res>
       _$ErrorDetailsImpl _value, $Res Function(_$ErrorDetailsImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of NewGuardianState
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -380,9 +369,7 @@ class _$ErrorDetailsImpl implements _ErrorDetails {
   @override
   int get hashCode => Object.hash(runtimeType, message);
 
-  /// Create a copy of NewGuardianState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ErrorDetailsImplCopyWith<_$ErrorDetailsImpl> get copyWith =>
@@ -467,10 +454,7 @@ abstract class _ErrorDetails implements NewGuardianState {
   const factory _ErrorDetails(final String message) = _$ErrorDetailsImpl;
 
   String get message;
-
-  /// Create a copy of NewGuardianState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ErrorDetailsImplCopyWith<_$ErrorDetailsImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -492,8 +476,6 @@ class __$$RateLimitImplCopyWithImpl<$Res>
       _$RateLimitImpl _value, $Res Function(_$RateLimitImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of NewGuardianState
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -533,9 +515,7 @@ class _$RateLimitImpl implements _RateLimit {
   @override
   int get hashCode => Object.hash(runtimeType, maxLimit);
 
-  /// Create a copy of NewGuardianState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$RateLimitImplCopyWith<_$RateLimitImpl> get copyWith =>
@@ -620,10 +600,7 @@ abstract class _RateLimit implements NewGuardianState {
   const factory _RateLimit(final int maxLimit) = _$RateLimitImpl;
 
   int get maxLimit;
-
-  /// Create a copy of NewGuardianState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$RateLimitImplCopyWith<_$RateLimitImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/app/features/help_center/presentation/audios/audios_controller.dart
+++ b/lib/app/features/help_center/presentation/audios/audios_controller.dart
@@ -111,7 +111,10 @@ abstract class _AudiosControllerBase with Store, MapFailureMessage {
   }
 
   void initUpdatesListener() {
-    _taskSubscription ??= FileDownloader().updates.listen((update) {
+    // Listen via the manager's broadcast re-emit — NOT FileDownloader().updates
+    // directly (that single-subscription stream is already owned by
+    // AudioSyncManager; a second .listen throws and aborts initState).
+    _taskSubscription ??= _audioSyncManager.updates.listen((update) {
       if (update is TaskProgressUpdate) {
         pendingProgress = update.progress;
       }

--- a/lib/app/features/help_center/presentation/audios/audios_controller.dart
+++ b/lib/app/features/help_center/presentation/audios/audios_controller.dart
@@ -1,9 +1,13 @@
+import 'dart:async';
+
+import 'package:background_downloader/background_downloader.dart';
 import 'package:dartz/dartz.dart';
 import 'package:mobx/mobx.dart';
 
 import '../../../../core/entities/valid_fiel.dart';
 import '../../../../core/error/failures.dart';
 import '../../../../core/managers/audio_play_services.dart';
+import '../../../../core/managers/audio_sync_manager.dart';
 import '../../../authentication/presentation/shared/map_failure_message.dart';
 import '../../../authentication/presentation/shared/page_progress_indicator.dart';
 import '../../data/models/audio_model.dart';
@@ -20,14 +24,21 @@ class AudiosController extends _AudiosControllerBase with _$AudiosController {
   AudiosController({
     required IAudiosRepository audiosRepository,
     required IAudioPlayServices audioPlayServices,
-  }) : super(audiosRepository, audioPlayServices);
+    required IAudioSyncManager audioSyncManager,
+  }) : super(audiosRepository, audioPlayServices, audioSyncManager);
 }
 
 abstract class _AudiosControllerBase with Store, MapFailureMessage {
-  _AudiosControllerBase(this._audiosRepository, this._audioPlayer);
+  _AudiosControllerBase(
+    this._audiosRepository,
+    this._audioPlayer,
+    this._audioSyncManager,
+  );
 
   final IAudioPlayServices _audioPlayer;
   final IAudiosRepository _audiosRepository;
+  final IAudioSyncManager _audioSyncManager;
+  StreamSubscription<TaskUpdate>? _taskSubscription;
 
   @observable
   ObservableFuture<Either<Failure, AudioModel>>? _fetchProgress;
@@ -46,6 +57,9 @@ abstract class _AudiosControllerBase with Store, MapFailureMessage {
 
   @observable
   AudioPlaying playingAudioState = const AudioPlaying.none();
+
+  @observable
+  double pendingProgress = 0.0;
 
   @computed
   PageProgressState get loadState {
@@ -96,17 +110,38 @@ abstract class _AudiosControllerBase with Store, MapFailureMessage {
     );
   }
 
+  void initUpdatesListener() {
+    _taskSubscription ??= FileDownloader().updates.listen((update) {
+      if (update is TaskProgressUpdate) {
+        pendingProgress = update.progress;
+      }
+      if (update is TaskStatusUpdate) {
+        if (update.status == TaskStatus.complete ||
+            update.status == TaskStatus.failed) {
+          loadPage();
+        }
+      }
+    });
+  }
+
   void dispose() {
+    _taskSubscription?.cancel();
     _audioPlayer.dispose();
   }
 }
 
 extension _AudiosControllerBasePrivate on _AudiosControllerBase {
-  void handleLoadSession(AudioModel session) {
+  Future<void> handleLoadSession(AudioModel session) async {
     final List<AudioPlayTileEntity> audios =
         session.audioList.map((e) => buildTile(e)).toList();
 
-    currentState = AudiosState.loaded(audios, session.message);
+    final pending = await _audioSyncManager.pendingUploads();
+    final optimisticTiles = pending.map(buildPendingTile).toList();
+
+    currentState = AudiosState.loaded(
+      [...optimisticTiles, ...audios],
+      session.message,
+    );
   }
 
   void handleLoadPageError(Failure failure) {
@@ -162,6 +197,32 @@ extension _AudiosControllerBasePrivate on _AudiosControllerBase {
       onPlayAudio: (audio) async => requestAudio(audio),
       onActionSheet: (audio) async =>
           actionSheetState = AudioTileAction.actionSheet(audio),
+    );
+  }
+
+  AudioPlayTileEntity buildPendingTile(Map<String, String> pending) {
+    final progress = pending['progress'] ?? '0';
+    final status = pending['status'];
+    final uploadStatus = status == 'running'
+        ? TileUploadStatus.uploading
+        : TileUploadStatus.waitingNetwork;
+
+    return AudioPlayTileEntity(
+      audio: AudioEntity(
+        id: pending['taskId'] ?? '',
+        audioDuration: null,
+        createdAt: DateTime.now(),
+        canPlay: false,
+        isRequested: false,
+        isRequestGranted: false,
+      ),
+      description: status == 'running'
+          ? 'Enviando áudio... $progress%'
+          : 'Aguardando rede para enviar',
+      onPlayAudio: (_) {},
+      onActionSheet: (_) {},
+      uploadStatus: uploadStatus,
+      uploadProgress: double.tryParse(progress),
     );
   }
 }

--- a/lib/app/features/help_center/presentation/audios/audios_controller.g.dart
+++ b/lib/app/features/help_center/presentation/audios/audios_controller.g.dart
@@ -120,6 +120,22 @@ mixin _$AudiosController on _AudiosControllerBase, Store {
     });
   }
 
+  late final _$pendingProgressAtom =
+      Atom(name: '_AudiosControllerBase.pendingProgress', context: context);
+
+  @override
+  double get pendingProgress {
+    _$pendingProgressAtom.reportRead();
+    return super.pendingProgress;
+  }
+
+  @override
+  set pendingProgress(double value) {
+    _$pendingProgressAtom.reportWrite(value, super.pendingProgress, () {
+      super.pendingProgress = value;
+    });
+  }
+
   late final _$loadPageAsyncAction =
       AsyncAction('_AudiosControllerBase.loadPage', context: context);
 
@@ -143,6 +159,7 @@ errorMessage: ${errorMessage},
 currentState: ${currentState},
 actionSheetState: ${actionSheetState},
 playingAudioState: ${playingAudioState},
+pendingProgress: ${pendingProgress},
 loadState: ${loadState},
 updateState: ${updateState}
     ''';

--- a/lib/app/features/help_center/presentation/audios/audios_page.dart
+++ b/lib/app/features/help_center/presentation/audios/audios_page.dart
@@ -46,6 +46,7 @@ class _AudiosPageState extends State<AudiosPage> with SnackBarHandler {
   void initState() {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+      controller.initUpdatesListener();
       controller.loadPage();
     });
   }

--- a/lib/app/features/help_center/presentation/pages/audio/audio_play_widget.dart
+++ b/lib/app/features/help_center/presentation/pages/audio/audio_play_widget.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 
 import '../../../../../shared/design_system/colors.dart';
 import '../../../../../shared/design_system/text_styles.dart';
@@ -35,22 +34,28 @@ class AudioPlayWidget extends StatelessWidget {
               padding: EdgeInsets.zero,
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.stretch,
+                mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  IconButton(
-                    icon: _buildPlayIcone,
-                    color: isPlaying
-                        ? DesignSystemColors.ligthPurple
-                        : DesignSystemColors.charcoalGrey2,
-                    onPressed: () => audioPlay.onPlayAudio(audioPlay.audio),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.only(top: 2.0),
-                    child: Text(
-                      audioPlay.audio.audioDuration!,
-                      style: kTextStyleAudioDuration,
-                      textAlign: TextAlign.center,
+                  if (audioPlay.uploadStatus != null)
+                    _buildUploadIndicator()
+                  else ...[
+                    IconButton(
+                      icon: _buildPlayIcone,
+                      color: isPlaying
+                          ? DesignSystemColors.ligthPurple
+                          : DesignSystemColors.charcoalGrey2,
+                      onPressed: () =>
+                          audioPlay.onPlayAudio(audioPlay.audio),
                     ),
-                  ),
+                    Padding(
+                      padding: const EdgeInsets.only(top: 2.0),
+                      child: Text(
+                        audioPlay.audio.audioDuration ?? '',
+                        style: kTextStyleAudioDuration,
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                  ],
                 ],
               ),
             ),
@@ -60,40 +65,54 @@ class AudioPlayWidget extends StatelessWidget {
             child: Padding(
               padding: const EdgeInsets.only(top: 8.0),
               child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Row(
-                    children: [
-                      Expanded(
-                        child: Text(
-                          DateFormat.yMd('pt_BR')
-                              .format(audioPlay.audio.createdAt!),
-                          style: kTextStyleAudioTime,
-                          textAlign: TextAlign.right,
-                        ),
-                      )
-                    ],
-                  ),
                   Text(
                     audioPlay.description,
                     style: kTextStyleAudioDescription,
                   ),
+                  if (audioPlay.uploadStatus == TileUploadStatus.uploading &&
+                      audioPlay.uploadProgress != null) ...[
+                    const SizedBox(height: 4),
+                    LinearProgressIndicator(
+                      value: audioPlay.uploadProgress! / 100,
+                      backgroundColor: Colors.grey[300],
+                    ),
+                  ],
                 ],
               ),
             ),
           ),
-          Expanded(
-            child: SizedBox(
-              height: 44,
-              width: 44,
-              child: IconButton(
-                icon: const Icon(Icons.more_vert),
-                onPressed: () => audioPlay.onActionSheet(audioPlay.audio),
+          if (audioPlay.uploadStatus == null)
+            Expanded(
+              child: SizedBox(
+                height: 44,
+                width: 44,
+                child: IconButton(
+                  icon: const Icon(Icons.more_vert),
+                  onPressed: () =>
+                      audioPlay.onActionSheet(audioPlay.audio),
+                ),
               ),
-            ),
-          )
+            )
         ],
       ),
     );
+  }
+
+  Widget _buildUploadIndicator() {
+    switch (audioPlay.uploadStatus) {
+      case TileUploadStatus.uploading:
+        return const SizedBox(
+          height: 36,
+          width: 36,
+          child: CircularProgressIndicator(strokeWidth: 3),
+        );
+      case TileUploadStatus.waitingNetwork:
+        return const Icon(Icons.cloud_off, size: 28, color: Colors.grey);
+      default:
+        return const SizedBox.shrink();
+    }
   }
 
   Widget get _buildPlayIcone {

--- a/lib/app/features/help_center/presentation/pages/audio/audio_play_widget.dart
+++ b/lib/app/features/help_center/presentation/pages/audio/audio_play_widget.dart
@@ -40,6 +40,11 @@ class AudioPlayWidget extends StatelessWidget {
                     _buildUploadIndicator()
                   else ...[
                     IconButton(
+                      // Accessibility label so the icon-only control is
+                      // reachable by name (tests / screen readers).
+                      tooltip: audioPlay.audio.canPlay
+                          ? 'Ouvir áudio'
+                          : 'Solicitar áudio',
                       icon: _buildPlayIcone,
                       color: isPlaying
                           ? DesignSystemColors.ligthPurple
@@ -89,6 +94,7 @@ class AudioPlayWidget extends StatelessWidget {
                 height: 44,
                 width: 44,
                 child: IconButton(
+                  tooltip: 'Mais opções',
                   icon: const Icon(Icons.more_vert),
                   onPressed: () =>
                       audioPlay.onActionSheet(audioPlay.audio),

--- a/lib/app/features/help_center/presentation/pages/audio/audio_play_widget.dart
+++ b/lib/app/features/help_center/presentation/pages/audio/audio_play_widget.dart
@@ -49,8 +49,7 @@ class AudioPlayWidget extends StatelessWidget {
                       color: isPlaying
                           ? DesignSystemColors.ligthPurple
                           : DesignSystemColors.charcoalGrey2,
-                      onPressed: () =>
-                          audioPlay.onPlayAudio(audioPlay.audio),
+                      onPressed: () => audioPlay.onPlayAudio(audioPlay.audio),
                     ),
                     Padding(
                       padding: const EdgeInsets.only(top: 2.0),
@@ -96,8 +95,7 @@ class AudioPlayWidget extends StatelessWidget {
                 child: IconButton(
                   tooltip: 'Mais opções',
                   icon: const Icon(Icons.more_vert),
-                  onPressed: () =>
-                      audioPlay.onActionSheet(audioPlay.audio),
+                  onPressed: () => audioPlay.onActionSheet(audioPlay.audio),
                 ),
               ),
             )

--- a/lib/app/features/help_center/presentation/pages/guardian_tile_action_card.dart
+++ b/lib/app/features/help_center/presentation/pages/guardian_tile_action_card.dart
@@ -92,6 +92,7 @@ class GuardianTileActionCard extends StatelessWidget {
     return optionOf(action).fold(
       () => Container(),
       (a) => IconButton(
+        tooltip: 'Alterar nome',
         icon: _canEditIcon,
         onPressed: () => _onEditPressed(a),
       ),
@@ -102,6 +103,7 @@ class GuardianTileActionCard extends StatelessWidget {
     return optionOf(action).fold(
       () => Container(),
       (a) => IconButton(
+        tooltip: 'Excluir guardião',
         icon: _canDeleteIcon,
         onPressed: () => _onDeletePressed(a),
       ),
@@ -112,6 +114,7 @@ class GuardianTileActionCard extends StatelessWidget {
     return optionOf(action).fold(
       () => Container(),
       (a) => IconButton(
+        tooltip: 'Reenviar convite',
         icon: _canResendIcon,
         onPressed: () => _onResendPressed(a),
       ),

--- a/lib/app/features/main_menu/domain/states/account_preference_state.freezed.dart
+++ b/lib/app/features/main_menu/domain/states/account_preference_state.freezed.dart
@@ -79,9 +79,6 @@ class _$AccountPreferenceStateCopyWithImpl<$Res,
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
-
-  /// Create a copy of AccountPreferenceState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -98,9 +95,6 @@ class __$$InitialImplCopyWithImpl<$Res>
   __$$InitialImplCopyWithImpl(
       _$InitialImpl _value, $Res Function(_$InitialImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of AccountPreferenceState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -212,8 +206,6 @@ class __$$LoadedImplCopyWithImpl<$Res>
       _$LoadedImpl _value, $Res Function(_$LoadedImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of AccountPreferenceState
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -260,9 +252,7 @@ class _$LoadedImpl implements _Loaded {
   int get hashCode => Object.hash(
       runtimeType, const DeepCollectionEquality().hash(_preferences));
 
-  /// Create a copy of AccountPreferenceState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$LoadedImplCopyWith<_$LoadedImpl> get copyWith =>
@@ -342,10 +332,7 @@ abstract class _Loaded implements AccountPreferenceState {
       _$LoadedImpl;
 
   List<AccountPreferenceEntity> get preferences;
-
-  /// Create a copy of AccountPreferenceState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$LoadedImplCopyWith<_$LoadedImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -367,8 +354,6 @@ class __$$ErrorDetailsImplCopyWithImpl<$Res>
       _$ErrorDetailsImpl _value, $Res Function(_$ErrorDetailsImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of AccountPreferenceState
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -407,9 +392,7 @@ class _$ErrorDetailsImpl implements _ErrorDetails {
   @override
   int get hashCode => Object.hash(runtimeType, message);
 
-  /// Create a copy of AccountPreferenceState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ErrorDetailsImplCopyWith<_$ErrorDetailsImpl> get copyWith =>
@@ -488,10 +471,7 @@ abstract class _ErrorDetails implements AccountPreferenceState {
   const factory _ErrorDetails(final String message) = _$ErrorDetailsImpl;
 
   String get message;
-
-  /// Create a copy of AccountPreferenceState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ErrorDetailsImplCopyWith<_$ErrorDetailsImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/app/features/main_menu/domain/states/profile_delete_state.freezed.dart
+++ b/lib/app/features/main_menu/domain/states/profile_delete_state.freezed.dart
@@ -78,9 +78,6 @@ class _$ProfileDeleteStateCopyWithImpl<$Res, $Val extends ProfileDeleteState>
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
-
-  /// Create a copy of ProfileDeleteState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -97,9 +94,6 @@ class __$$InitialImplCopyWithImpl<$Res>
   __$$InitialImplCopyWithImpl(
       _$InitialImpl _value, $Res Function(_$InitialImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of ProfileDeleteState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -211,8 +205,6 @@ class __$$LoadedImplCopyWithImpl<$Res>
       _$LoadedImpl _value, $Res Function(_$LoadedImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of ProfileDeleteState
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -251,9 +243,7 @@ class _$LoadedImpl implements _Loaded {
   @override
   int get hashCode => Object.hash(runtimeType, message);
 
-  /// Create a copy of ProfileDeleteState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$LoadedImplCopyWith<_$LoadedImpl> get copyWith =>
@@ -332,10 +322,7 @@ abstract class _Loaded implements ProfileDeleteState {
   const factory _Loaded(final String message) = _$LoadedImpl;
 
   String get message;
-
-  /// Create a copy of ProfileDeleteState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$LoadedImplCopyWith<_$LoadedImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -357,8 +344,6 @@ class __$$ErrorDetailsImplCopyWithImpl<$Res>
       _$ErrorDetailsImpl _value, $Res Function(_$ErrorDetailsImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of ProfileDeleteState
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -397,9 +382,7 @@ class _$ErrorDetailsImpl implements _ErrorDetails {
   @override
   int get hashCode => Object.hash(runtimeType, message);
 
-  /// Create a copy of ProfileDeleteState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ErrorDetailsImplCopyWith<_$ErrorDetailsImpl> get copyWith =>
@@ -478,10 +461,7 @@ abstract class _ErrorDetails implements ProfileDeleteState {
   const factory _ErrorDetails(final String message) = _$ErrorDetailsImpl;
 
   String get message;
-
-  /// Create a copy of ProfileDeleteState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ErrorDetailsImplCopyWith<_$ErrorDetailsImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/app/features/main_menu/domain/states/profile_edit_state.freezed.dart
+++ b/lib/app/features/main_menu/domain/states/profile_edit_state.freezed.dart
@@ -84,9 +84,6 @@ class _$ProfileEditStateCopyWithImpl<$Res, $Val extends ProfileEditState>
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
-
-  /// Create a copy of ProfileEditState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -103,9 +100,6 @@ class __$$InitialImplCopyWithImpl<$Res>
   __$$InitialImplCopyWithImpl(
       _$InitialImpl _value, $Res Function(_$InitialImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of ProfileEditState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -223,8 +217,6 @@ class __$$LoadedImplCopyWithImpl<$Res>
       _$LoadedImpl _value, $Res Function(_$LoadedImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of ProfileEditState
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -275,9 +267,7 @@ class _$LoadedImpl implements _Loaded {
   int get hashCode =>
       Object.hash(runtimeType, profile, securityModeFeatureEnabled);
 
-  /// Create a copy of ProfileEditState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$LoadedImplCopyWith<_$LoadedImpl> get copyWith =>
@@ -364,10 +354,7 @@ abstract class _Loaded implements ProfileEditState {
 
   UserProfileEntity get profile;
   bool get securityModeFeatureEnabled;
-
-  /// Create a copy of ProfileEditState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$LoadedImplCopyWith<_$LoadedImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -389,8 +376,6 @@ class __$$ErrorDetailsImplCopyWithImpl<$Res>
       _$ErrorDetailsImpl _value, $Res Function(_$ErrorDetailsImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of ProfileEditState
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -429,9 +414,7 @@ class _$ErrorDetailsImpl implements _ErrorDetails {
   @override
   int get hashCode => Object.hash(runtimeType, message);
 
-  /// Create a copy of ProfileEditState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ErrorDetailsImplCopyWith<_$ErrorDetailsImpl> get copyWith =>
@@ -516,10 +499,7 @@ abstract class _ErrorDetails implements ProfileEditState {
   const factory _ErrorDetails(final String message) = _$ErrorDetailsImpl;
 
   String get message;
-
-  /// Create a copy of ProfileEditState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ErrorDetailsImplCopyWith<_$ErrorDetailsImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/app/features/main_menu/presentation/account/pages/card_profile_header_edit_page.dart
+++ b/lib/app/features/main_menu/presentation/account/pages/card_profile_header_edit_page.dart
@@ -23,6 +23,7 @@ class CardProfileHeaderEditPage extends StatelessWidget {
           Container()
         else
           IconButton(
+            tooltip: 'Editar $title',
             icon: SvgPicture.asset(
               'assets/images/svg/profile/edit.svg',
               colorFilter: const ColorFilter.mode(

--- a/lib/app/features/mainboard/domain/states/mainboard_security_state.freezed.dart
+++ b/lib/app/features/mainboard/domain/states/mainboard_security_state.freezed.dart
@@ -73,9 +73,6 @@ class _$MainboardSecurityStateCopyWithImpl<$Res,
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
-
-  /// Create a copy of MainboardSecurityState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -92,9 +89,6 @@ class __$$EnableImplCopyWithImpl<$Res>
   __$$EnableImplCopyWithImpl(
       _$EnableImpl _value, $Res Function(_$EnableImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of MainboardSecurityState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -197,9 +191,6 @@ class __$$DisableImplCopyWithImpl<$Res>
   __$$DisableImplCopyWithImpl(
       _$DisableImpl _value, $Res Function(_$DisableImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of MainboardSecurityState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc

--- a/lib/app/features/mainboard/domain/states/mainboard_state.freezed.dart
+++ b/lib/app/features/mainboard/domain/states/mainboard_state.freezed.dart
@@ -96,9 +96,6 @@ class _$MainboardStateCopyWithImpl<$Res, $Val extends MainboardState>
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
-
-  /// Create a copy of MainboardState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -114,9 +111,6 @@ class __$$ChatImplCopyWithImpl<$Res>
     implements _$$ChatImplCopyWith<$Res> {
   __$$ChatImplCopyWithImpl(_$ChatImpl _value, $Res Function(_$ChatImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of MainboardState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -242,9 +236,6 @@ class __$$FeedImplCopyWithImpl<$Res>
     implements _$$FeedImplCopyWith<$Res> {
   __$$FeedImplCopyWithImpl(_$FeedImpl _value, $Res Function(_$FeedImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of MainboardState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -371,9 +362,6 @@ class __$$EscapeManualImplCopyWithImpl<$Res>
   __$$EscapeManualImplCopyWithImpl(
       _$EscapeManualImpl _value, $Res Function(_$EscapeManualImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of MainboardState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -500,9 +488,6 @@ class __$$ComposeImplCopyWithImpl<$Res>
   __$$ComposeImplCopyWithImpl(
       _$ComposeImpl _value, $Res Function(_$ComposeImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of MainboardState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -629,9 +614,6 @@ class __$$SupportPointImplCopyWithImpl<$Res>
   __$$SupportPointImplCopyWithImpl(
       _$SupportPointImpl _value, $Res Function(_$SupportPointImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of MainboardState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -758,9 +740,6 @@ class __$$HelpCenterImplCopyWithImpl<$Res>
   __$$HelpCenterImplCopyWithImpl(
       _$HelpCenterImpl _value, $Res Function(_$HelpCenterImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of MainboardState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc

--- a/lib/app/features/mainboard/presentation/mainboard/mainboard_module.dart
+++ b/lib/app/features/mainboard/presentation/mainboard/mainboard_module.dart
@@ -585,6 +585,7 @@ class MainboardModule extends Module {
           (i) => AudiosController(
             audiosRepository: i.get<IAudiosRepository>(),
             audioPlayServices: i.get<IAudioPlayServices>(),
+            audioSyncManager: i.get<IAudioSyncManager>(),
           ),
         ),
         Bind.factory(

--- a/lib/app/features/notification/domain/states/notification_state.freezed.dart
+++ b/lib/app/features/notification/domain/states/notification_state.freezed.dart
@@ -84,9 +84,6 @@ class _$NotificationStateCopyWithImpl<$Res, $Val extends NotificationState>
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
-
-  /// Create a copy of NotificationState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -103,9 +100,6 @@ class __$$InitialImplCopyWithImpl<$Res>
   __$$InitialImplCopyWithImpl(
       _$InitialImpl _value, $Res Function(_$InitialImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of NotificationState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -223,8 +217,6 @@ class __$$LoadedImplCopyWithImpl<$Res>
       _$LoadedImpl _value, $Res Function(_$LoadedImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of NotificationState
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -271,9 +263,7 @@ class _$LoadedImpl implements _Loaded {
   int get hashCode => Object.hash(
       runtimeType, const DeepCollectionEquality().hash(_notifications));
 
-  /// Create a copy of NotificationState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$LoadedImplCopyWith<_$LoadedImpl> get copyWith =>
@@ -359,10 +349,7 @@ abstract class _Loaded implements NotificationState {
       _$LoadedImpl;
 
   List<NotificationEntity> get notifications;
-
-  /// Create a copy of NotificationState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$LoadedImplCopyWith<_$LoadedImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -381,9 +368,6 @@ class __$$EmptyImplCopyWithImpl<$Res>
   __$$EmptyImplCopyWithImpl(
       _$EmptyImpl _value, $Res Function(_$EmptyImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of NotificationState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -501,8 +485,6 @@ class __$$ErrorDetailsImplCopyWithImpl<$Res>
       _$ErrorDetailsImpl _value, $Res Function(_$ErrorDetailsImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of NotificationState
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -541,9 +523,7 @@ class _$ErrorDetailsImpl implements _ErrorDetails {
   @override
   int get hashCode => Object.hash(runtimeType, message);
 
-  /// Create a copy of NotificationState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ErrorDetailsImplCopyWith<_$ErrorDetailsImpl> get copyWith =>
@@ -628,10 +608,7 @@ abstract class _ErrorDetails implements NotificationState {
   const factory _ErrorDetails(final String message) = _$ErrorDetailsImpl;
 
   String get message;
-
-  /// Create a copy of NotificationState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ErrorDetailsImplCopyWith<_$ErrorDetailsImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/app/features/quiz/domain/entities/quiz_message.freezed.dart
+++ b/lib/app/features/quiz/domain/entities/quiz_message.freezed.dart
@@ -90,9 +90,7 @@ mixin _$QuizMessage {
   }) =>
       throw _privateConstructorUsedError;
 
-  /// Create a copy of QuizMessage
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $QuizMessageCopyWith<QuizMessage> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -116,8 +114,6 @@ class _$QuizMessageCopyWithImpl<$Res, $Val extends QuizMessage>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of QuizMessage
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -151,8 +147,6 @@ class __$$TextMessageImplCopyWithImpl<$Res>
       _$TextMessageImpl _value, $Res Function(_$TextMessageImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of QuizMessage
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -202,9 +196,7 @@ class _$TextMessageImpl extends _TextMessage {
   @override
   int get hashCode => Object.hash(runtimeType, reference, content);
 
-  /// Create a copy of QuizMessage
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$TextMessageImplCopyWith<_$TextMessageImpl> get copyWith =>
@@ -316,11 +308,8 @@ abstract class _TextMessage extends QuizMessage {
   @override
   String get reference;
   String get content;
-
-  /// Create a copy of QuizMessage
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$TextMessageImplCopyWith<_$TextMessageImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -348,8 +337,6 @@ class __$$SentMessageImplCopyWithImpl<$Res>
       _$SentMessageImpl _value, $Res Function(_$SentMessageImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of QuizMessage
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -421,9 +408,7 @@ class _$SentMessageImpl extends _SentMessage {
   int get hashCode =>
       Object.hash(runtimeType, reference, content, answer, status);
 
-  /// Create a copy of QuizMessage
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$SentMessageImplCopyWith<_$SentMessageImpl> get copyWith =>
@@ -539,11 +524,8 @@ abstract class _SentMessage extends QuizMessage {
   String get content;
   UserAnswer? get answer;
   AnswerStatus get status;
-
-  /// Create a copy of QuizMessage
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$SentMessageImplCopyWith<_$SentMessageImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -569,8 +551,6 @@ class __$$HorizontalButtonsMessageImplCopyWithImpl<$Res>
       $Res Function(_$HorizontalButtonsMessageImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of QuizMessage
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -627,9 +607,7 @@ class _$HorizontalButtonsMessageImpl extends _HorizontalButtonsMessage {
   int get hashCode => Object.hash(
       runtimeType, reference, const DeepCollectionEquality().hash(_buttons));
 
-  /// Create a copy of QuizMessage
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$HorizontalButtonsMessageImplCopyWith<_$HorizontalButtonsMessageImpl>
@@ -743,11 +721,8 @@ abstract class _HorizontalButtonsMessage extends QuizMessage {
   @override
   String get reference;
   List<ButtonOption> get buttons;
-
-  /// Create a copy of QuizMessage
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$HorizontalButtonsMessageImplCopyWith<_$HorizontalButtonsMessageImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -771,8 +746,6 @@ class __$$SingleChoiceMessageImplCopyWithImpl<$Res>
       $Res Function(_$SingleChoiceMessageImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of QuizMessage
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -829,9 +802,7 @@ class _$SingleChoiceMessageImpl extends _SingleChoiceMessage {
   int get hashCode => Object.hash(
       runtimeType, reference, const DeepCollectionEquality().hash(_options));
 
-  /// Create a copy of QuizMessage
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$SingleChoiceMessageImplCopyWith<_$SingleChoiceMessageImpl> get copyWith =>
@@ -944,11 +915,8 @@ abstract class _SingleChoiceMessage extends QuizMessage {
   @override
   String get reference;
   List<MessageOption> get options;
-
-  /// Create a copy of QuizMessage
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$SingleChoiceMessageImplCopyWith<_$SingleChoiceMessageImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -973,8 +941,6 @@ class __$$MultipleChoiceMessageImplCopyWithImpl<$Res>
       $Res Function(_$MultipleChoiceMessageImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of QuizMessage
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1031,9 +997,7 @@ class _$MultipleChoiceMessageImpl extends _MultipleChoiceMessage {
   int get hashCode => Object.hash(
       runtimeType, reference, const DeepCollectionEquality().hash(_options));
 
-  /// Create a copy of QuizMessage
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$MultipleChoiceMessageImplCopyWith<_$MultipleChoiceMessageImpl>
@@ -1147,11 +1111,8 @@ abstract class _MultipleChoiceMessage extends QuizMessage {
   @override
   String get reference;
   List<MessageOption> get options;
-
-  /// Create a copy of QuizMessage
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$MultipleChoiceMessageImplCopyWith<_$MultipleChoiceMessageImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -1200,9 +1161,7 @@ mixin _$MessageOption {
   }) =>
       throw _privateConstructorUsedError;
 
-  /// Create a copy of MessageOption
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $MessageOptionCopyWith<MessageOption> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1226,8 +1185,6 @@ class _$MessageOptionCopyWithImpl<$Res, $Val extends MessageOption>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of MessageOption
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1266,8 +1223,6 @@ class __$$MessageOptionImplCopyWithImpl<$Res>
       _$MessageOptionImpl _value, $Res Function(_$MessageOptionImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of MessageOption
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1315,9 +1270,7 @@ class _$MessageOptionImpl extends _MessageOption {
   @override
   int get hashCode => Object.hash(runtimeType, label, value);
 
-  /// Create a copy of MessageOption
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$MessageOptionImplCopyWith<_$MessageOptionImpl> get copyWith =>
@@ -1397,11 +1350,8 @@ abstract class _MessageOption extends MessageOption {
   String get label;
   @override
   String get value;
-
-  /// Create a copy of MessageOption
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$MessageOptionImplCopyWith<_$MessageOptionImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1427,8 +1377,6 @@ class __$$ButtonOptionImplCopyWithImpl<$Res>
       _$ButtonOptionImpl _value, $Res Function(_$ButtonOptionImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of MessageOption
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1452,8 +1400,6 @@ class __$$ButtonOptionImplCopyWithImpl<$Res>
     ));
   }
 
-  /// Create a copy of MessageOption
-  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $ButtonActionCopyWith<$Res>? get action {
@@ -1499,9 +1445,7 @@ class _$ButtonOptionImpl extends ButtonOption {
   @override
   int get hashCode => Object.hash(runtimeType, label, value, action);
 
-  /// Create a copy of MessageOption
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ButtonOptionImplCopyWith<_$ButtonOptionImpl> get copyWith =>
@@ -1583,11 +1527,8 @@ abstract class ButtonOption extends MessageOption {
   @override
   String get value;
   ButtonAction? get action;
-
-  /// Create a copy of MessageOption
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ButtonOptionImplCopyWith<_$ButtonOptionImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1629,9 +1570,7 @@ mixin _$ButtonAction {
   }) =>
       throw _privateConstructorUsedError;
 
-  /// Create a copy of ButtonAction
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   $ButtonActionCopyWith<ButtonAction> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1655,8 +1594,6 @@ class _$ButtonActionCopyWithImpl<$Res, $Val extends ButtonAction>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
-  /// Create a copy of ButtonAction
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1695,8 +1632,6 @@ class __$$NavigateActionImplCopyWithImpl<$Res>
       _$NavigateActionImpl _value, $Res Function(_$NavigateActionImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of ButtonAction
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1746,9 +1681,7 @@ class _$NavigateActionImpl extends _NavigateAction {
   @override
   int get hashCode => Object.hash(runtimeType, route, readableResult);
 
-  /// Create a copy of ButtonAction
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$NavigateActionImplCopyWith<_$NavigateActionImpl> get copyWith =>
@@ -1822,11 +1755,8 @@ abstract class _NavigateAction extends ButtonAction {
   String get route;
   @override
   String get readableResult;
-
-  /// Create a copy of ButtonAction
-  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$NavigateActionImplCopyWith<_$NavigateActionImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/app/features/quiz/presentation/quiz_start/quiz_start_state.freezed.dart
+++ b/lib/app/features/quiz/presentation/quiz_start/quiz_start_state.freezed.dart
@@ -72,9 +72,6 @@ class _$QuizStartStateCopyWithImpl<$Res, $Val extends QuizStartState>
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
-
-  /// Create a copy of QuizStartState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -91,9 +88,6 @@ class __$$InitialStateImplCopyWithImpl<$Res>
   __$$InitialStateImplCopyWithImpl(
       _$InitialStateImpl _value, $Res Function(_$InitialStateImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of QuizStartState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -199,8 +193,6 @@ class __$$ErrorStateImplCopyWithImpl<$Res>
       _$ErrorStateImpl _value, $Res Function(_$ErrorStateImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of QuizStartState
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -239,9 +231,7 @@ class _$ErrorStateImpl implements _ErrorState {
   @override
   int get hashCode => Object.hash(runtimeType, message);
 
-  /// Create a copy of QuizStartState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ErrorStateImplCopyWith<_$ErrorStateImpl> get copyWith =>
@@ -314,10 +304,7 @@ abstract class _ErrorState implements QuizStartState {
   const factory _ErrorState(final String message) = _$ErrorStateImpl;
 
   String get message;
-
-  /// Create a copy of QuizStartState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ErrorStateImplCopyWith<_$ErrorStateImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/app/features/support_center/domain/states/support_center_add_state.freezed.dart
+++ b/lib/app/features/support_center/domain/states/support_center_add_state.freezed.dart
@@ -79,9 +79,6 @@ class _$SupportCenterAddStateCopyWithImpl<$Res,
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
-
-  /// Create a copy of SupportCenterAddState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -98,9 +95,6 @@ class __$$InitialImplCopyWithImpl<$Res>
   __$$InitialImplCopyWithImpl(
       _$InitialImpl _value, $Res Function(_$InitialImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of SupportCenterAddState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -209,9 +203,6 @@ class __$$LoadedImplCopyWithImpl<$Res>
   __$$LoadedImplCopyWithImpl(
       _$LoadedImpl _value, $Res Function(_$LoadedImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of SupportCenterAddState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -323,8 +314,6 @@ class __$$ErrorDetailsImplCopyWithImpl<$Res>
       _$ErrorDetailsImpl _value, $Res Function(_$ErrorDetailsImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of SupportCenterAddState
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -363,9 +352,7 @@ class _$ErrorDetailsImpl implements _ErrorDetails {
   @override
   int get hashCode => Object.hash(runtimeType, message);
 
-  /// Create a copy of SupportCenterAddState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ErrorDetailsImplCopyWith<_$ErrorDetailsImpl> get copyWith =>
@@ -444,10 +431,7 @@ abstract class _ErrorDetails implements SupportCenterAddState {
   const factory _ErrorDetails(final String message) = _$ErrorDetailsImpl;
 
   String get message;
-
-  /// Create a copy of SupportCenterAddState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ErrorDetailsImplCopyWith<_$ErrorDetailsImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/app/features/support_center/domain/states/support_center_show_state.freezed.dart
+++ b/lib/app/features/support_center/domain/states/support_center_show_state.freezed.dart
@@ -79,9 +79,6 @@ class _$SupportCenterShowStateCopyWithImpl<$Res,
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
-
-  /// Create a copy of SupportCenterShowState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -98,9 +95,6 @@ class __$$InitialImplCopyWithImpl<$Res>
   __$$InitialImplCopyWithImpl(
       _$InitialImpl _value, $Res Function(_$InitialImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of SupportCenterShowState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -212,8 +206,6 @@ class __$$LoadedImplCopyWithImpl<$Res>
       _$LoadedImpl _value, $Res Function(_$LoadedImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of SupportCenterShowState
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -252,9 +244,7 @@ class _$LoadedImpl implements _Loaded {
   @override
   int get hashCode => Object.hash(runtimeType, detail);
 
-  /// Create a copy of SupportCenterShowState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$LoadedImplCopyWith<_$LoadedImpl> get copyWith =>
@@ -334,10 +324,7 @@ abstract class _Loaded implements SupportCenterShowState {
       _$LoadedImpl;
 
   SupportCenterPlaceDetailEntity get detail;
-
-  /// Create a copy of SupportCenterShowState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$LoadedImplCopyWith<_$LoadedImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -359,8 +346,6 @@ class __$$ErrorDetailsImplCopyWithImpl<$Res>
       _$ErrorDetailsImpl _value, $Res Function(_$ErrorDetailsImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of SupportCenterShowState
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -399,9 +384,7 @@ class _$ErrorDetailsImpl implements _ErrorDetails {
   @override
   int get hashCode => Object.hash(runtimeType, message);
 
-  /// Create a copy of SupportCenterShowState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ErrorDetailsImplCopyWith<_$ErrorDetailsImpl> get copyWith =>
@@ -480,10 +463,7 @@ abstract class _ErrorDetails implements SupportCenterShowState {
   const factory _ErrorDetails(final String message) = _$ErrorDetailsImpl;
 
   String get message;
-
-  /// Create a copy of SupportCenterShowState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ErrorDetailsImplCopyWith<_$ErrorDetailsImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/app/features/support_center/domain/states/support_center_state.freezed.dart
+++ b/lib/app/features/support_center/domain/states/support_center_state.freezed.dart
@@ -78,9 +78,6 @@ class _$SupportCenterStateCopyWithImpl<$Res, $Val extends SupportCenterState>
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
-
-  /// Create a copy of SupportCenterState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -97,9 +94,6 @@ class __$$LoadedImplCopyWithImpl<$Res>
   __$$LoadedImplCopyWithImpl(
       _$LoadedImpl _value, $Res Function(_$LoadedImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of SupportCenterState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -211,8 +205,6 @@ class __$$ErrorDetailsImplCopyWithImpl<$Res>
       _$ErrorDetailsImpl _value, $Res Function(_$ErrorDetailsImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of SupportCenterState
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -251,9 +243,7 @@ class _$ErrorDetailsImpl implements _ErrorDetails {
   @override
   int get hashCode => Object.hash(runtimeType, message);
 
-  /// Create a copy of SupportCenterState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ErrorDetailsImplCopyWith<_$ErrorDetailsImpl> get copyWith =>
@@ -332,10 +322,7 @@ abstract class _ErrorDetails implements SupportCenterState {
   const factory _ErrorDetails(final String message) = _$ErrorDetailsImpl;
 
   String get message;
-
-  /// Create a copy of SupportCenterState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ErrorDetailsImplCopyWith<_$ErrorDetailsImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -357,8 +344,6 @@ class __$$GpsErrorImplCopyWithImpl<$Res>
       _$GpsErrorImpl _value, $Res Function(_$GpsErrorImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of SupportCenterState
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -397,9 +382,7 @@ class _$GpsErrorImpl implements _GpsError {
   @override
   int get hashCode => Object.hash(runtimeType, message);
 
-  /// Create a copy of SupportCenterState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$GpsErrorImplCopyWith<_$GpsErrorImpl> get copyWith =>
@@ -478,10 +461,7 @@ abstract class _GpsError implements SupportCenterState {
   const factory _GpsError(final String message) = _$GpsErrorImpl;
 
   String get message;
-
-  /// Create a copy of SupportCenterState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$GpsErrorImplCopyWith<_$GpsErrorImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/app/features/support_center/presentation/support_center_page.dart
+++ b/lib/app/features/support_center/presentation/support_center_page.dart
@@ -154,48 +154,60 @@ extension _SupportCenterPageStateBuilder on _SupportCenterPageState {
             right: 0,
             child: Column(
               children: [
-                TextButton(
-                  onPressed: () {
-                    controller.requestLocation((LatLng location) {
-                      mapController!.animateCamera(
-                        CameraUpdate.newCameraPosition(
-                          CameraPosition(
-                            tilt: 75.0,
-                            zoom: 12.0,
-                            bearing: 15.0,
-                            target: location,
+                Semantics(
+                  button: true,
+                  label: 'Minha localização',
+                  child: TextButton(
+                    onPressed: () {
+                      controller.requestLocation((LatLng location) {
+                        mapController!.animateCamera(
+                          CameraUpdate.newCameraPosition(
+                            CameraPosition(
+                              tilt: 75.0,
+                              zoom: 12.0,
+                              bearing: 15.0,
+                              target: location,
+                            ),
                           ),
-                        ),
-                      );
-                    });
-                  },
-                  child: CircleAvatar(
-                    radius: 12,
-                    backgroundColor: DesignSystemColors.pumpkinOrange,
-                    child: SvgPicture.asset(
-                      'assets/images/svg/support_center/location.svg',
+                        );
+                      });
+                    },
+                    child: CircleAvatar(
+                      radius: 12,
+                      backgroundColor: DesignSystemColors.pumpkinOrange,
+                      child: SvgPicture.asset(
+                        'assets/images/svg/support_center/location.svg',
+                      ),
                     ),
                   ),
                 ),
-                TextButton(
-                  onPressed: () =>
-                      _dismissSnackBarForAction(controller.listPlaces),
-                  child: CircleAvatar(
-                    radius: 12,
-                    backgroundColor: DesignSystemColors.pumpkinOrange,
-                    child: SvgPicture.asset(
-                      'assets/images/svg/support_center/list.svg',
+                Semantics(
+                  button: true,
+                  label: 'Lista de pontos de apoio',
+                  child: TextButton(
+                    onPressed: () =>
+                        _dismissSnackBarForAction(controller.listPlaces),
+                    child: CircleAvatar(
+                      radius: 12,
+                      backgroundColor: DesignSystemColors.pumpkinOrange,
+                      child: SvgPicture.asset(
+                        'assets/images/svg/support_center/list.svg',
+                      ),
                     ),
                   ),
                 ),
-                TextButton(
-                  onPressed: () =>
-                      _dismissSnackBarForAction(controller.addPlace),
-                  child: CircleAvatar(
-                    radius: 20,
-                    backgroundColor: DesignSystemColors.pumpkinOrange,
-                    child: SvgPicture.asset(
-                      'assets/images/svg/support_center/suggest_place.svg',
+                Semantics(
+                  button: true,
+                  label: 'Sugerir ponto de apoio',
+                  child: TextButton(
+                    onPressed: () =>
+                        _dismissSnackBarForAction(controller.addPlace),
+                    child: CircleAvatar(
+                      radius: 20,
+                      backgroundColor: DesignSystemColors.pumpkinOrange,
+                      child: SvgPicture.asset(
+                        'assets/images/svg/support_center/suggest_place.svg',
+                      ),
                     ),
                   ),
                 ),

--- a/lib/app/features/users/presentation/user_profile_state.freezed.dart
+++ b/lib/app/features/users/presentation/user_profile_state.freezed.dart
@@ -78,9 +78,6 @@ class _$UserProfileStateCopyWithImpl<$Res, $Val extends UserProfileState>
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
-
-  /// Create a copy of UserProfileState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -97,9 +94,6 @@ class __$$InitialImplCopyWithImpl<$Res>
   __$$InitialImplCopyWithImpl(
       _$InitialImpl _value, $Res Function(_$InitialImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of UserProfileState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -211,8 +205,6 @@ class __$$LoadedImplCopyWithImpl<$Res>
       _$LoadedImpl _value, $Res Function(_$LoadedImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of UserProfileState
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -251,9 +243,7 @@ class _$LoadedImpl implements _Loaded {
   @override
   int get hashCode => Object.hash(runtimeType, person);
 
-  /// Create a copy of UserProfileState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$LoadedImplCopyWith<_$LoadedImpl> get copyWith =>
@@ -332,10 +322,7 @@ abstract class _Loaded implements UserProfileState {
   const factory _Loaded(final UserDetailEntity person) = _$LoadedImpl;
 
   UserDetailEntity get person;
-
-  /// Create a copy of UserProfileState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$LoadedImplCopyWith<_$LoadedImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -357,8 +344,6 @@ class __$$ErrorDetailsImplCopyWithImpl<$Res>
       _$ErrorDetailsImpl _value, $Res Function(_$ErrorDetailsImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of UserProfileState
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -397,9 +382,7 @@ class _$ErrorDetailsImpl implements _ErrorDetails {
   @override
   int get hashCode => Object.hash(runtimeType, message);
 
-  /// Create a copy of UserProfileState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ErrorDetailsImplCopyWith<_$ErrorDetailsImpl> get copyWith =>
@@ -478,10 +461,7 @@ abstract class _ErrorDetails implements UserProfileState {
   const factory _ErrorDetails(final String message) = _$ErrorDetailsImpl;
 
   String get message;
-
-  /// Create a copy of UserProfileState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ErrorDetailsImplCopyWith<_$ErrorDetailsImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -544,9 +524,6 @@ class _$UserMenuStateCopyWithImpl<$Res, $Val extends UserMenuState>
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
-
-  /// Create a copy of UserMenuState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -563,9 +540,6 @@ class __$$MenuStateHiddenImplCopyWithImpl<$Res>
   __$$MenuStateHiddenImplCopyWithImpl(
       _$MenuStateHiddenImpl _value, $Res Function(_$MenuStateHiddenImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of UserMenuState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -668,9 +642,6 @@ class __$$MenuStateVisibleImplCopyWithImpl<$Res>
   __$$MenuStateVisibleImplCopyWithImpl(_$MenuStateVisibleImpl _value,
       $Res Function(_$MenuStateVisibleImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of UserMenuState
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -853,9 +824,6 @@ class _$UserProfileReactionCopyWithImpl<$Res, $Val extends UserProfileReaction>
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
-
-  /// Create a copy of UserProfileReaction
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -875,8 +843,6 @@ class __$$ReactionShowSnackBarImplCopyWithImpl<$Res>
       $Res Function(_$ReactionShowSnackBarImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of UserProfileReaction
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -925,9 +891,7 @@ class _$ReactionShowSnackBarImpl implements _ReactionShowSnackBar {
   @override
   int get hashCode => Object.hash(runtimeType, message, inMainboardPage);
 
-  /// Create a copy of UserProfileReaction
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ReactionShowSnackBarImplCopyWith<_$ReactionShowSnackBarImpl>
@@ -1040,10 +1004,7 @@ abstract class _ReactionShowSnackBar implements UserProfileReaction {
 
   String get message;
   bool get inMainboardPage;
-
-  /// Create a copy of UserProfileReaction
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ReactionShowSnackBarImplCopyWith<_$ReactionShowSnackBarImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -1065,9 +1026,6 @@ class __$$ReactionShowProfileOptionsImplCopyWithImpl<$Res>
       _$ReactionShowProfileOptionsImpl _value,
       $Res Function(_$ReactionShowProfileOptionsImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of UserProfileReaction
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -1213,8 +1171,6 @@ class __$$ReactionAskReportReasonDialogImplCopyWithImpl<$Res>
       $Res Function(_$ReactionAskReportReasonDialogImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of UserProfileReaction
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1255,9 +1211,7 @@ class _$ReactionAskReportReasonDialogImpl
   @override
   int get hashCode => Object.hash(runtimeType, reason);
 
-  /// Create a copy of UserProfileReaction
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ReactionAskReportReasonDialogImplCopyWith<
@@ -1369,10 +1323,7 @@ abstract class _ReactionAskReportReasonDialog implements UserProfileReaction {
       _$ReactionAskReportReasonDialogImpl;
 
   String? get reason;
-
-  /// Create a copy of UserProfileReaction
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ReactionAskReportReasonDialogImplCopyWith<
           _$ReactionAskReportReasonDialogImpl>
       get copyWith => throw _privateConstructorUsedError;
@@ -1398,8 +1349,6 @@ class __$$ReactionShowBlockConfirmationDialogImplCopyWithImpl<$Res>
       $Res Function(_$ReactionShowBlockConfirmationDialogImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of UserProfileReaction
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1439,9 +1388,7 @@ class _$ReactionShowBlockConfirmationDialogImpl
   @override
   int get hashCode => Object.hash(runtimeType, message);
 
-  /// Create a copy of UserProfileReaction
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ReactionShowBlockConfirmationDialogImplCopyWith<
@@ -1554,10 +1501,7 @@ abstract class _ReactionShowBlockConfirmationDialog
       _$ReactionShowBlockConfirmationDialogImpl;
 
   String get message;
-
-  /// Create a copy of UserProfileReaction
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ReactionShowBlockConfirmationDialogImplCopyWith<
           _$ReactionShowBlockConfirmationDialogImpl>
       get copyWith => throw _privateConstructorUsedError;
@@ -1580,9 +1524,6 @@ class __$$ReactionShowProgressDialogImplCopyWithImpl<$Res>
       _$ReactionShowProgressDialogImpl _value,
       $Res Function(_$ReactionShowProgressDialogImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of UserProfileReaction
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -1725,9 +1666,6 @@ class __$$ReactionDismissProgressDialogImplCopyWithImpl<$Res>
       _$ReactionDismissProgressDialogImpl _value,
       $Res Function(_$ReactionDismissProgressDialogImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of UserProfileReaction
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -1914,9 +1852,6 @@ class _$UserProfileSelectedOptionCopyWithImpl<$Res,
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
-
-  /// Create a copy of UserProfileSelectedOption
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -1934,9 +1869,6 @@ class __$$SelectedOptionReportImplCopyWithImpl<$Res>
   __$$SelectedOptionReportImplCopyWithImpl(_$SelectedOptionReportImpl _value,
       $Res Function(_$SelectedOptionReportImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of UserProfileSelectedOption
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -2041,9 +1973,6 @@ class __$$SelectedOptionBlockImplCopyWithImpl<$Res>
   __$$SelectedOptionBlockImplCopyWithImpl(_$SelectedOptionBlockImpl _value,
       $Res Function(_$SelectedOptionBlockImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of UserProfileSelectedOption
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:developer';
 
+import 'package:background_downloader/background_downloader.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
@@ -17,8 +18,14 @@ void main() {
 
     await Bootstrap.instance.withRunner(
       MainAppRunner(),
-      onBeforeRun: () {
+      onBeforeRun: () async {
         BackgroundTaskManager.instance.registerDispatcher(callbackDispatcher);
+
+        await FileDownloader().configure(
+          globalConfig: {Config.requestTimeout: const Duration(minutes: 2)},
+        );
+        await FileDownloader().start();
+        await FileDownloader().rescheduleKilledTasks();
       },
     );
   }, (error, stack) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,17 +21,31 @@ void main() {
       onBeforeRun: () async {
         BackgroundTaskManager.instance.registerDispatcher(callbackDispatcher);
 
-        await FileDownloader().configure(
-          globalConfig: {Config.requestTimeout: const Duration(minutes: 2)},
-        );
-        await FileDownloader().start();
-        await FileDownloader().rescheduleKilledTasks();
+        // Configure + resume background uploads WITHOUT blocking app launch.
+        // Awaiting these here gated runApp() behind the platform handshake and
+        // could hang the splash indefinitely (the swallowed error in
+        // Bootstrap.withRunner meant run() never executed). Fire-and-forget,
+        // self-guarded, so a slow/failed downloader init never bricks boot.
+        unawaited(_initBackgroundUploads());
       },
     );
   }, (error, stack) {
     // Tratamento global de erro
     log('Error not disclosed $error');
   });
+}
+
+/// Initializes the background uploader off the boot-critical path.
+Future<void> _initBackgroundUploads() async {
+  try {
+    await FileDownloader().configure(
+      globalConfig: {Config.requestTimeout: const Duration(minutes: 2)},
+    );
+    await FileDownloader().start();
+    await FileDownloader().rescheduleKilledTasks();
+  } catch (error, stack) {
+    log('FileDownloader init failed: $error', stackTrace: stack);
+  }
 }
 
 @pragma('vm:entry-point')

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "16e298750b6d0af7ce8a3ba7c18c69c3785d11b15ec83f6dcd0ad2a0009b3cab"
+      sha256: "0b2f2bd91ba804e53a61d757b986f89f1f9eaed5b11e4b2f5a2468d86d6c9fc7"
       url: "https://pub.dev"
     source: hosted
-    version: "76.0.0"
+    version: "67.0.0"
   _flutterfire_internals:
     dependency: transitive
     description:
@@ -17,11 +17,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.53"
-  _macros:
-    dependency: transitive
-    description: dart
-    source: sdk
-    version: "0.3.3"
   alchemist:
     dependency: "direct dev"
     description:
@@ -34,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "1f14db053a8c23e260789e9b0980fa27f2680dd640932cae5e1137cce0e46e1e"
+      sha256: "37577842a27e4338429a1cbc32679d508836510b056f1eedf0c8d20e39c1383d"
       url: "https://pub.dev"
     source: hosted
-    version: "6.11.0"
+    version: "6.4.1"
   ansi_styles:
     dependency: transitive
     description:
@@ -78,6 +73,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.1.25"
+  background_downloader:
+    dependency: "direct main"
+    description:
+      name: background_downloader
+      sha256: aceacec2b2a72ec3a8862ab5895fcbbc71ab33765f3619d57963f3110dd268e3
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.5.5"
   badges:
     dependency: "direct main"
     description:
@@ -98,10 +101,10 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: cef23f1eda9b57566c81e2133d196f8e3df48f244b317368d65c5943d91148f0
+      sha256: "80184af8b6cb3e5c1c4ec6d8544d27711700bc3e6d2efad04238c7b5290889f0"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.1"
   build_config:
     dependency: transitive
     description:
@@ -122,26 +125,26 @@ packages:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: b9e4fda21d846e192628e7a4f6deda6888c36b5b69ba02ff291a01fd529140f0
+      sha256: "339086358431fa15d7eca8b6a36e5d783728cf025e559b834f4609a1fcfb7b0a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.4"
+    version: "2.4.2"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "058fe9dce1de7d69c4b84fada934df3e0153dd000758c4d65964d0166779aa99"
+      sha256: "028819cfb90051c6b5440c7e574d1896f8037e3c96cf17aaeb054c9311cfbf4d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.15"
+    version: "2.4.13"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: "22e3aa1c80e0ada3722fe5b63fd43d9c8990759d0a2cf489c8c5d7b2bdebc021"
+      sha256: f8126682b87a7282a339b871298cc12009cb67109cfa1614d6436fb0289193e0
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.0"
+    version: "7.3.2"
   built_collection:
     dependency: transitive
     description:
@@ -298,10 +301,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "7306ab8a2359a48d22310ad823521d723acfed60ee1f7e37388e8986853b6820"
+      sha256: "99e066ce75c89d6b29903d788a7bb9369cf754f7b24bf70bf4b6d6d6b26853b9"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.8"
+    version: "2.3.6"
   dartz:
     dependency: "direct main"
     description:
@@ -694,10 +697,10 @@ packages:
     dependency: "direct dev"
     description:
       name: freezed
-      sha256: "44c19278dd9d89292cf46e97dc0c1e52ce03275f40a97c5a348e802a924bf40e"
+      sha256: a434911f643466d78462625df76fd9eb13e57348ff43fe1f77bbe909522c67a1
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.7"
+    version: "2.5.2"
   freezed_annotation:
     dependency: "direct main"
     description:
@@ -958,10 +961,10 @@ packages:
     dependency: "direct dev"
     description:
       name: json_serializable
-      sha256: c2fcb3920cf2b6ae6845954186420fca40bc0a8abcc84903b7801f17d7050d7c
+      sha256: ea1432d167339ea9b5bb153f0571d0039607a873d6e04e0117af043f14a1fd4b
       url: "https://pub.dev"
     source: hosted
-    version: "6.9.0"
+    version: "6.8.0"
   just_audio:
     dependency: transitive
     description:
@@ -1050,14 +1053,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
-  macros:
-    dependency: transitive
-    description:
-      name: macros
-      sha256: "1d9e801cd66f7ea3663c45fc708450db1fa57f988142c64289142c9b7ee80656"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.3-main.0"
   map_launcher:
     dependency: "direct main"
     description:
@@ -1486,10 +1481,10 @@ packages:
     dependency: transitive
     description:
       name: shelf_web_socket
-      sha256: "3632775c8e90d6c9712f883e633716432a27758216dfb61bd86a8321c0580925"
+      sha256: cc36c297b52866d203dbf9332263c94becc2fe0ceaa9681d07b6ef9807023b67
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "2.0.1"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -74,6 +74,7 @@ dependencies:
   timeago: ^3.1.0
   url_launcher: ^6.1.7
   uuid: ^4.3.3
+  background_downloader: ^9.5.5
   flutter_background_service: ^5.1.0
   platform: ^3.1.6
   flutter_html: ^3.0.0

--- a/test/app/core/managers/audio_sync_manager_test.dart
+++ b/test/app/core/managers/audio_sync_manager_test.dart
@@ -1,0 +1,179 @@
+import 'dart:io';
+
+import 'package:dartz/dartz.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:penhas/app/core/entities/valid_fiel.dart';
+import 'package:penhas/app/core/error/failures.dart';
+import 'package:penhas/app/core/managers/audio_sync_manager.dart';
+import 'package:penhas/app/core/network/api_server_configure.dart';
+import 'package:penhas/app/features/help_center/data/repositories/audio_sync_repository.dart';
+import 'package:penhas/app/features/help_center/domain/entities/audio_entity.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+class MockAudioSyncRepository extends Mock implements IAudioSyncRepository {}
+
+class MockApiServerConfigure extends Mock implements IApiServerConfigure {}
+
+class AudioEntityFake extends Fake implements AudioEntity {}
+
+class FileFake extends Fake implements File {}
+
+/// path_provider stub pointing every directory at a real, disposable temp dir
+/// so the manager's file operations work without a device.
+class MockPathProviderPlatform extends PathProviderPlatform
+    with MockPlatformInterfaceMixin {
+  MockPathProviderPlatform(this.root);
+
+  final String root;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => root;
+
+  @override
+  Future<String?> getTemporaryPath() async => root;
+
+  @override
+  Future<String?> getApplicationSupportPath() async => root;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+  late MockAudioSyncRepository repository;
+  late MockApiServerConfigure serverConfiguration;
+  late AudioSyncManager sut;
+
+  // The SUT is built ONCE: its constructor subscribes to the
+  // FileDownloader() singleton's (single-subscription) updates stream, so a
+  // second instance would throw "Stream has already been listened to".
+  setUpAll(() {
+    registerFallbackValue(AudioEntityFake());
+    registerFallbackValue(FileFake());
+
+    // Silence the background_downloader platform channel so the singleton's
+    // bootstrap inside the constructor never throws MissingPluginException.
+    const channel = MethodChannel('com.bbflight.background_downloader');
+    TestWidgetsFlutterBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async => null);
+
+    tempDir = Directory.systemTemp.createTempSync('audio_sync_manager_test');
+    PathProviderPlatform.instance = MockPathProviderPlatform(tempDir.path);
+
+    repository = MockAudioSyncRepository();
+    serverConfiguration = MockApiServerConfigure();
+
+    sut = AudioSyncManager(
+      audioRepository: repository,
+      serverConfiguration: serverConfiguration,
+    );
+  });
+
+  // SUT (and therefore its repository) is shared, so wipe interactions/stubs
+  // between tests to keep verify() counts meaningful.
+  setUp(() => reset(repository));
+
+  tearDownAll(() {
+    sut.dispose();
+    if (tempDir.existsSync()) {
+      tempDir.deleteSync(recursive: true);
+    }
+  });
+
+  group('mapEpochToUTC', () {
+    test('converts a millisecond epoch to an ISO-8601 UTC string', () {
+      final epoch = DateTime.utc(2024, 1, 2, 3, 4, 5).millisecondsSinceEpoch;
+
+      final result = sut.mapEpochToUTC(epoch.toString());
+
+      expect(result, '2024-01-02T03:04:05.000Z');
+    });
+
+    test('falls back to a valid recent UTC instant for a bad epoch', () {
+      final result = sut.mapEpochToUTC('not-a-number');
+
+      // does not throw; yields a parseable UTC timestamp near "now"
+      final parsed = DateTime.parse(result);
+      expect(parsed.isUtc, isTrue);
+      expect(
+        DateTime.now().toUtc().difference(parsed).inMinutes.abs(),
+        lessThanOrEqualTo(2),
+      );
+    });
+  });
+
+  group('audioFile', () {
+    test('builds the {epoch}_{session}_{sequence}.aac filename', () async {
+      final path = await sut.audioFile(session: 'event-1', sequence: '3');
+
+      final name = p.basename(path);
+      final parts = name.split('_');
+      expect(parts, hasLength(3));
+      expect(int.tryParse(parts[0]), isNotNull); // epoch prefix
+      expect(parts[1], 'event-1');
+      expect(parts[2], '3.aac');
+      expect(Directory(p.dirname(path)).existsSync(), isTrue);
+    });
+
+    test('normalizes a suffix without a leading dot', () async {
+      final path =
+          await sut.audioFile(session: 's', sequence: '1', suffix: 'aac');
+
+      expect(p.extension(path), '.aac');
+    });
+  });
+
+  group('cache', () {
+    AudioEntity audio(String id) => AudioEntity(
+          id: id,
+          audioDuration: '1s',
+          createdAt: DateTime(2021, 1, 1),
+          canPlay: true,
+          isRequested: true,
+          isRequestGranted: true,
+        );
+
+    test('returns the cached file without downloading when it is populated',
+        () async {
+      // arrange: pre-populate the cache file beyond the empty threshold
+      final cached = File(p.join(tempDir.path, 'cached-big.cached'));
+      cached.writeAsBytesSync(List<int>.filled(200, 0));
+
+      // act
+      final result = await sut.cache(audio('cached-big'));
+
+      // assert
+      expect(result.isRight(), isTrue);
+      verifyNever(() => repository.download(any(), any()));
+    });
+
+    test('downloads when the cache file is empty', () async {
+      // arrange
+      when(() => repository.download(any(), any()))
+          .thenAnswer((_) async => right(const ValidField()));
+
+      // act
+      final result = await sut.cache(audio('cached-empty'));
+
+      // assert
+      expect(result.isRight(), isTrue);
+      verify(() => repository.download(any(), any())).called(1);
+    });
+
+    test('propagates a download failure as Left', () async {
+      // arrange
+      when(() => repository.download(any(), any()))
+          .thenAnswer((_) async => left(ServerFailure()));
+
+      // act
+      final result = await sut.cache(audio('cached-fail'));
+
+      // assert
+      expect(result.isLeft(), isTrue);
+    });
+  });
+}

--- a/test/app/features/help_center/data/repositories/audio_sync_repository_test.dart
+++ b/test/app/features/help_center/data/repositories/audio_sync_repository_test.dart
@@ -28,62 +28,8 @@ void main() {
   });
 
   group(AudioSyncRepository, () {
-    group('upload', () {
-      test(
-        'get ValidField for a valid upload',
-        () async {
-          // arrange
-          final expected = right(
-            const ValidField(message: 'Áudio recebido com sucesso!'),
-          );
-          final audio = AudioData(
-            sequence: '1',
-            createdAt: '1',
-            eventId: '15dba431-b9c9-4983-af75-9f08c3070c15',
-            media: File('test/assets/audio/silence.aac'),
-          );
-          const bodyMessage =
-              '{"message":"Áudio recebido com sucesso!","success":1,"data":{"id":1234}}';
-          when(
-            () => apiProvider.upload(
-              path: any(named: 'path'),
-              file: any(named: 'file'),
-              fields: any(named: 'fields'),
-            ),
-          ).thenAnswer((_) async => bodyMessage);
-          // act
-          final received = await sut.upload(audio);
-          // assert
-          expect(expected, received);
-        },
-      );
-      test(
-        'return Failure when get Exception',
-        () async {
-          // arrange
-          when(
-            () => apiProvider.upload(
-              path: any(named: 'path'),
-              file: any(named: 'file'),
-              fields: any(named: 'fields'),
-            ),
-          ).thenThrow(ApiProviderSessionError());
-          final audio = AudioData(
-            createdAt: '1',
-            sequence: '1',
-            eventId: '15dba431-b9c9-4983-af75-9f08c3070c15',
-            media: File('test/assets/audio/silence.aac'),
-          );
-
-          final expected = left(ServerSideSessionFailed());
-          // act
-          final received = await sut.upload(audio);
-          // assert
-          expect(expected, received);
-        },
-      );
-    });
-
+    // Upload moved to background_downloader (UploadTask in AudioSyncManager);
+    // the repository now only owns download. See audio.md.
     group('download', () {
       test(
         'get ValidField for a valid download',

--- a/test/app/features/help_center/presentation/audios/audios_controller_test.dart
+++ b/test/app/features/help_center/presentation/audios/audios_controller_test.dart
@@ -9,7 +9,6 @@ import 'package:penhas/app/features/help_center/data/models/audio_model.dart';
 import 'package:penhas/app/features/help_center/data/repositories/audios_repository.dart';
 import 'package:penhas/app/features/help_center/domain/entities/audio_entity.dart';
 import 'package:penhas/app/features/help_center/domain/entities/audio_play_tile_entity.dart';
-import 'package:penhas/app/features/help_center/domain/states/audio_playing.dart';
 import 'package:penhas/app/features/help_center/domain/states/audios_state.dart';
 import 'package:penhas/app/features/help_center/presentation/audios/audios_controller.dart';
 

--- a/test/app/features/help_center/presentation/audios/audios_controller_test.dart
+++ b/test/app/features/help_center/presentation/audios/audios_controller_test.dart
@@ -2,40 +2,53 @@ import 'package:dartz/dartz.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:penhas/app/core/entities/valid_fiel.dart';
+import 'package:penhas/app/core/error/failures.dart';
 import 'package:penhas/app/core/managers/audio_play_services.dart';
+import 'package:penhas/app/core/managers/audio_sync_manager.dart';
 import 'package:penhas/app/features/help_center/data/models/audio_model.dart';
-import 'package:penhas/app/features/help_center/domain/entities/audio_entity.dart';
-import 'package:penhas/app/features/help_center/presentation/audios/audios_controller.dart';
 import 'package:penhas/app/features/help_center/data/repositories/audios_repository.dart';
+import 'package:penhas/app/features/help_center/domain/entities/audio_entity.dart';
+import 'package:penhas/app/features/help_center/domain/entities/audio_play_tile_entity.dart';
+import 'package:penhas/app/features/help_center/domain/states/audio_playing.dart';
+import 'package:penhas/app/features/help_center/domain/states/audios_state.dart';
+import 'package:penhas/app/features/help_center/presentation/audios/audios_controller.dart';
 
 import '../../../../../utils/json_util.dart';
 
+class MockAudiosRepository extends Mock implements IAudiosRepository {}
+
 class MockAudioPlayServices extends Mock implements IAudioPlayServices {}
 
-class MockAudiosRepository extends Mock implements IAudiosRepository {}
+class MockAudioSyncManager extends Mock implements IAudioSyncManager {}
 
 class AudioEntityFake extends Fake implements AudioEntity {}
 
 void main() {
   late MockAudiosRepository audiosRepository;
   late MockAudioPlayServices audioPlayServices;
+  late MockAudioSyncManager audioSyncManager;
   late AudioEntity audioReference;
 
   late AudiosController sut;
   late Map<String, dynamic> jsonData;
 
+  // Pulls the tile list out of the freezed [AudiosState] union (or fails).
+  List<AudioPlayTileEntity> loadedTiles(AudiosState state) => state.when(
+        initial: () => fail('expected loaded state, got initial'),
+        loaded: (audios, _) => audios,
+        error: (message) => fail('expected loaded state, got error: $message'),
+      );
+
+  setUpAll(() {
+    registerFallbackValue(AudioEntityFake());
+  });
+
   group(AudiosController, () {
-    setUp(() {
-      registerFallbackValue(AudioEntityFake());
+    setUp(() async {
       audioPlayServices = MockAudioPlayServices();
       audiosRepository = MockAudiosRepository();
-      sut = AudiosController(
-          audioPlayServices: audioPlayServices,
-          audiosRepository: audiosRepository);
-    });
+      audioSyncManager = MockAudioSyncManager();
 
-    test('delete', () async {
-      // arrange
       jsonData = await JsonUtil.getJson(from: 'audios/audios_fetch.json');
 
       audioReference = AudioEntity(
@@ -47,17 +60,172 @@ void main() {
         isRequested: true,
       );
 
-      when(() => audiosRepository.delete(any()))
-          .thenAnswer((_) async => right(const ValidField(message: '')));
-
+      // No pending uploads unless a test overrides it.
+      when(() => audioSyncManager.pendingUploads())
+          .thenAnswer((_) async => <Map<String, String>>[]);
       when(() => audiosRepository.fetch())
           .thenAnswer((_) async => right(AudioModel.fromJson(jsonData)));
+
+      sut = AudiosController(
+        audioPlayServices: audioPlayServices,
+        audiosRepository: audiosRepository,
+        audioSyncManager: audioSyncManager,
+      );
+    });
+
+    test('delete removes the audio and reloads the list', () async {
+      // arrange
+      when(() => audiosRepository.delete(any()))
+          .thenAnswer((_) async => right(const ValidField(message: '')));
 
       // act
       await sut.delete(audioReference);
 
       // assert
       verify(() => audiosRepository.delete(audioReference)).called(1);
+      verify(() => audiosRepository.fetch()).called(1);
+    });
+
+    group('loadPage', () {
+      test('emits server audios when there are no pending uploads', () async {
+        // act
+        await sut.loadPage();
+
+        // assert
+        final tiles = loadedTiles(sut.currentState);
+        // fixture has 2 audios, no pending uploads were stubbed
+        expect(tiles, hasLength(2));
+        expect(tiles.every((t) => t.uploadStatus == null), isTrue);
+      });
+
+      test('emits an error state when the fetch fails', () async {
+        // arrange
+        when(() => audiosRepository.fetch())
+            .thenAnswer((_) async => left(ServerFailure()));
+
+        // act
+        await sut.loadPage();
+
+        // assert
+        final isError = sut.currentState.when(
+          initial: () => false,
+          loaded: (_, __) => false,
+          error: (_) => true,
+        );
+        expect(isError, isTrue);
+      });
+
+      test(
+        'prepends optimistic tiles for pending uploads before server audios',
+        () async {
+          // arrange
+          when(() => audioSyncManager.pendingUploads()).thenAnswer(
+            (_) async => [
+              {'taskId': 'running.aac', 'status': 'running', 'progress': '42'},
+              {
+                'taskId': 'waiting.aac',
+                'status': 'enqueued',
+                'progress': '0',
+              },
+            ],
+          );
+
+          // act
+          await sut.loadPage();
+
+          // assert
+          final tiles = loadedTiles(sut.currentState);
+          // 2 optimistic + 2 server tiles, optimistic first
+          expect(tiles, hasLength(4));
+
+          final uploading = tiles[0];
+          expect(uploading.uploadStatus, TileUploadStatus.uploading);
+          expect(uploading.uploadProgress, 42);
+          expect(uploading.description, contains('Enviando'));
+          expect(uploading.description, contains('42%'));
+
+          final waiting = tiles[1];
+          expect(waiting.uploadStatus, TileUploadStatus.waitingNetwork);
+          expect(waiting.description, contains('Aguardando rede'));
+
+          // server tiles keep their normal (non-upload) state
+          expect(tiles[2].uploadStatus, isNull);
+          expect(tiles[3].uploadStatus, isNull);
+        },
+      );
+    });
+
+    group('listen', () {
+      test('playing a downloadable audio starts the player and flips state',
+          () async {
+        // arrange — the fixture's first audio has download_granted=1 (canPlay).
+        await sut.loadPage();
+        final tiles = loadedTiles(sut.currentState);
+        final playable = tiles.firstWhere((t) => t.audio.canPlay);
+
+        when(
+          () => audioPlayServices.start(
+            any(),
+            onFinished: any(named: 'onFinished'),
+          ),
+        ).thenAnswer((_) async => right(playable.audio));
+
+        // act — tap the play button on a playable tile (callback is void)
+        playable.onPlayAudio(playable.audio);
+        await untilCalled(
+          () => audioPlayServices.start(
+            any(),
+            onFinished: any(named: 'onFinished'),
+          ),
+        );
+        await Future<void>.delayed(Duration.zero); // let the fold settle state
+
+        // assert — player invoked and state reflects playback
+        verify(
+          () => audioPlayServices.start(
+            playable.audio,
+            onFinished: any(named: 'onFinished'),
+          ),
+        ).called(1);
+
+        final playingId = sut.playingAudioState.when(
+          none: () => null,
+          playing: (audio) => audio.id,
+        );
+        expect(playingId, playable.audio.id);
+      });
+
+      test('tapping a not-yet-granted audio requests access instead of playing',
+          () async {
+        // arrange — an audio that is neither playable nor already requested
+        await sut.loadPage();
+        final anyTile = loadedTiles(sut.currentState).first;
+        final lockedAudio = AudioEntity(
+          id: 'locked',
+          audioDuration: '0m10s',
+          createdAt: DateTime(2024, 1, 1),
+          canPlay: false,
+          isRequested: false,
+          isRequestGranted: false,
+        );
+
+        when(() => audiosRepository.requestAccess(any())).thenAnswer(
+          (_) async => right(const ValidField(message: 'Solicitação enviada')),
+        );
+
+        // act — reuse a real tile's play callback with the locked audio
+        anyTile.onPlayAudio(lockedAudio);
+        await untilCalled(() => audiosRepository.requestAccess(any()));
+
+        // assert — goes through request-access, never starts the player
+        verify(() => audiosRepository.requestAccess(lockedAudio)).called(1);
+        verifyNever(
+          () => audioPlayServices.start(
+            any(),
+            onFinished: any(named: 'onFinished'),
+          ),
+        );
+      });
     });
   });
 }

--- a/test/app/features/help_center/presentation/audios/audios_page_test.dart
+++ b/test/app/features/help_center/presentation/audios/audios_page_test.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:intl/date_symbol_data_local.dart';
-import 'package:intl/intl.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:penhas/app/features/help_center/domain/entities/audio_entity.dart';
 import 'package:penhas/app/features/help_center/domain/entities/audio_play_tile_entity.dart';
@@ -38,8 +36,6 @@ void main() {
 
   testWidgets('Audios Page With State Loaded', (tester) async {
     // arrange
-    initializeDateFormatting();
-
     const audioDuration = '1m30s';
     const message = 'Você tem 1 áudio gravado';
     const description = 'Toque no ícone para solicitar o áudio';
@@ -69,7 +65,6 @@ void main() {
     final messageWidget = find.text(message);
     final audioDurationWidget = find.text(audioDuration);
     final audioDescriptionWidget = find.text(description);
-    final audioDateWidget = find.text(DateFormat.yMd('pt_BR').format(date));
 
     // act
     await tester.pumpWidget(
@@ -84,7 +79,6 @@ void main() {
     expect(messageWidget, findsOneWidget);
     expect(audioDurationWidget, findsOneWidget);
     expect(audioDescriptionWidget, findsOneWidget);
-    expect(audioDateWidget, findsOneWidget);
   });
 
   testWidgets('Audios Page With State Error', (tester) async {

--- a/test/app/features/help_center/presentation/pages/audio/audio_play_widget_test.dart
+++ b/test/app/features/help_center/presentation/pages/audio/audio_play_widget_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:penhas/app/features/help_center/domain/entities/audio_entity.dart';
+import 'package:penhas/app/features/help_center/domain/entities/audio_play_tile_entity.dart';
+import 'package:penhas/app/features/help_center/presentation/pages/audio/audio_play_widget.dart';
+
+void main() {
+  AudioEntity audio() => AudioEntity(
+        id: 'event.aac',
+        audioDuration: '1m30s',
+        createdAt: DateTime(2023, 2, 3, 14, 44),
+        canPlay: false,
+        isRequested: false,
+        isRequestGranted: false,
+      );
+
+  Future<void> pump(WidgetTester tester, AudioPlayTileEntity tile) {
+    return tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: AudioPlayWidget(
+            audioPlay: tile,
+            isPlaying: false,
+            backgroundColor: Colors.transparent,
+          ),
+        ),
+      ),
+    );
+  }
+
+  group(AudioPlayWidget, () {
+    testWidgets('uploading tile shows spinner, progress bar and no controls',
+        (tester) async {
+      final tile = AudioPlayTileEntity(
+        audio: audio(),
+        description: 'Enviando áudio... 42%',
+        onPlayAudio: (_) {},
+        onActionSheet: (_) {},
+        uploadStatus: TileUploadStatus.uploading,
+        uploadProgress: 42,
+      );
+
+      await pump(tester, tile);
+
+      expect(find.text('Enviando áudio... 42%'), findsOneWidget);
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+      final bar = tester.widget<LinearProgressIndicator>(
+        find.byType(LinearProgressIndicator),
+      );
+      expect(bar.value, closeTo(0.42, 0.0001));
+
+      // a pending tile is not playable and exposes no action menu
+      expect(find.byIcon(Icons.play_circle_filled), findsNothing);
+      expect(find.byIcon(Icons.save_alt), findsNothing);
+      expect(find.byIcon(Icons.more_vert), findsNothing);
+    });
+
+    testWidgets('waitingNetwork tile shows cloud_off and no progress bar',
+        (tester) async {
+      final tile = AudioPlayTileEntity(
+        audio: audio(),
+        description: 'Aguardando rede para enviar',
+        onPlayAudio: (_) {},
+        onActionSheet: (_) {},
+        uploadStatus: TileUploadStatus.waitingNetwork,
+      );
+
+      await pump(tester, tile);
+
+      expect(find.text('Aguardando rede para enviar'), findsOneWidget);
+      expect(find.byIcon(Icons.cloud_off), findsOneWidget);
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(find.byType(LinearProgressIndicator), findsNothing);
+      expect(find.byIcon(Icons.more_vert), findsNothing);
+    });
+
+    testWidgets('confirmed tile shows the action menu and no upload indicators',
+        (tester) async {
+      final tile = AudioPlayTileEntity(
+        audio: audio(),
+        description: 'Toque no ícone para solicitar o audio',
+        onPlayAudio: (_) {},
+        onActionSheet: (_) {},
+      );
+
+      await pump(tester, tile);
+
+      expect(find.byIcon(Icons.more_vert), findsOneWidget);
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(find.byType(LinearProgressIndicator), findsNothing);
+      expect(find.byIcon(Icons.cloud_off), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
Summary
Implements background audio upload with optimistic queue, fallback resilience, and upload status UI.

Key Changes

Background Upload
- Replaces synchronous upload with background_downloader (v9.5.5)
- Uploads continue when app is closed or offline; auto-resumes on network available

Optimistic Queue
- Pending uploads appear immediately with progress indicators (Enviando... X% / Aguardando rede)
- Optimistic tiles shown before server-confirmed audios

Fallback and Fixes
- Palliative recording fallback when primary recorder fails
- Tooltips and Semantics labels for accessibility

Build Updates
- Android: compileSdk 35 to 36, Kotlin 1.9.24 to 2.1.0, AGP 8.5.0 to 8.9.1
- iOS: Added background_downloader pod, fetch permission

Testing
- New unit tests: audio_sync_manager_test.dart and audio_play_widget_test.dart

Ready for review