### PR TITLE
fix(android): upload de áudio em background + codec/data no playback; CI versioning

### DIFF
--- a/.github/workflows/distribute-flutter-android.yml
+++ b/.github/workflows/distribute-flutter-android.yml
@@ -7,6 +7,10 @@ on:
         description: "Distribution environment"
         type: string
         required: true
+      version_name:
+        description: "Semantic version name (e.g. 3.7.4) to stamp on the build"
+        type: string
+        required: false
 
     secrets:
       PENHAS_BASE_URL:
@@ -93,7 +97,7 @@ jobs:
         uses: maierj/fastlane-action@v3.0.0
         with:
           lane: ${{ vars.TARGET_LANE }}
-          options: '{ "tester_email": "${{ secrets.TESTER_EMAIL }}" }'
+          options: '{ "tester_email": "${{ secrets.TESTER_EMAIL }}", "version_name": "${{ inputs.version_name }}" }'
           subdirectory: ./android
         env:
           FASTLANE_SKIP_UPDATE_CHECK: true

--- a/.github/workflows/distribute-flutter-android.yml
+++ b/.github/workflows/distribute-flutter-android.yml
@@ -24,17 +24,16 @@ on:
       TESTER_EMAIL:
         required: false
 
-# Define permissions for GITHUB_TOKEN
-permissions:
-  contents: read  # Required for actions/checkout
-  id-token: write # Required for some authentication tasks
-  packages: write # Required if you're publishing packages
-  actions: write  # Required if you're triggering other workflows
-
 jobs:
   distribute:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
+    # Define permissions for GITHUB_TOKEN at the job level (least privilege)
+    permissions:
+      contents: read  # Required for actions/checkout
+      id-token: write # Required for some authentication tasks
+      packages: write # Required if you're publishing packages
+      actions: write  # Required if you're triggering other workflows
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/distribute-flutter-ios.yml
+++ b/.github/workflows/distribute-flutter-ios.yml
@@ -7,6 +7,10 @@ on:
         description: "Distribution environment"
         type: string
         required: true
+      version_name:
+        description: "Semantic version name (e.g. 3.7.4) to stamp on the build"
+        type: string
+        required: false
 
     secrets:
       APPLE_API_KEY_B64:
@@ -90,7 +94,7 @@ jobs:
         uses: maierj/fastlane-action@v3.0.0
         with:
           lane: ${{ vars.TARGET_LANE }}
-          options: '{ "tester_email": "${{ secrets.TESTER_EMAIL }}" }'
+          options: '{ "tester_email": "${{ secrets.TESTER_EMAIL }}", "version_name": "${{ inputs.version_name }}" }'
           subdirectory: ./ios
         env:
           APPLE_API_KEY_PATH: ${{ runner.temp }}/app-store-api-key.json

--- a/.github/workflows/manual-distribution.yml
+++ b/.github/workflows/manual-distribution.yml
@@ -15,6 +15,15 @@ on:
         description: "Distribution environment"
         type: environment
         required: true
+      bump:
+        description: "Semantic version name bump"
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: patch
+        required: true
 
 # Define permissions for the GITHUB_TOKEN
 permissions:
@@ -26,11 +35,62 @@ permissions:
   deployments: write
 
 jobs:
+  version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      version_name: ${{ steps.bump.outputs.version_name }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Bump semantic version name in pubspec.yaml
+        id: bump
+        env:
+          BUMP: ${{ github.event.inputs.bump }}
+        run: |
+          set -euo pipefail
+          current=$(grep -E '^version:' pubspec.yaml | head -1 | sed -E 's/^version:[[:space:]]*//' | tr -d '[:space:]')
+          name="${current%%+*}"
+          if [[ "$current" == *"+"* ]]; then build="+${current#*+}"; else build=""; fi
+          IFS='.' read -r major minor patch <<< "$name"
+          case "$BUMP" in
+            major) major=$((major + 1)); minor=0; patch=0 ;;
+            minor) minor=$((minor + 1)); patch=0 ;;
+            patch) patch=$((patch + 1)) ;;
+            *) echo "::error::invalid bump value: $BUMP"; exit 1 ;;
+          esac
+          new_name="${major}.${minor}.${patch}"
+          new_version="${new_name}${build}"
+          sed -i -E "s/^version:.*/version: ${new_version}/" pubspec.yaml
+          echo "version_name=${new_name}" >> "$GITHUB_OUTPUT"
+          echo "Bumped ${current} -> ${new_version}"
+
+      - name: Commit and push version bump
+        env:
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet pubspec.yaml; then
+            echo "pubspec.yaml unchanged, skipping commit"
+            exit 0
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add pubspec.yaml
+          git commit -m "chore: bump version name to ${{ steps.bump.outputs.version_name }} [skip ci]"
+          git push origin "HEAD:${BRANCH}"
+
   distribute-android:
+    needs: version
     if: ${{ github.event.inputs.platform == 'android' || github.event.inputs.platform == 'all' }}
     uses: ./.github/workflows/distribute-flutter-android.yml
     with:
       environment: ${{ github.event.inputs.environment }}
+      version_name: ${{ needs.version.outputs.version_name }}
     secrets:
       ANDROID_BUILD_FILES: ${{ secrets.ANDROID_BUILD_FILES }}
       FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
@@ -38,10 +98,12 @@ jobs:
       PENHAS_BASE_URL: ${{ secrets.PENHAS_BASE_URL }}
 
   distribute-ios:
+    needs: version
     if: ${{ github.event.inputs.platform == 'ios' || github.event.inputs.platform == 'all' }}
     uses: ./.github/workflows/distribute-flutter-ios.yml
     with:
       environment: ${{ github.event.inputs.environment }}
+      version_name: ${{ needs.version.outputs.version_name }}
     secrets:
       APPLE_API_KEY_B64: ${{ secrets.APPLE_API_KEY_B64 }}
       APPLE_ID: ${{ secrets.APPLE_ID }}

--- a/.github/workflows/manual-distribution.yml
+++ b/.github/workflows/manual-distribution.yml
@@ -25,15 +25,6 @@ on:
         default: patch
         required: true
 
-# Define permissions for the GITHUB_TOKEN
-permissions:
-  contents: write # Required to commit the version bump
-  packages: write # Required if you are publishing packages
-  actions: write # Required if you are using reusable workflows
-  id-token: write
-  checks: write
-  deployments: write
-
 jobs:
   version:
     runs-on: ubuntu-latest
@@ -87,6 +78,11 @@ jobs:
   distribute-android:
     needs: version
     if: ${{ github.event.inputs.platform == 'android' || github.event.inputs.platform == 'all' }}
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+      actions: write
     uses: ./.github/workflows/distribute-flutter-android.yml
     with:
       environment: ${{ github.event.inputs.environment }}
@@ -100,6 +96,11 @@ jobs:
   distribute-ios:
     needs: version
     if: ${{ github.event.inputs.platform == 'ios' || github.event.inputs.platform == 'all' }}
+    permissions:
+      contents: write
+      actions: write
+      checks: write
+      deployments: write
     uses: ./.github/workflows/distribute-flutter-ios.yml
     with:
       environment: ${{ github.event.inputs.environment }}

--- a/.github/workflows/tester-email-distribute.yml
+++ b/.github/workflows/tester-email-distribute.yml
@@ -16,16 +16,14 @@ on:
         type: string
         required: true
 
-# Define permissions for the GITHUB_TOKEN
-permissions:
-  contents: write # Required to commit the version bump
-  actions: write # Allow writing to actions (if needed)
-  checks: write # Allow writing to checks (if needed)
-  # Add other permissions as needed
-
 jobs:
   distribute-android:
     if: ${{ github.event.inputs.platform == 'android' || github.event.inputs.platform == 'all' }}
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+      actions: write
     uses: ./.github/workflows/distribute-flutter-android.yml
     with:
       environment: firebase-distribution
@@ -38,6 +36,11 @@ jobs:
 
   distribute-ios:
     if: ${{ github.event.inputs.platform == 'ios' || github.event.inputs.platform == 'all' }}
+    permissions:
+      contents: write
+      actions: write
+      checks: write
+      deployments: write
     uses: ./.github/workflows/distribute-flutter-ios.yml
     with:
       environment: firebase-distribution

--- a/android/app/src/dev/res/xml/network_security_config.xml
+++ b/android/app/src/dev/res/xml/network_security_config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  DEV / Firebase App Distribution override. Permits cleartext HTTP so the native
+  background_downloader upload reaches an http dev backend (e.g. 10.0.2.2:8000 on
+  the emulator, or a staging host without TLS). NEVER shipped to production: the
+  src/dev/res sourceSet is only merged for debug builds and for release builds
+  when IS_FIREBASE_DISTRIBUTION=true (see android/app/build.gradle).
+-->
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true" />
+</network-security-config>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -26,6 +26,7 @@
         android:icon="@mipmap/ic_launcher"
         android:allowBackup="false"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:enableOnBackInvokedCallback="true">
         
         <activity

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Production / default config. Cleartext HTTP is denied everywhere; only the
+  https backend (api.penhas.com.br) is reachable. The dev/Firebase-distribution
+  flavor overrides this file via src/dev/res to permit cleartext to the local
+  backend (see that copy). Native HTTP clients (e.g. background_downloader's
+  WorkManager uploader) honor this config; dart:io does not, which is why audio
+  uploads failed on Android dev builds while every Dart API call succeeded.
+-->
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false" />
+</network-security-config>

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -10,9 +10,13 @@ $api_base_url = ENV['PENHAS_BASE_URL']
 platform :android do
 
   desc 'Build release APK'
-  lane :build_apk do
+  lane :build_apk do |options|
+    options ||= {}
     puts "Building release APK, API Base URL: #{$api_base_url}"
-    sh("flutter build apk --release --dart-define=PENHAS_BASE_URL=#{$api_base_url}")
+    cmd = "flutter build apk --release --dart-define=PENHAS_BASE_URL=#{$api_base_url}"
+    cmd += " --build-name=#{options[:version_name]}" if options[:version_name] && !options[:version_name].to_s.empty?
+    cmd += " --build-number=#{options[:build_number]}" if options[:build_number]
+    sh(cmd)
   end
 
   desc 'Build release Bundle'
@@ -27,10 +31,21 @@ platform :android do
     testers = options[:tester_email] || ''
     groups = testers.empty? ? testers_group : nil
 
-    build_apk
+    app_id = firebase_id()
+
+    latest = firebase_app_distribution_get_latest_release(app: app_id)
+    pubspec_build = File.read("#{$project_path}/pubspec.yaml").match(/^version:\s*\S+\+(\d+)/)[1].to_i
+    last_uploaded = latest && latest[:buildVersion] ? latest[:buildVersion].to_i : 0
+    next_build = [pubspec_build, last_uploaded].max + 1
+    UI.message("Android build number: #{next_build} (pubspec=#{pubspec_build}, firebase_latest=#{last_uploaded})")
+
+    build_apk(
+      version_name: options[:version_name],
+      build_number: next_build,
+    )
 
     firebase_app_distribution(
-      app: firebase_id(),
+      app: app_id,
       release_notes: get_changelog(),
       android_artifact_path: "#{$project_path}/build/app/outputs/apk/release/app-release.apk",
       groups: groups,

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -24,6 +24,7 @@ platform :ios do
   desc 'Build release IPA'
   lane :build do |options|
     cmd = "flutter build ios --release --no-codesign --config-only --dart-define=PENHAS_BASE_URL=#{$api_base_url}"
+    cmd += " --build-name=#{options[:version_name]}" if options[:version_name] && !options[:version_name].to_s.empty?
     cmd += " --build-number=#{options[:build_number]}" if options[:build_number]
     sh(cmd)
   end
@@ -78,6 +79,7 @@ platform :ios do
     build(
       profile_type: options[:profile_type],
       build_number: options[:build_number],
+      version_name: options[:version_name],
     )
 
     gym(
@@ -128,6 +130,7 @@ platform :ios do
       profile_type: profile_type_edirock,
       force_profile: new_devices.any?,
       build_number: next_build,
+      version_name: options[:version_name],
     )
 
     firebase_app_distribution(
@@ -137,32 +140,6 @@ platform :ios do
       groups: groups,
       testers: testers,
     )
-
-    commit_build_bump(build_number: next_build) if ENV['CI']
-  end
-
-  desc 'Write bumped build number back to pubspec.yaml and push to remote'
-  private_lane :commit_build_bump do |options|
-    build_number = options[:build_number]
-    pubspec_path = "#{$project_path}/pubspec.yaml"
-    pubspec_content = File.read(pubspec_path)
-    updated = pubspec_content.sub(/^(version:\s*\S+?)\+\d+/, "\\1+#{build_number}")
-
-    if updated == pubspec_content
-      UI.important("pubspec.yaml unchanged — skipping commit")
-      next
-    end
-
-    File.write(pubspec_path, updated)
-
-    branch = ENV['GITHUB_REF_NAME']
-    UI.user_error!('GITHUB_REF_NAME not set — cannot push') if branch.nil? || branch.empty?
-
-    sh("git config user.email '41898282+github-actions[bot]@users.noreply.github.com'")
-    sh("git config user.name 'github-actions[bot]'")
-    sh("git add #{pubspec_path}")
-    sh("git commit -m 'chore(ios): bump build number to #{build_number} [skip ci]'")
-    sh("git push origin HEAD:#{branch}")
   end
 
   private_lane :request_api_key do

--- a/lib/app/core/managers/audio_play_services.dart
+++ b/lib/app/core/managers/audio_play_services.dart
@@ -57,9 +57,49 @@ class AudioPlayServices implements IAudioPlayServices {
 
     await _playerModule.startPlayer(
       fromURI: file.path,
-      codec: _audioCodec,
+      codec: _detectCodec(file),
       whenFinished: onFinished,
     );
+  }
+
+  /// The recorder normally writes AAC ADTS, but on devices where ADTS recording
+  /// fails it falls back to AAC MP4 (PALLIATIVE_FIX_20260523 in
+  /// [AudioRecordServices]) — both end up in a file named `.aac`, and the
+  /// downloaded copy is cached as `{id}.cached`, so the extension carries no
+  /// codec hint. Decoding an MP4 container as ADTS yields garbled/silent
+  /// playback, so sniff the container from the file header instead of trusting
+  /// a fixed codec. Falls back to [_audioCodec] when the bytes are unreadable
+  /// or inconclusive.
+  Codec _detectCodec(File file) {
+    try {
+      final raf = file.openSync();
+      final List<int> header;
+      try {
+        header = raf.readSync(12);
+      } finally {
+        raf.closeSync();
+      }
+
+      // ISO-BMFF (MP4/M4A): 'ftyp' box type at byte offset 4.
+      if (header.length >= 8 &&
+          header[4] == 0x66 && // f
+          header[5] == 0x74 && // t
+          header[6] == 0x79 && // y
+          header[7] == 0x70) {
+        return Codec.aacMP4;
+      }
+
+      // AAC ADTS: 12-bit sync word 0xFFF at the start of the stream.
+      if (header.length >= 2 &&
+          header[0] == 0xFF &&
+          (header[1] & 0xF6) == 0xF0) {
+        return Codec.aacADTS;
+      }
+    } catch (e, stack) {
+      logError(e, stack);
+    }
+
+    return _audioCodec;
   }
 
   Future<void> _setupPlayEnvironment() async {

--- a/lib/app/features/help_center/presentation/pages/audio/audio_play_widget.dart
+++ b/lib/app/features/help_center/presentation/pages/audio/audio_play_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart' show DateFormat;
 
 import '../../../../../shared/design_system/colors.dart';
 import '../../../../../shared/design_system/text_styles.dart';
@@ -71,6 +72,14 @@ class AudioPlayWidget extends StatelessWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
+                  // Recording date. Guarded against null because optimistic
+                  // upload tiles have no createdAt yet (force-unwrapping here is
+                  // what dropped the date in the background-upload refactor).
+                  if (audioPlay.audio.createdAt != null)
+                    Text(
+                      DateFormat.yMd('pt_BR').format(audioPlay.audio.createdAt!),
+                      style: kTextStyleAudioTime,
+                    ),
                   Text(
                     audioPlay.description,
                     style: kTextStyleAudioDescription,

--- a/lib/app/features/help_center/presentation/pages/audio/audio_play_widget.dart
+++ b/lib/app/features/help_center/presentation/pages/audio/audio_play_widget.dart
@@ -77,7 +77,8 @@ class AudioPlayWidget extends StatelessWidget {
                   // what dropped the date in the background-upload refactor).
                   if (audioPlay.audio.createdAt != null)
                     Text(
-                      DateFormat.yMd('pt_BR').format(audioPlay.audio.createdAt!),
+                      DateFormat.yMd('pt_BR')
+                          .format(audioPlay.audio.createdAt!),
                       style: kTextStyleAudioTime,
                     ),
                   Text(

--- a/test/app/core/managers/audio_play_services_test.dart
+++ b/test/app/core/managers/audio_play_services_test.dart
@@ -90,6 +90,72 @@ void main() {
       expect(result.fold((l) => l, (r) => r), audioReference);
     });
 
+    group('codec detection (recorder may fall back to aacMP4)', () {
+      late Directory tmpDir;
+
+      setUp(() {
+        tmpDir = Directory.systemTemp.createTempSync('audio_codec_test');
+        when(() => flutterSoundPlayer.isStopped).thenReturn(true);
+        when(() => flutterSoundPlayer.closePlayer())
+            .thenAnswer((_) => Future.value());
+        when(() => flutterSoundPlayer.openPlayer())
+            .thenAnswer((_) async => null);
+        when(() => flutterSoundPlayer
+                .setSubscriptionDuration(Duration(milliseconds: 100)))
+            .thenAnswer((_) => Future.value());
+      });
+
+      tearDown(() => tmpDir.deleteSync(recursive: true));
+
+      Future<void> playFile(File file, Codec expected) async {
+        when(() => audioSyncManager.cache(audioReference))
+            .thenAnswer((_) async => right(file));
+        when(() => flutterSoundPlayer.startPlayer(
+              fromURI: any(named: 'fromURI'),
+              codec: expected,
+              whenFinished: any(named: 'whenFinished'),
+            )).thenAnswer((_) => Future.value());
+
+        final audioPlayServices = AudioPlayServices(
+          audioSyncManager: audioSyncManager,
+          player: flutterSoundPlayer,
+        );
+
+        await audioPlayServices.start(audioReference);
+        // start() fire-and-forgets _play() inside Either.fold, so let its async
+        // chain (release -> open -> startPlayer) drain before verifying.
+        await pumpEventQueue();
+
+        verify(() => flutterSoundPlayer.startPlayer(
+              fromURI: file.path,
+              codec: expected,
+              whenFinished: any(named: 'whenFinished'),
+            )).called(1);
+      }
+
+      test('plays a real ADTS file (0xFFFx sync word) as aacADTS', () async {
+        await playFile(File('test/assets/audio/silence.aac'), Codec.aacADTS);
+      });
+
+      test('plays an MP4 container (ftyp box) as aacMP4', () async {
+        // The downloaded file is named `{id}.cached`, so the codec must come
+        // from the header, not the extension. 'ftyp' sits at byte offset 4.
+        final file = File('${tmpDir.path}/123.cached')
+          ..writeAsBytesSync([
+            0x00, 0x00, 0x00, 0x18, // box size
+            0x66, 0x74, 0x79, 0x70, // 'ftyp'
+            0x4D, 0x34, 0x41, 0x20, // 'M4A '
+          ]);
+        await playFile(file, Codec.aacMP4);
+      });
+
+      test('falls back to aacADTS for an inconclusive header', () async {
+        final file = File('${tmpDir.path}/garbage.cached')
+          ..writeAsBytesSync([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]);
+        await playFile(file, Codec.aacADTS);
+      });
+    });
+
     test('dispose release the audio session', () async {
       // arrange
       when((() => audioSyncManager.cache(audioReference)))

--- a/test/app/core/managers/audio_play_services_test.dart
+++ b/test/app/core/managers/audio_play_services_test.dart
@@ -100,9 +100,8 @@ void main() {
             .thenAnswer((_) => Future.value());
         when(() => flutterSoundPlayer.openPlayer())
             .thenAnswer((_) async => null);
-        when(() => flutterSoundPlayer
-                .setSubscriptionDuration(Duration(milliseconds: 100)))
-            .thenAnswer((_) => Future.value());
+        when(() => flutterSoundPlayer.setSubscriptionDuration(
+            Duration(milliseconds: 100))).thenAnswer((_) => Future.value());
       });
 
       tearDown(() => tmpDir.deleteSync(recursive: true));

--- a/test/app/features/help_center/presentation/audios/audios_page_test.dart
+++ b/test/app/features/help_center/presentation/audios/audios_page_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/date_symbol_data_local.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:penhas/app/features/help_center/domain/entities/audio_entity.dart';
 import 'package:penhas/app/features/help_center/domain/entities/audio_play_tile_entity.dart';
@@ -10,7 +11,12 @@ import 'package:penhas/app/features/help_center/presentation/audios/audios_page.
 void main() {
   late AudiosController mockController;
 
-  setUpAll(() {
+  setUpAll(() async {
+    // AudioPlayWidget formats the recording date with the pt_BR locale, which
+    // GlobalMaterialLocalizations loads at runtime but the bare MaterialApp in
+    // these tests does not — initialize it explicitly.
+    await initializeDateFormatting('pt_BR');
+
     mockController = _MockAudiosController();
     when(() => mockController.loadPage()).thenAnswer((_) => Future.value());
   });

--- a/test/app/features/help_center/presentation/pages/audio/audio_play_widget_test.dart
+++ b/test/app/features/help_center/presentation/pages/audio/audio_play_widget_test.dart
@@ -1,14 +1,21 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:intl/intl.dart' show DateFormat;
 import 'package:penhas/app/features/help_center/domain/entities/audio_entity.dart';
 import 'package:penhas/app/features/help_center/domain/entities/audio_play_tile_entity.dart';
 import 'package:penhas/app/features/help_center/presentation/pages/audio/audio_play_widget.dart';
 
 void main() {
-  AudioEntity audio() => AudioEntity(
+  // The widget formats the recording date with the pt_BR locale; at runtime
+  // GlobalMaterialLocalizations loads it, but the bare MaterialApp below does
+  // not, so initialize it explicitly for the tests.
+  setUpAll(() => initializeDateFormatting('pt_BR'));
+
+  AudioEntity audio({DateTime? createdAt}) => AudioEntity(
         id: 'event.aac',
         audioDuration: '1m30s',
-        createdAt: DateTime(2023, 2, 3, 14, 44),
+        createdAt: createdAt,
         canPlay: false,
         isRequested: false,
         isRequestGranted: false,
@@ -90,6 +97,41 @@ void main() {
       expect(find.byType(CircularProgressIndicator), findsNothing);
       expect(find.byType(LinearProgressIndicator), findsNothing);
       expect(find.byIcon(Icons.cloud_off), findsNothing);
+    });
+
+    testWidgets('confirmed tile renders the recording date (pt_BR)',
+        (tester) async {
+      final createdAt = DateTime(2023, 2, 3, 14, 44);
+      final tile = AudioPlayTileEntity(
+        audio: audio(createdAt: createdAt),
+        description: 'Toque no ícone para solicitar o audio',
+        onPlayAudio: (_) {},
+        onActionSheet: (_) {},
+      );
+
+      await pump(tester, tile);
+
+      expect(
+        find.text(DateFormat.yMd('pt_BR').format(createdAt)),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('tile without createdAt renders no date and does not crash',
+        (tester) async {
+      final tile = AudioPlayTileEntity(
+        audio: audio(),
+        description: 'Enviando áudio... 10%',
+        onPlayAudio: (_) {},
+        onActionSheet: (_) {},
+        uploadStatus: TileUploadStatus.uploading,
+        uploadProgress: 10,
+      );
+
+      await pump(tester, tile);
+
+      expect(tester.takeException(), isNull);
+      expect(find.textContaining('/'), findsNothing);
     });
   });
 }


### PR DESCRIPTION
## Mudanças

### Áudio — Android

- **Upload em background não subia (cleartext bloqueado).** O `background_downloader` faz upload pela stack HTTP **nativa** do Android, que respeita a política de cleartext; com `targetSdk 35` o cleartext é negado por padrão, então uploads para backend `http` (dev/staging) falhavam com `Cleartext HTTP traffic not permitted` — enquanto login/lista/download seguiam funcionando porque o `dart:io` ignora essa política. Adicionado `network_security_config`: cleartext **negado** em `main` (prod/https intacto) e **permitido só no flavor dev/Firebase** (`src/dev/res`, mergeado em debug e em release com `IS_FIREBASE_DISTRIBUTION`).
  - `android/app/src/main/AndroidManifest.xml`, `android/app/src/main/res/xml/network_security_config.xml`, `android/app/src/dev/res/xml/network_security_config.xml`

- **Playback com áudio quebrado (codec fixo).** O gravador grava AAC ADTS, mas cai para AAC MP4 (fallback palliative) em devices onde ADTS falha — ambos em arquivo `.aac`, e a cópia baixada é cacheada como `{id}.cached` (sem dica de codec na extensão). O player usava `Codec.aacADTS` fixo, então um container MP4 tocado como ADTS dava áudio sem som/distorcido. Agora o player **detecta o container pelo header** (box `ftyp` / sync word ADTS), com fallback para aacADTS.
  - `lib/app/core/managers/audio_play_services.dart` (+ testes)

- **Data da gravação some na lista.** A refatoração de upload em background removeu a data do tile porque fazia force-unwrap de `createdAt` (null em tiles otimistas de upload). Data restaurada com null-guard.
  - `lib/app/features/help_center/presentation/pages/audio/audio_play_widget.dart` (+ testes)

### CI / Distribuição

- Versionamento semântico por distribuição + auto-incremento de build portado para Android; ajustes nos workflows de distribuição e Fastfiles.
  - `.github/workflows/distribute-flutter-android.yml`, `.github/workflows/distribute-flutter-ios.yml`, `.github/workflows/manual-distribution.yml`, `android/fastlane/Fastfile`, `ios/fastlane/Fastfile`

## Testes

- Unit/widget tests novos cobrindo detecção de codec (ADTS/MP4/inconclusivo) e renderização/ausência da data.
- Validado fim-a-fim em emulador Android: upload confirmado no backend sobre `http` (dev) e `https` (hmg); playback decodifica; data aparece na lista.

## Notas

- Prod (`https://api.penhas.com.br`) não é afetado pelo cleartext (https) e segue com cleartext **negado** em release de loja.
