### PR TITLE
ci(ios): bump runner to macos-26 and select Xcode via setup-xcode

### DIFF
--- a/.github/workflows/distribute-flutter-ios.yml
+++ b/.github/workflows/distribute-flutter-ios.yml
@@ -35,7 +35,7 @@ on:
 jobs:
 
   distribute:
-    runs-on: macos-15
+    runs-on: macos-26
     environment: ${{ inputs.environment }}
     
     # Add permissions here
@@ -50,7 +50,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Select Xcode version
-        run: sudo xcode-select -s /Applications/Xcode_16.3.app
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
 
       - name: Retrieve Flutter version from FVM config
         uses: kuhnroyal/flutter-fvm-config-action@v1

--- a/.github/workflows/distribute-flutter-ios.yml
+++ b/.github/workflows/distribute-flutter-ios.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Select Xcode version
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: latest-stable
 


### PR DESCRIPTION
Xcode 16.3 / iOS 18.4 SDK is no longer present on the macos-15 image, breaking the archive step. Move to macos-26 and pick the image's latest-stable Xcode via maxim-lobanov/setup-xcode instead of a hardcoded /Applications/Xcode_*.app path that drifts with the runner image.