### PR TITLE
Conformidade Google Play: target API 36 e publicação em produção (16 KB)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -46,7 +46,7 @@ android {
 defaultConfig {
     applicationId "penhas.com.br"
     minSdkVersion 24
-    targetSdkVersion 35
+    targetSdkVersion 36
     versionCode flutterVersionCode.toInteger()
     versionName flutterVersionName
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,27 +1,9 @@
-buildscript {
-    ext.kotlin_version = '2.1.0'
-    repositories {
-        google()
-        jcenter()
-        maven {
-            url 'https://maven.fabric.io/public'
-        }
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:8.5.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        // Add the google services classpath
-        classpath 'com.google.gms:google-services:4.4.2'
-        // Add fabric classpath
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.8.1'
-    }
-}
+// Plugin versions are declared once in settings.gradle (pluginManagement/plugins).
+// Declaring them again as buildscript classpaths silently overrides those versions.
 
 allprojects {
     repositories {
         google()
-        jcenter()
         mavenCentral()
     }
 }

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -21,7 +21,12 @@ platform :android do
   end
 
   desc 'Build release Bundle'
+  # Sem --build-name/--build-number: a release de produção usa exatamente o
+  # version do pubspec.yaml. O bump que manual-distribution.yml calcula não é
+  # commitado, então aceitá-lo aqui publicaria no Play uma versão inexistente
+  # no repositório.
   lane :build_bundle do
+    puts "Building release Bundle, API Base URL: #{$api_base_url}"
     sh("flutter build appbundle --release --dart-define=PENHAS_BASE_URL=#{$api_base_url}")
   end
 
@@ -59,10 +64,17 @@ platform :android do
   end
 
   desc 'Deploy a new version to the Play Store'
+  # Publica no track de produção como rascunho: o AAB fica disponível no Play
+  # Console para revisão e a publicação é confirmada manualmente. Alertas do
+  # Play (target API, 16 KB page size) avaliam a release de produção, então
+  # bundles enviados a outros tracks não os encerram.
+  #
+  # O versionCode vem do pubspec.yaml — nenhum bump automático acontece aqui.
+  # Incremente-o antes de rodar, ou o Play recusa o upload por versão duplicada.
   lane :release_distribute do
     build_bundle
     upload_to_play_store(
-      track: 'alpha',
+      track: 'production',
       release_status: 'draft',
       aab: "#{$project_path}/build/app/outputs/bundle/release/app-release.aab",
     )

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
-android.enableR8=true
 android.useAndroidX=true
 android.enableJetifier=true

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -20,7 +20,7 @@ plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version '8.9.1' apply false
     id "org.jetbrains.kotlin.android" version "2.1.0" apply false
-    id "com.google.gms.google-services" version "4.3.15" apply false
+    id "com.google.gms.google-services" version "4.4.2" apply false
     id "com.google.firebase.crashlytics" version "2.8.1" apply false
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ description: A new Flutter project.
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 3.7.3+70
+version: 3.7.4+71
 publish_to: none
 
 environment:


### PR DESCRIPTION
Resolve os dois alertas de conformidade abertos no Google Play Console.

## Contexto

O Console reportava dois bloqueios de publicação:

1. **`App must target Android 16 (API level 36) or higher`** — a partir de 30/08/2026 não será possível publicar atualizações com target abaixo disso. O maior target não conforme era o Android 15 (API 35).
2. **`App must support 16 KB memory page sizes`** — a partir de 31/01/2027, atualizações sem suporte a páginas de 16 KB são recusadas.

## O que foi feito

### Target API 36

`targetSdkVersion` 35 → 36 em `android/app/build.gradle`. O `compileSdkVersion` já estava em 36.

Nenhuma mudança de comportamento do Android 16 exigiu adaptação nesta base:

| Mudança do API 36 | Situação |
|---|---|
| Edge-to-edge com opt-out ignorado | Já vigente desde o targetSdk 35; o projeto não usa `windowOptOutEdgeToEdgeEnforcement` |
| `screenOrientation`/`resizableActivity` ignorados em telas ≥ 600dp | Não declarados no manifest, nem `SystemChrome.setPreferredOrientations` no código Dart |
| Predictive back por padrão | `android:enableOnBackInvokedCallback="true"` já presente no manifest |

### Suporte a 16 KB

O bundle **já estava em conformidade** — a causa do alerta não era o build, e sim o destino da publicação.

O lane `release_distribute` enviava o AAB para o track `alpha` com `release_status: 'draft'`. Como os alertas do Play avaliam exclusivamente a *release de produção*, nenhum bundle corrigido chegava a fechá-los. Isso explica o alerta ter reaparecido mesmo após correções anteriores.

O lane passou a publicar em `track: 'production'`. O `release_status: 'draft'` foi mantido de propósito: o AAB fica aguardando confirmação manual no Play Console, preservando o gate humano que o fluxo já tinha.

### Consolidação de versões de plugin do Gradle

`android/build.gradle` declarava um bloco `buildscript` com classpaths que **sobrescreviam silenciosamente** as versões do `settings.gradle`. O efeito prático: o AGP em uso era 8.5.0, não o 8.9.1 declarado — a atualização feita em `a5c66d44` nunca chegou a valer.

- removido o `buildscript` do `build.gradle` raiz; o `settings.gradle` passa a ser fonte única
- `google-services` 4.3.15 → 4.4.2 no `settings.gradle`, preservando a versão que estava de fato em uso via classpath
- removidos `jcenter()` e `maven.fabric.io`, ambos desativados desde 2021
- removido `android.enableR8` do `gradle.properties` (sem efeito desde o AGP 7.0, e o build emitia aviso)

Vale registrar que **o AGP não tinha relação com o alerta de 16 KB**: builds com 8.5.0 e 8.9.1 produzem alinhamento idêntico, conforme verificado. A consolidação entra por corrigir a divergência entre versão declarada e versão efetiva.

### Versão

`pubspec.yaml`: `3.7.3+70` → `3.7.4+71`.

O bump é necessariamente manual: `release_distribute` chama `build_bundle` sem `--build-name`/`--build-number`, então a release de produção usa exatamente o que está no `pubspec.yaml`. Nenhum workflow incrementa o build number para produção — o `manual-distribution.yml` bumpa apenas o nome semântico, em runtime e sem commitar, e o auto-incremento do `firebase_distribute` aplica-se ao app de testes (`dev.penhas.com.br`), que é outro applicationId.

## Validação

Build de release limpo (`flutter clean` + `pub get` + `bundleRelease`), AAB de 38.0 MB gerado. Manifest mesclado de release confirma:

```
package="penhas.com.br"  versionCode="71"  versionName="3.7.4"
targetSdkVersion="36"    minSdkVersion="24"
```

Conformidade de 16 KB verificada nos **dois** critérios exigidos, sobre as ABIs de 64 bits (arm64-v8a e x86_64 — páginas de 16 KB só existem em dispositivos 64-bit):

- **Alinhamento ELF**: todos os segmentos `PT_LOAD` com `p_align` ≥ 16384. `libapp.so` e `libflutter.so` em `0x10000`, `libdatastore_shared_counter.so` em `0x4000`.
- **Alinhamento no ZIP**: todas as `.so` gravadas como `stored` e em offsets múltiplos de 16384 dentro do APK. Esse critério é obrigatório aqui porque o manifest resolve para `extractNativeLibs="false"` — o loader mapeia a biblioteca diretamente do APK, então o offset precisa coincidir com a fronteira de página.

## Após o merge

Os alertas só se encerram quando uma release chegar efetivamente à produção:

1. executar o `manual-distribution.yml` para a plataforma `android`, o que envia o AAB ao track de produção como rascunho;
2. publicar o rascunho no Play Console.

Um ponto a confirmar antes da primeira execução: a service account usada pelo CI precisa de permissão para o track de produção, que é mais ampla que a exigida para tracks de teste. Caso tenha acesso apenas a tracks de teste, o upload falhará. O lane `verify_play_store_auth`, já existente, permite checar isso.

Como efeito colateral da mudança de track, o repositório perde o caminho automatizado de publicar no alpha. Se for desejável mantê-lo, dá para reintroduzir um lane separado sem alterar o atual.
