### PR TITLE
ci(ios): distribuir builds de teste pelo TestFlight

### DIFF
--- a/.github/workflows/distribute-flutter-ios.yml
+++ b/.github/workflows/distribute-flutter-ios.yml
@@ -21,16 +21,12 @@ on:
         required: true
       CERTIFICATE_PWD:
         required: true
-      FIREBASE_SERVICE_ACCOUNT_B64:
-        required: true
       IOS_BUILD_FILES:
         required: true
       KEYCHAIN_PWD:
         required: true
       PENHAS_BASE_URL:
         required: true
-      TESTER_EMAIL:
-        required: false
 
 jobs:
 
@@ -77,12 +73,6 @@ jobs:
         env:
           APPLE_API_KEY_PATH: ${{ runner.temp }}/app-store-api-key.json
 
-      - name: Get Firebase service account
-        run: base64 -d <<< "$FIREBASE_SERVICE_ACCOUNT_B64" > "$FIREBASE_SERVICE_ACCOUNT_PATH"
-        env:
-          FIREBASE_SERVICE_ACCOUNT_B64: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_B64 }}
-          FIREBASE_SERVICE_ACCOUNT_PATH: ${{ runner.temp }}/firebase-service-account.json
-
       - name: Create default keychain
         run: |
           security create-keychain -p "$KEYCHAIN_PWD" $KEYCHAIN_PATH
@@ -101,8 +91,8 @@ jobs:
       - name: Run lane to distribute
         uses: maierj/fastlane-action@v3.0.0
         with:
-          lane: ${{ vars.TARGET_LANE }}
-          options: '{ "tester_email": "${{ secrets.TESTER_EMAIL }}", "version_name": "${{ inputs.version_name }}" }'
+          lane: distribute
+          options: '{ "version_name": "${{ inputs.version_name }}" }'
           subdirectory: ./ios
         env:
           APPLE_API_KEY_PATH: ${{ runner.temp }}/app-store-api-key.json
@@ -110,9 +100,9 @@ jobs:
           CERTIFICATE_PATH: ${{ runner.temp }}/build_certificate.p12
           CERTIFICATE_PWD: ${{ secrets.CERTIFICATE_PWD }}
           FASTLANE_SKIP_UPDATE_CHECK: true
-          FIREBASE_SERVICE_ACCOUNT_PATH: ${{ runner.temp }}/firebase-service-account.json
           IOS_BUNDLE_ID: ${{ vars.IOS_BUNDLE_ID }}
+          IOS_PROVISIONING_PROFILE: ${{ vars.IOS_PROVISIONING_PROFILE }}
           KEYCHAIN_PATH: ${{ runner.temp }}/app-signing.keychain-db
           KEYCHAIN_PWD: ${{ secrets.KEYCHAIN_PWD }}
           PENHAS_BASE_URL: ${{ secrets.PENHAS_BASE_URL }}
-          TMP_DEVICES_FILE: ${{ runner.temp }}/ios_devices.txt
+          TESTFLIGHT_GROUPS: ${{ vars.TESTFLIGHT_GROUPS }}

--- a/.github/workflows/manual-distribution.yml
+++ b/.github/workflows/manual-distribution.yml
@@ -93,7 +93,6 @@ jobs:
       APPLE_ID: ${{ secrets.APPLE_ID }}
       CERTIFICATE_CONTENT: ${{ secrets.CERTIFICATE_CONTENT }}
       CERTIFICATE_PWD: ${{ secrets.CERTIFICATE_PWD }}
-      FIREBASE_SERVICE_ACCOUNT_B64: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_B64 }}
       IOS_BUILD_FILES: ${{ secrets.IOS_BUILD_FILES }}
       KEYCHAIN_PWD: ${{ secrets.KEYCHAIN_PWD }}
       PENHAS_BASE_URL: ${{ secrets.PENHAS_BASE_URL }}

--- a/.github/workflows/tester-email-distribute.yml
+++ b/.github/workflows/tester-email-distribute.yml
@@ -1,16 +1,12 @@
 name: "Distribute app to tester"
 
+# Somente Android: o canal de teste do iOS migrou para o TestFlight, que
+# distribui por grupo/link público em vez de e-mail individual.
+# Ver .github/workflows/testflight-distribute.yml e docs/testflight-testes.md.
+
 on:
   workflow_dispatch:
     inputs:
-      platform:
-        description: "Build target platform"
-        options:
-          - all
-          - android
-          - ios
-        type: choice
-        required: true
       tester_email:
         description: "Tester email address"
         type: string
@@ -18,7 +14,6 @@ on:
 
 jobs:
   distribute-android:
-    if: ${{ github.event.inputs.platform == 'android' || github.event.inputs.platform == 'all' }}
     permissions:
       contents: read
       id-token: write
@@ -31,26 +26,5 @@ jobs:
       ANDROID_BUILD_FILES: ${{ secrets.ANDROID_BUILD_FILES }}
       FIREBASE_SERVICE_ACCOUNT_B64: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_B64 }}
       GOOGLE_SERVICE_ACCOUNT_CREDENTIAL_B64: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_CREDENTIAL_B64 }}
-      PENHAS_BASE_URL: ${{ secrets.PENHAS_BASE_URL }}
-      TESTER_EMAIL: ${{ github.event.inputs.tester_email }}
-
-  distribute-ios:
-    if: ${{ github.event.inputs.platform == 'ios' || github.event.inputs.platform == 'all' }}
-    permissions:
-      contents: write
-      actions: write
-      checks: write
-      deployments: write
-    uses: ./.github/workflows/distribute-flutter-ios.yml
-    with:
-      environment: firebase-distribution
-    secrets:
-      APPLE_API_KEY_B64: ${{ secrets.APPLE_API_KEY_B64 }}
-      APPLE_ID: ${{ secrets.APPLE_ID }}
-      CERTIFICATE_CONTENT: ${{ secrets.CERTIFICATE_CONTENT }}
-      CERTIFICATE_PWD: ${{ secrets.CERTIFICATE_PWD }}
-      FIREBASE_SERVICE_ACCOUNT_B64: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_B64 }}
-      IOS_BUILD_FILES: ${{ secrets.IOS_BUILD_FILES }}
-      KEYCHAIN_PWD: ${{ secrets.KEYCHAIN_PWD }}
       PENHAS_BASE_URL: ${{ secrets.PENHAS_BASE_URL }}
       TESTER_EMAIL: ${{ github.event.inputs.tester_email }}

--- a/.github/workflows/testflight-distribute.yml
+++ b/.github/workflows/testflight-distribute.yml
@@ -1,0 +1,23 @@
+name: "Distribute iOS test build to TestFlight"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  distribute-ios:
+    permissions:
+      contents: write
+      actions: write
+      checks: write
+      deployments: write
+    uses: ./.github/workflows/distribute-flutter-ios.yml
+    with:
+      environment: firebase-distribution
+    secrets:
+      APPLE_API_KEY_B64: ${{ secrets.APPLE_API_KEY_B64 }}
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      CERTIFICATE_CONTENT: ${{ secrets.CERTIFICATE_CONTENT }}
+      CERTIFICATE_PWD: ${{ secrets.CERTIFICATE_PWD }}
+      IOS_BUILD_FILES: ${{ secrets.IOS_BUILD_FILES }}
+      KEYCHAIN_PWD: ${{ secrets.KEYCHAIN_PWD }}
+      PENHAS_BASE_URL: ${{ secrets.PENHAS_BASE_URL }}

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -6,19 +6,18 @@ skip_docs
 
 default_platform(:ios)
 
-profile_type_edirock = 'ad-hoc' # Firebase
 profile_type_store = 'app-store'
 
-provisioning_names = {
-  "#{profile_type_edirock}": "#{$app_name} AdHoc",
-  "#{profile_type_store}": "#{$app_name} AppStore",
-}
+# Nome do provisioning profile App Store no portal da Apple. Permite que o app
+# de teste use um profile próprio sem afetar produção.
+provisioning_name = ENV.fetch('IOS_PROVISIONING_PROFILE', '')
+provisioning_name = "#{$app_name} AppStore" if provisioning_name.empty?
 
-ios_devices_file = ENV['TMP_DEVICES_FILE']
 apple_api_key_path = ENV['APPLE_API_KEY_PATH']
-firebase_service_account_path = ENV['FIREBASE_SERVICE_ACCOUNT_PATH']
 
-testers_group = 'iostestersgroup'
+# Grupos externos do TestFlight (nomes separados por vírgula). Vazio = só sobe a
+# build, sem distribuição externa (grupos internos pegam pela config do ASC).
+testflight_groups = ENV['TESTFLIGHT_GROUPS'].to_s.split(',').map(&:strip).reject(&:empty?)
 
 platform :ios do
 
@@ -31,12 +30,7 @@ platform :ios do
   end
 
   desc 'Generates a provisioning profile, saving it in the current folder '
-  private_lane :update_profile do |options|
-
-    is_edirock = options[:profile_type] == profile_type_edirock
-    provisioning_name = provisioning_names[:"#{options[:profile_type]}"]
-    sigh_force = is_edirock && options[:force]
-
+  private_lane :update_profile do
     FastlaneCore::KeychainImporter.import_file(
       ENV['CERTIFICATE_PATH'],
       ENV['KEYCHAIN_PATH'],
@@ -48,38 +42,14 @@ platform :ios do
       provisioning_name: provisioning_name,
       output_path: "#{$project_path}/ios/certificates",
       skip_certificate_verification: true,
-      adhoc: is_edirock,
-      force: sigh_force,
     )
-  end
-
-  desc 'Download devices IDs from Firebase'
-  private_lane :download_udids do |options|
-    firebase_app_distribution_get_udids(
-      app: options[:app_id],
-      output_file: ios_devices_file,
-      service_credentials_file: firebase_service_account_path,
-    )
-  end
-
-  desc 'Registers devices to the Apple Dev Portal'
-  private_lane :sync_device_info do
-    if File.exist?(ios_devices_file)
-      register_devices(
-        devices_file: ios_devices_file,
-      )
-    end
   end
 
   desc 'Generate IPA'
   private_lane :generate_ipa do |options|
-    profile_uuid = update_profile(
-      profile_type: options[:profile_type],
-      force: options[:force_profile],
-    )
+    profile_uuid = update_profile
 
     build(
-      profile_type: options[:profile_type],
       build_number: options[:build_number],
       version_name: options[:version_name],
     )
@@ -90,61 +60,34 @@ platform :ios do
       workspace: "#{$project_path}/ios/Runner.xcworkspace",
       archive_path: "#{$project_path}/build/ios/Runner.xcarchive",
       output_directory: "#{$project_path}/build/ios/Runner",
-      export_method: options[:profile_type],
+      export_method: profile_type_store,
       xcargs: "PROVISIONING_PROFILE_SPECIFIER='#{profile_uuid}'",
     )
   end
 
-  desc 'Distribute to iOS beta testers in TestFlight'
-  lane :release_distribute do
+  desc 'Distribute to TestFlight'
+  lane :distribute do |options|
     request_api_key
 
-    generate_ipa(
-      profile_type: profile_type_store,
-    )
-
-    pilot(
-      ipa: "#{$project_path}/build/ios/Runner/Runner.ipa",
-    )
-  end
-
-  desc 'Distribute to iOS beta testers in Firebase'
-  lane :firebase_distribute do |options|
-    ENV['IS_FIREBASE_DISTRIBUTION'] = 'true'
-
-    testers = options[:tester_email] || ''
-    groups = testers.empty? ? testers_group : nil
-
-    request_api_key
-
-    app_id = firebase_id()
-
-    latest = firebase_app_distribution_get_latest_release(
-      app: app_id,
-      service_credentials_file: firebase_service_account_path,
-    )
     pubspec_build = File.read("#{$project_path}/pubspec.yaml").match(/^version:\s*\S+\+(\d+)/)[1].to_i
-    last_uploaded = latest && latest[:buildVersion] ? latest[:buildVersion].to_i : 0
+    last_uploaded = latest_testflight_build_number(initial_build_number: 0)
     next_build = [pubspec_build, last_uploaded].max + 1
-    UI.message("iOS build number: #{next_build} (pubspec=#{pubspec_build}, firebase_latest=#{last_uploaded})")
-
-    download_udids(app_id: app_id)
-    new_devices = sync_device_info || []
+    UI.message("iOS build number: #{next_build} (pubspec=#{pubspec_build}, testflight_latest=#{last_uploaded})")
 
     generate_ipa(
-      profile_type: profile_type_edirock,
-      force_profile: new_devices.any?,
       build_number: next_build,
       version_name: options[:version_name],
     )
 
-    firebase_app_distribution(
-      app: app_id,
-      release_notes: get_changelog(),
-      ipa_path: "#{$project_path}/build/ios/Runner/Runner.ipa",
-      groups: groups,
-      testers: testers,
-      service_credentials_file: firebase_service_account_path,
+    # distribute_external exige changelog não-vazio; a seção [Unreleased] pode estar vazia.
+    changelog = get_changelog()
+    changelog = "Build de teste #{next_build}." if changelog.empty?
+
+    pilot(
+      ipa: "#{$project_path}/build/ios/Runner/Runner.ipa",
+      changelog: changelog,
+      groups: testflight_groups.empty? ? nil : testflight_groups,
+      distribute_external: !testflight_groups.empty?,
     )
   end
 
@@ -170,12 +113,6 @@ platform :ios do
       app_identifier: CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier),
       initial_build_number: true
     )
-  end
-
-  desc 'Get Firebase project ID from config file'
-  lane :firebase_id do
-    google_services_file = "#{$project_path}/ios/Runner/GoogleService-Info.plist"
-    sh("cat '#{google_services_file}' | grep ':ios:' | sed 's/^.*>\\(.*\\)<.*\$/\\1/g'").strip
   end
 
 end

--- a/ios/fastlane/README.md
+++ b/ios/fastlane/README.md
@@ -23,21 +23,13 @@ For _fastlane_ installation instructions, see [Installing _fastlane_](https://do
 
 Build release IPA
 
-### ios release_distribute
+### ios distribute
 
 ```sh
-[bundle exec] fastlane ios release_distribute
+[bundle exec] fastlane ios distribute
 ```
 
-Distribute to iOS beta testers in TestFlight
-
-### ios firebase_distribute
-
-```sh
-[bundle exec] fastlane ios firebase_distribute
-```
-
-Distribute to iOS beta testers in Firebase
+Distribute to TestFlight
 
 ### ios verify_app_store_auth
 
@@ -46,14 +38,6 @@ Distribute to iOS beta testers in Firebase
 ```
 
 Check if json credentials is valid
-
-### ios firebase_id
-
-```sh
-[bundle exec] fastlane ios firebase_id
-```
-
-Get Firebase project ID from config file
 
 ----
 


### PR DESCRIPTION
Substitui o Firebase App Distribution pelo TestFlight como canal de teste iOS.

## Por quê

No iOS, o Firebase App Distribution exige coletar o **UDID** de cada aparelho, registrá-lo no portal da Apple e **re-assinar o IPA** com profile ad-hoc a cada testador novo — fricção que o time não-técnico não vence sozinho. Com o TestFlight, o testador instala o app TestFlight, abre um link e toca em Install.

O Android continua no Firebase App Distribution, onde não há dor de UDID.

## O que muda

**`ios/fastlane/Fastfile`** — lane única `distribute`:

- iOS só distribui por TestFlight, então não há escolha de lane. `TARGET_LANE` deixa de ser lido pelo iOS (segue valendo para o Android, que escolhe entre Firebase e Play Store).
- substitui `release_distribute`, que fazia o mesmo `pilot` só que sem calcular build number e **ignorando o `version_name`** que o `manual-distribution.yml` já passava;
- build number = `max(build do pubspec, último no TestFlight) + 1`;
- "What to Test" sai da seção `## [Unreleased]` do CHANGELOG; se vazia, usa texto padrão (`distribute_external` exige changelog não-vazio);
- removidas `firebase_distribute`, `firebase_id`, `download_udids`, `sync_device_info` e todo o caminho ad-hoc de assinatura.

**Workflows**

- novo `testflight-distribute.yml` (`workflow_dispatch`), reusando o environment `firebase-distribution`;
- `distribute-flutter-ios.yml` sem os secrets/steps do Firebase e sem `TESTER_EMAIL`;
- `tester-email-distribute.yml` fica **só para Android** — no TestFlight a entrega é por grupo/link público, não por e-mail avulso.

**Novas vars de environment (iOS)**

| var | efeito |
|---|---|
| `IOS_PROVISIONING_PROFILE` | nome do profile App Store; vazio cai em `PenhaS AppStore` |
| `TESTFLIGHT_GROUPS` | grupos **externos** (vírgula) ligam `distribute_external`; vazio só sobe a build |

## Configuração já aplicada no environment `firebase-distribution`

| | de | para |
|---|---|---|
| var `IOS_BUNDLE_ID` | `dev.penhas.alphacode.com.br` | `dev.penhas.testflight.com.br` |
| var `IOS_PROVISIONING_PROFILE` | — | `PenhaS Dev Testflight` |
| secret `IOS_BUILD_FILES` | tarball do app dev antigo | tarball com o `GoogleService-Info.plist` novo |

As três são lidas só pelo job iOS — a distribuição Android por Firebase segue intacta.

## Verificação pendente

Nenhum run de CI ainda. Antes de mergear:

```bash
cd ios && IOS_BUNDLE_ID=dev.penhas.testflight.com.br bundle exec fastlane ios verify_app_store_auth
gh workflow run testflight-distribute.yml --repo institutoazmina/penhas-app --ref ci/ios-testflight
```

O grupo interno "PenhaS Testers" recebe em minutos, sem review.
